### PR TITLE
feat: EMM（拡張メモリ）対応 v0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(EMSCRIPTEN)
     message(STATUS "Building for Emscripten/WebAssembly")
 
     # Emscriptenフラグ
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -sUSE_ZLIB=1")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
     # 最適化フラグ
@@ -18,8 +18,9 @@ if(EMSCRIPTEN)
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s ALLOW_MEMORY_GROWTH=1")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s INITIAL_MEMORY=67108864") # 64MB
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s GLOBAL_BASE=131072") # 128KB: stack-first layout 対策
-    set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_FUNCTIONS='[\"_main\",\"_malloc\",\"_free\",\"_js_xmil_start\",\"_js_xmil_stop\",\"_js_xmil_reset\",\"_js_xmil_nmi\",\"_js_xmil_power_off\",\"_js_xmil_power_on\",\"_js_insert_disk\",\"_js_set_rom_type\",\"_js_set_dip_sw\",\"_js_set_skip_line\",\"_js_set_motor\",\"_js_set_motor_volume\",\"_js_eject_disk\",\"_js_insert_cmt\",\"_js_cmt_eject\",\"_js_cmt_play\",\"_js_cmt_stop\",\"_js_cmt_ff\",\"_js_cmt_rew\",\"_js_get_cmt_cmd\",\"_js_get_cmt_pos\",\"_js_get_cmt_end\",\"_js_get_cmt_freq\",\"_js_set_sasi_path\",\"_js_set_joystick\",\"_js_set_key_mode\",\"_js_set_mouse\",\"_js_reload_fonts\",\"_js_key_down\",\"_js_key_up\",\"_js_save_state\",\"_js_load_state\",\"_js_get_load_warnings\",\"_js_get_dip_sw\",\"_js_get_rom_type\"]'")
+    set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_FUNCTIONS='[\"_main\",\"_malloc\",\"_free\",\"_js_xmil_start\",\"_js_xmil_stop\",\"_js_xmil_reset\",\"_js_xmil_nmi\",\"_js_xmil_power_off\",\"_js_xmil_power_on\",\"_js_insert_disk\",\"_js_set_rom_type\",\"_js_set_dip_sw\",\"_js_set_skip_line\",\"_js_set_motor\",\"_js_set_motor_volume\",\"_js_eject_disk\",\"_js_insert_cmt\",\"_js_cmt_eject\",\"_js_cmt_play\",\"_js_cmt_stop\",\"_js_cmt_ff\",\"_js_cmt_rew\",\"_js_get_cmt_cmd\",\"_js_get_cmt_pos\",\"_js_get_cmt_end\",\"_js_get_cmt_freq\",\"_js_set_sasi_path\",\"_js_set_joystick\",\"_js_set_key_mode\",\"_js_set_mouse\",\"_js_reload_fonts\",\"_js_key_down\",\"_js_key_up\",\"_js_save_state\",\"_js_load_state\",\"_js_get_load_warnings\",\"_js_get_dip_sw\",\"_js_get_rom_type\",\"_js_emm_flush\",\"_js_emm_reset_slot\",\"_js_emm_take_dirty_slots\"]'")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\",\"FS\",\"wasmMemory\"]'")
+    set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -sUSE_ZLIB=1")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} --pre-js ${CMAKE_SOURCE_DIR}/html/pre.js")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/html/shell.html")
 

--- a/html/index.html
+++ b/html/index.html
@@ -213,7 +213,7 @@
 <div class="container">
 
     <header>
-        <div class="site-title">X millennium Web <span style="font-size:0.42em; opacity:0.45; letter-spacing:1px; vertical-align:middle;">v0.3.0</span></div>
+        <div class="site-title">X millennium Web <span style="font-size:0.42em; opacity:0.45; letter-spacing:1px; vertical-align:middle;">v0.4.0</span></div>
         <div class="site-subtitle">SHARP X1 シリーズ エミュレータ for Web Browser</div>
         <div class="based-on">Based on X millennium by ぷにゅ氏 / T_tune 改変版</div>
     </header>

--- a/html/pre.js
+++ b/html/pre.js
@@ -16,20 +16,30 @@
 
     // ----------------------------------------------------------------
     // ファイルライブラリ: スロット状態
-    // slotName: 'drive0', 'drive1', 'hdd0', 'hdd1', 'cmt'
+    // slotName: 'drive0', 'drive1', 'hdd0', 'hdd1', 'cmt', 'emm0'..'emm9'
     // ----------------------------------------------------------------
-    const slotState         = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null };  // OPFS key | null
-    const slotDirty         = { drive0: false, drive1: false, hdd0: false, hdd1: false, cmt: false };
-    const slotFlushInFlight = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null };
-    const slotVfsPath       = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null };
+    const slotState         = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null, emm0: null, emm1: null, emm2: null, emm3: null, emm4: null, emm5: null, emm6: null, emm7: null, emm8: null, emm9: null };
+    const slotDirty         = { drive0: false, drive1: false, hdd0: false, hdd1: false, cmt: false, emm0: false, emm1: false, emm2: false, emm3: false, emm4: false, emm5: false, emm6: false, emm7: false, emm8: false, emm9: false };
+    const slotFlushInFlight = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null, emm0: null, emm1: null, emm2: null, emm3: null, emm4: null, emm5: null, emm6: null, emm7: null, emm8: null, emm9: null };
+    const slotVfsPath       = { drive0: null, drive1: null, hdd0: null, hdd1: null, cmt: null, emm0: null, emm1: null, emm2: null, emm3: null, emm4: null, emm5: null, emm6: null, emm7: null, emm8: null, emm9: null };
 
     let isFlushing = false;
+    var emmImportSlot = -1;       // インポート対象スロット番号
+    var emmImportInput = null;    // 隠し file input (init() で生成)
+    var emmSlotInFlight = {};     // スロット単位の処理中ガード
 
     // スロット→対応タイプ
-    const SLOT_TYPES = { drive0: 'fdd', drive1: 'fdd', hdd0: 'hdd', hdd1: 'hdd', cmt: 'cmt' };
+    const SLOT_TYPES = { drive0: 'fdd', drive1: 'fdd', hdd0: 'hdd', hdd1: 'hdd', cmt: 'cmt', emm0: 'emm', emm1: 'emm', emm2: 'emm', emm3: 'emm', emm4: 'emm', emm5: 'emm', emm6: 'emm', emm7: 'emm', emm8: 'emm', emm9: 'emm' };
 
     // ファイルタイプ別サイズ上限 (DoS防止)
-    const SIZE_LIMIT = { fdd: 32 * 1024 * 1024, cmt: 32 * 1024 * 1024, hdd: 512 * 1024 * 1024 };
+    const SIZE_LIMIT = { fdd: 32 * 1024 * 1024, cmt: 32 * 1024 * 1024, hdd: 512 * 1024 * 1024, emm: 16 * 1024 * 1024 };
+
+    // ---- EMM ユーティリティ ----
+    function emmSlotFromName(filename) {
+        var m = filename.match(/^EMM(\d)\.MEM$/i);
+        return m ? ('emm' + m[1]) : null;
+    }
+    function emmSlotNum(slotName) { return parseInt(slotName.replace('emm', ''), 10); }
 
     // ----------------------------------------------------------------
     // localStorage キー
@@ -103,6 +113,9 @@
 
     // VFS パス生成 (元拡張子保持: x1_set_fd() が拡張子で分岐するため)
     function slotToVfsPath(slotName, ext) {
+        if (slotName.startsWith('emm')) {
+            return '/EMM' + emmSlotNum(slotName) + '.MEM';
+        }
         var base = { drive0: 'fdd0', drive1: 'fdd1', hdd0: 'hdd0', hdd1: 'hdd1', cmt: 'cmt' }[slotName];
         return '/' + base + '.' + ext;
     }
@@ -144,7 +157,225 @@
         if (['d88', '2d', '88d'].includes(ext)) return 'fdd';
         if (['hdd', 'hd'].includes(ext)) return 'hdd';
         if (['cas', 'cmt', 'tap', 'bas', 'bin'].includes(ext)) return 'cmt';
+        if (ext === 'mem' && /^EMM\d\.MEM$/i.test(filename)) return 'emm';
         return null;
+    }
+
+    // ----------------------------------------------------------------
+    // EMM 作成・管理
+    // ----------------------------------------------------------------
+
+    async function createEmm(slotNum, sizeBytes) {
+        if (slotNum < 0 || slotNum > 9) return;
+        if (sizeBytes <= 0 || sizeBytes > 16 * 1024 * 1024) return;
+        // 256B 境界に丸める
+        sizeBytes = Math.ceil(sizeBytes / 256) * 256;
+
+        var slotName = 'emm' + slotNum;
+        var fileName = 'EMM' + slotNum + '.MEM';
+
+        // 既存マウント中ならイジェクト
+        if (slotState[slotName]) await ejectSlot(slotName);
+
+        // ゼロ埋めデータ作成
+        var data = new ArrayBuffer(sizeBytes);
+
+        // OPFS に保存
+        await window.XmilStorage.write(fileName, data);
+
+        // ライブラリ upsert（同キー or 同 name+type を除去してから push）
+        // 古いキーが異なる場合は OPFS の孤児データを削除
+        var oldLib = getLibrary();
+        for (var oi = 0; oi < oldLib.length; oi++) {
+            var oe = oldLib[oi];
+            if (oe.key !== fileName && oe.type === 'emm' && oe.name === fileName) {
+                try { await window.XmilStorage.remove(oe.key); } catch(_) {}
+            }
+        }
+        var lib = oldLib.filter(function(e) {
+            return e.key !== fileName && !(e.type === 'emm' && e.name === fileName);
+        });
+        var entry = { key: fileName, name: fileName, type: 'emm', ext: 'MEM', size: sizeBytes, addedAt: new Date().toISOString() };
+        lib.push(entry);
+        saveLibrary(lib);
+
+        // 即マウント
+        await mountFromLibrary(fileName, slotName);
+        renderLibraryList();
+        updateStatus('EMM' + slotNum + ' 作成 (' + (sizeBytes / 1024) + 'KB)');
+    }
+
+    function openEmmCreateDialog(fixedSlot) {
+        var dlg = document.getElementById('emm-create-dialog');
+        if (!dlg) return;
+        var sel = dlg.querySelector('#emm-create-slot');
+        if (sel) {
+            if (fixedSlot !== undefined) {
+                // スロット固定モード（10スロット UI から呼ばれる）
+                sel.value = fixedSlot;
+                sel.disabled = true;
+            } else {
+                sel.disabled = false;
+                for (var i = 0; i < sel.options.length; i++)
+                    sel.options[i].disabled = !!slotState['emm' + i];
+                for (var j = 0; j < sel.options.length; j++)
+                    if (!sel.options[j].disabled) { sel.selectedIndex = j; break; }
+            }
+        }
+        emmSyncCustomInput();
+        dlg.classList.remove('hidden');
+    }
+
+    function closeEmmCreateDialog() {
+        var dlg = document.getElementById('emm-create-dialog');
+        if (dlg) {
+            dlg.classList.add('hidden');
+            // 固定モード解除
+            var sel = dlg.querySelector('#emm-create-slot');
+            if (sel) sel.disabled = false;
+        }
+    }
+
+    // ラジオ選択に応じて custom 入力欄を有効/無効化
+    function emmSyncCustomInput() {
+        var checked = document.querySelector('input[name="emm-size"]:checked');
+        var inp = document.getElementById('emm-custom-size');
+        if (inp) inp.disabled = !(checked && checked.value === 'custom');
+    }
+
+    // ラジオボタン change イベント (init() 内で設定)
+    function initEmmSizeRadios() {
+        var radios = document.querySelectorAll('input[name="emm-size"]');
+        for (var i = 0; i < radios.length; i++) {
+            radios[i].addEventListener('change', emmSyncCustomInput);
+        }
+        // custom 入力欄クリック時に custom ラジオを自動選択
+        var inp = document.getElementById('emm-custom-size');
+        if (inp) {
+            inp.addEventListener('focus', function() {
+                var customRadio = document.querySelector('input[name="emm-size"][value="custom"]');
+                if (customRadio) { customRadio.checked = true; emmSyncCustomInput(); }
+            });
+        }
+    }
+
+    async function onEmmCreateConfirm() {
+        var sel = document.getElementById('emm-create-slot');
+        if (!sel) return;
+        var slotNum = parseInt(sel.value, 10);
+
+        // サイズ取得
+        var sizeBytes;
+        var checkedRadio = document.querySelector('input[name="emm-size"]:checked');
+        if (checkedRadio && checkedRadio.value === 'custom') {
+            // custom: KB 単位入力 → バイト変換
+            var customInput = document.getElementById('emm-custom-size');
+            var kb = parseInt(customInput ? customInput.value : '0', 10);
+            if (!kb || kb <= 0) { alert('サイズを入力してください'); return; }
+            sizeBytes = kb * 1024;
+        } else if (checkedRadio) {
+            // プリセット: value はバイト単位
+            sizeBytes = parseInt(checkedRadio.value, 10);
+        } else {
+            sizeBytes = 1048576; // デフォルト 1MB
+        }
+
+        if (!sizeBytes || sizeBytes <= 0) { alert('サイズを入力してください'); return; }
+        if (sizeBytes > 16 * 1024 * 1024) { alert('最大 16MB です'); return; }
+        if (sizeBytes % 256 !== 0) { sizeBytes = Math.ceil(sizeBytes / 256) * 256; }
+
+        closeEmmCreateDialog();
+        await createEmm(slotNum, sizeBytes);
+    }
+
+    // ----------------------------------------------------------------
+    // EMM 10スロット固定ビュー
+    // ----------------------------------------------------------------
+
+    function renderEmmSlotList() {
+        var listEl = document.getElementById('library-list');
+        if (!listEl) return;
+        var lib = getLibrary();
+        var html = '';
+        for (var i = 0; i < 10; i++) {
+            var slotName = 'emm' + i;
+            var fileName = 'EMM' + i + '.MEM';
+            var entry = lib.find(function(e) { return e.type === 'emm' && e.name === fileName; });
+            var isMounted = !!slotState[slotName];
+            var hasEntry = !!entry;
+            var busy = !!emmSlotInFlight[i];
+
+            html += '<div class="emm-slot-row' + (isMounted ? ' mounted' : '') + '">';
+            html += '<span class="emm-slot-label">EMM' + i + '</span>';
+
+            if (hasEntry) {
+                var sizeMb = (entry.size / 1024 / 1024).toFixed(1);
+                html += '<span class="emm-slot-info">' + escHtml(entry.name) + ' (' + sizeMb + 'MB)</span>';
+            } else {
+                html += '<span class="emm-slot-info emm-unassigned">未割り当て</span>';
+            }
+
+            html += '<div class="emm-slot-btns">';
+            html += '<button class="emm-action-btn" data-action="emm-create" data-slot="' + i + '"'
+                 + (busy ? ' disabled' : '') + '>作成</button>';
+            html += '<button class="emm-action-btn" data-action="emm-export" data-slot="' + i + '"'
+                 + (!hasEntry || busy ? ' disabled' : '') + '>エクスポート</button>';
+            html += '<button class="emm-action-btn" data-action="emm-import" data-slot="' + i + '"'
+                 + (busy ? ' disabled' : '') + '>インポート</button>';
+            if (hasEntry) {
+                html += '<button class="emm-action-btn emm-action-del" data-action="emm-delete" data-slot="' + i + '"'
+                     + (busy ? ' disabled' : '') + '>削除</button>';
+            }
+            html += '</div></div>';
+        }
+        listEl.innerHTML = html;
+    }
+
+    // ---- EMM ガード（create / import 用）----
+    function emmGuardStart(slotNum) {
+        if (emmSlotInFlight[slotNum]) return false;
+        emmSlotInFlight[slotNum] = true;
+        renderEmmSlotList();
+        return true;
+    }
+    function emmGuardEnd(slotNum) {
+        delete emmSlotInFlight[slotNum];
+        renderEmmSlotList();
+    }
+
+    // ---- EMM スロットアクションハンドラ ----
+    function onEmmSlotCreate(slotNum) {
+        var fileName = 'EMM' + slotNum + '.MEM';
+        var lib = getLibrary();
+        var existing = lib.find(function(e) { return e.type === 'emm' && e.name === fileName; });
+        if (existing) {
+            if (!confirm('現在割り当てられている EMM データを削除して新規に EMM 領域を作成しますか？')) return;
+        }
+        openEmmCreateDialog(slotNum);
+    }
+
+    function onEmmSlotExport(slotNum) {
+        var fileName = 'EMM' + slotNum + '.MEM';
+        var entry = getLibrary().find(function(e) { return e.type === 'emm' && e.name === fileName; });
+        if (!entry) return;
+        downloadFromLibrary(entry.key, entry.name);
+    }
+
+    function onEmmSlotImport(slotNum) {
+        var fileName = 'EMM' + slotNum + '.MEM';
+        var existing = getLibrary().find(function(e) { return e.type === 'emm' && e.name === fileName; });
+        if (existing) {
+            if (!confirm('EMM' + slotNum + ' には既にデータが割り当てられています。上書きしますか？')) return;
+        }
+        emmImportSlot = slotNum;
+        if (emmImportInput) emmImportInput.click();
+    }
+
+    function onEmmSlotDelete(slotNum) {
+        var fileName = 'EMM' + slotNum + '.MEM';
+        var entry = getLibrary().find(function(e) { return e.type === 'emm' && e.name === fileName; });
+        if (!entry) return;
+        deleteFromLibrary(entry.key);
     }
 
     // ----------------------------------------------------------------
@@ -254,6 +485,11 @@
                         updateStatus('テープロード失敗: ' + entry.name + ' (対応していない形式の可能性があります)');
                         return;  // slotState を更新しない
                     }
+                } else if (slotName.startsWith('emm')) {
+                    // EMM: VFS にファイルが配置済み → C++ エラーフラグ/キャッシュ無効化
+                    if (module._js_emm_reset_slot) {
+                        module._js_emm_reset_slot(emmSlotNum(slotName));
+                    }
                 }
             } catch(e) {
                 console.error('mount emulator call failed:', slotName, e);
@@ -291,6 +527,11 @@
                     module.ccall('js_set_sasi_path', null, ['string', 'number'], ['', 1]);
                 } else if (slotName === 'cmt') {
                     if (module._js_cmt_eject) module._js_cmt_eject();
+                } else if (slotName.startsWith('emm')) {
+                    // EMM: C++ dirty バッファ → VFS にフラッシュ
+                    if (module._js_emm_flush) module._js_emm_flush();
+                    // dirty_slots を JS に反映 (flushSlot が OPFS 保存を判断するため)
+                    syncEmmDirtyFromCpp();
                 }
             } catch(e) {
                 console.error('ejectSlot emulator call failed:', slotName, e);
@@ -298,7 +539,17 @@
         }
 
         // C++がVFSを更新した後にOPFSへ保存
-        if (slotDirty[slotName]) await flushSlot(slotName);
+        // flush 失敗してもスロット状態はクリアする（不整合防止）
+        try {
+            if (slotDirty[slotName]) await flushSlot(slotName);
+        } catch(e) {
+            console.error('ejectSlot flush failed:', slotName, e);
+        }
+
+        // EMM: VFS ファイルも削除
+        if (slotName.startsWith('emm') && slotVfsPath[slotName]) {
+            try { module.FS.unlink(slotVfsPath[slotName]); } catch(e) {}
+        }
 
         slotState[slotName]   = null;
         slotVfsPath[slotName] = null;
@@ -370,14 +621,27 @@
         if (!slotDirty[slotName] || !slotState[slotName]) return Promise.resolve();
         var p = flushVfsToStorage(slotVfsPath[slotName], slotState[slotName])
             .then(function() { slotDirty[slotName] = false; })
-            .catch(function(e) { console.warn('flushSlot(' + slotName + ') failed:', e); })
             .finally(function() { slotFlushInFlight[slotName] = null; });
         slotFlushInFlight[slotName] = p;
         return p;
     }
 
+    // EMM dirty ビットマスクを C++ から取得 (take: 取得+クリアがアトミック)
+    function syncEmmDirtyFromCpp() {
+        if (!module || !module._js_emm_take_dirty_slots) return;
+        var mask = module._js_emm_take_dirty_slots();
+        for (var i = 0; i < 10; i++) {
+            if (mask & (1 << i)) slotDirty['emm' + i] = true;
+        }
+    }
+
     async function flushAllDirty() {
         if (isFlushing) return;
+
+        // EMM: C++ dirty バッファ → VFS → dirty_slots 取得
+        if (module && module._js_emm_flush) module._js_emm_flush();
+        syncEmmDirtyFromCpp();
+
         var anyDirty = false;
         for (var sn in slotDirty) { if (slotDirty[sn]) { anyDirty = true; break; } }
         if (!anyDirty) return;
@@ -393,12 +657,14 @@
     }
 
     // ライフサイクルフラッシュ (visibilitychange が主系)
-    document.addEventListener('visibilitychange', async function() {
-        if (document.visibilityState === 'hidden') await flushAllDirty();
+    // flush 失敗はログのみ（ユーザー操作なしのバックグラウンド処理のため）
+    function silentFlush() { flushAllDirty().catch(function(e) { console.error('background flush failed:', e); }); }
+    document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'hidden') silentFlush();
     });
-    window.addEventListener('pagehide', function() { flushAllDirty(); });
-    window.addEventListener('beforeunload', function() { flushAllDirty(); });
-    setInterval(function() { flushAllDirty(); }, 30000);
+    window.addEventListener('pagehide', silentFlush);
+    window.addEventListener('beforeunload', silentFlush);
+    setInterval(silentFlush, 30000);
 
     // ----------------------------------------------------------------
     // ステートセーブ/ロード
@@ -454,9 +720,11 @@
             // 1. dirty VFS → OPFS 書き戻し
             await flushAllDirty();
 
-            // 2. C側セーブ (js_save_state → malloc buffer → JS copy → free)
+            // 2. C側セーブ (js_save_state(sizePtr, flags) → malloc buffer → JS copy → free)
+            var portableEmm = document.getElementById('cfg-portable-emm');
+            var portableFlag = (portableEmm && portableEmm.checked) ? 0x04 : 0;  // STATE_FLAG_PORTABLE_EMM
             var sizePtr = module._malloc(4);
-            var bufPtr  = module._js_save_state(sizePtr);
+            var bufPtr  = module._js_save_state(sizePtr, portableFlag);
             var size    = new Int32Array(module.wasmMemory.buffer, sizePtr, 1)[0];
             module._free(sizePtr);
 
@@ -492,7 +760,8 @@
                 size: size,
                 mounts: Object.assign({}, slotState),
                 mountNames: mNames,
-                hashes: mediaHashes
+                hashes: mediaHashes,
+                portable: !!(portableFlag & 0x04)
             };
             var list = getStateList();
             list.unshift(entry);  // 最新を先頭
@@ -521,10 +790,13 @@
             // 1. 依存メディア存在チェック
             var mounts = entry.mounts || {};
             var mNames = entry.mountNames || {};
+            var isPortable = !!(entry.portable);
             var lib = getLibrary();
             var missing = [];
             for (var sn in mounts) {
                 if (mounts[sn]) {
+                    // Portable モードでは EMM スロットをスキップ（EMD セクションから復元される）
+                    if (isPortable && sn.startsWith('emm')) continue;
                     if (!lib.find(function(e) { return e.key === mounts[sn]; })) {
                         missing.push(sn + ': ' + (mNames[sn] || mounts[sn]));
                     }
@@ -546,6 +818,8 @@
             if (entry.hashes) {
                 var changed = [];
                 for (var sn3 in entry.hashes) {
+                    // Portable EMM はステート内に含まれるためスキップ
+                    if (isPortable && sn3.startsWith('emm')) continue;
                     if (mounts[sn3]) {
                         try {
                             var mediaData = await window.XmilStorage.read(mounts[sn3]);
@@ -577,6 +851,8 @@
             var mountFailed = [];
             for (var sn2 in mounts) {
                 if (mounts[sn2]) {
+                    // Portable EMM はステートロード後に VFS → OPFS で復元
+                    if (isPortable && sn2.startsWith('emm')) continue;
                     await mountFromLibrary(mounts[sn2], sn2);
                     if (slotState[sn2] !== mounts[sn2]) {
                         mountFailed.push(sn2);
@@ -604,6 +880,33 @@
             if (rc < 0) {
                 updateStatus('ステートロード失敗 (データ不正)');
                 return false;
+            }
+
+            // 5.5 Portable EMM: C++ が EMD 展開 → VFS 書き出し済み → OPFS に書き戻し
+            if (isPortable) {
+                for (var ei = 0; ei < 10; ei++) {
+                    var emmPath = '/EMM' + ei + '.MEM';
+                    try {
+                        var stat = module.FS.stat(emmPath);
+                        if (stat && stat.size > 0) {
+                            var emmData = module.FS.readFile(emmPath);
+                            var emmKey = 'EMM' + ei + '.MEM';
+                            await window.XmilStorage.write(emmKey, emmData.buffer);
+                            // ライブラリエントリがなければ作成
+                            var eLib = getLibrary();
+                            if (!eLib.find(function(e) { return e.key === emmKey; })) {
+                                eLib.push({ key: emmKey, name: emmKey, type: 'emm', size: emmData.length, added: new Date().toISOString() });
+                                saveLibrary(eLib);
+                            }
+                            // スロット状態を更新
+                            var emmSn = 'emm' + ei;
+                            slotState[emmSn] = emmKey;
+                            slotVfsPath[emmSn] = emmPath;
+                            slotDirty[emmSn] = false;
+                        }
+                    } catch(e) { /* VFS にファイルが無い場合はスキップ */ }
+                }
+                saveMountState();
             }
 
             // 6. 警告表示
@@ -737,8 +1040,10 @@
         try {
             await flushAllDirty();
 
+            var portableEmm2 = document.getElementById('cfg-portable-emm');
+            var portableFlag2 = (portableEmm2 && portableEmm2.checked) ? 0x04 : 0;
             var sizePtr = module._malloc(4);
-            var bufPtr  = module._js_save_state(sizePtr);
+            var bufPtr  = module._js_save_state(sizePtr, portableFlag2);
             var size    = new Int32Array(module.wasmMemory.buffer, sizePtr, 1)[0];
             module._free(sizePtr);
 
@@ -764,6 +1069,7 @@
             }
             list[idx].time = new Date().toISOString();
             list[idx].size = size;
+            list[idx].portable = !!(portableFlag2 & 0x04);
             list[idx].mounts = Object.assign({}, slotState);
             list[idx].mountNames = mNames2;
             list[idx].hashes = mediaHashes;
@@ -866,12 +1172,25 @@
                 }
             }
 
+            // Portable EMM 判定: ヘッダ flags bit2 を LE で読み取り
+            var importPortable = false;
+            if (arr.length >= 8) {
+                var dv;
+                if (arr instanceof Uint8Array) {
+                    dv = new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+                } else {
+                    dv = new DataView(buf, 0, 8);
+                }
+                var importFlags = dv.getUint16(6, true); // LE
+                importPortable = !!(importFlags & 0x04);  // STATE_FLAG_PORTABLE_EMM
+            }
+
             var name = file.name.replace(/\.xmst$/i, '') || 'Imported';
             var key = 'state_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
             // メタ部分を除いた純粋なステートバイナリのみ保存
             await window.XmilStorage.write(key, buf.slice(0, stateLen));
             var list = getStateList();
-            list.push({ key: key, name: name, time: new Date().toISOString(), size: stateLen, mounts: mounts, mountNames: mNames, hashes: hashes });
+            list.push({ key: key, name: name, time: new Date().toISOString(), size: stateLen, mounts: mounts, mountNames: mNames, hashes: hashes, portable: importPortable });
             saveStateList(list);
             updateStatus('ステートインポート完了: ' + name);
             return true;
@@ -974,6 +1293,7 @@
                 mouseEnable: elements.mouseEnable ? elements.mouseEnable.checked : false,
                 statusToast: elements.statusToastEnable ? elements.statusToastEnable.checked : false,
                 stateOverwrite: elements.stateOverwrite ? elements.stateOverwrite.checked : false,
+                portableEmm: !!(function() { var cb = document.getElementById('cfg-portable-emm'); return cb && cb.checked; })(),
                 keyMode: (function() {
                     var c = document.querySelector('input[name="key-mode"]:checked');
                     return c ? parseInt(c.value, 10) : 0;
@@ -1007,6 +1327,8 @@
             if (elements.mouseEnable) elements.mouseEnable.checked = !!s.mouseEnable;
             if (elements.statusToastEnable) elements.statusToastEnable.checked = (s.statusToast !== undefined ? !!s.statusToast : false);
             if (elements.stateOverwrite) elements.stateOverwrite.checked = !!s.stateOverwrite;
+            var peCb = document.getElementById('cfg-portable-emm');
+            if (peCb) peCb.checked = !!s.portableEmm;
             if (s.keyMode !== undefined && elements.keyModeRadios) {
                 elements.keyModeRadios.forEach(function(r) {
                     r.checked = (parseInt(r.value, 10) === s.keyMode);
@@ -1469,6 +1791,11 @@
                 if (action === 'drive-save') {
                     if (window.XmilDrive) window.XmilDrive.saveByKey(key);
                 }
+                // EMM 10スロットビュー用アクション
+                if (action === 'emm-create') onEmmSlotCreate(parseInt(btn.dataset.slot, 10));
+                if (action === 'emm-export') onEmmSlotExport(parseInt(btn.dataset.slot, 10));
+                if (action === 'emm-import') onEmmSlotImport(parseInt(btn.dataset.slot, 10));
+                if (action === 'emm-delete') onEmmSlotDelete(parseInt(btn.dataset.slot, 10));
             });
         }
 
@@ -1505,8 +1832,8 @@
         // 新FDDパネルのイジェクトボタン
         for (var di = 0; di < 2; di++) {
             (function(d) {
-                if (elements.fddEject[d])   elements.fddEject[d].addEventListener('click',   function() { ejectSlot('drive' + d); });
-                if (elements.fddHwEject[d]) elements.fddHwEject[d].addEventListener('click', function() { ejectSlot('drive' + d); });
+                if (elements.fddEject[d])   elements.fddEject[d].addEventListener('click',   function() { ejectSlot('drive' + d).catch(function(e) { console.error('eject failed:', e); }); });
+                if (elements.fddHwEject[d]) elements.fddHwEject[d].addEventListener('click', function() { ejectSlot('drive' + d).catch(function(e) { console.error('eject failed:', e); }); });
             })(di);
         }
 
@@ -1514,7 +1841,7 @@
         for (var hi = 0; hi < 2; hi++) {
             (function(h) {
                 var hddEjectBtn = document.getElementById('btn-hdd' + h + '-eject');
-                if (hddEjectBtn) hddEjectBtn.addEventListener('click', function() { ejectSlot(h === 0 ? 'hdd0' : 'hdd1'); });
+                if (hddEjectBtn) hddEjectBtn.addEventListener('click', function() { ejectSlot(h === 0 ? 'hdd0' : 'hdd1').catch(function(e) { console.error('eject failed:', e); }); });
             })(hi);
         }
 
@@ -1618,10 +1945,10 @@
             if (el) el.addEventListener('click', deckTransport[id]);
         });
         var cdEject = document.getElementById('cdeck-eject');
-        if (cdEject) cdEject.addEventListener('click', function() { ejectSlot('cmt'); });
+        if (cdEject) cdEject.addEventListener('click', function() { ejectSlot('cmt').catch(function(e) { console.error('eject failed:', e); }); });
 
         // CMT ボタン (後方互換)
-        if (elements.btnCmtEject) elements.btnCmtEject.addEventListener('click', function() { ejectSlot('cmt'); });
+        if (elements.btnCmtEject) elements.btnCmtEject.addEventListener('click', function() { ejectSlot('cmt').catch(function(e) { console.error('eject failed:', e); }); });
         if (elements.btnCmtPlay)  elements.btnCmtPlay.addEventListener('click',  function() { if (module && module._js_cmt_play)  { module._js_cmt_play();  updateStatus('CMT 再生');     } });
         if (elements.btnCmtStop)  elements.btnCmtStop.addEventListener('click',  function() { if (module && module._js_cmt_stop)  { module._js_cmt_stop();  updateStatus('CMT 停止');     } });
         if (elements.btnCmtFf)    elements.btnCmtFf.addEventListener('click',   function() { if (module && module._js_cmt_ff)    { module._js_cmt_ff();    updateStatus('CMT 早送り');   } });
@@ -1657,10 +1984,72 @@
             }},
             { id: 'lib-close-btn',      fn: closeLibraryPanel },
             { id: 'lib-add-btn',        fn: function() { var el = document.getElementById('file-add-to-library'); if (el) el.click(); } },
+            { id: 'btn-emm-manage',     fn: function() { openLibraryPanel('emm'); } },
+            { id: 'emm-create-close',   fn: closeEmmCreateDialog },
+            { id: 'emm-create-confirm', fn: onEmmCreateConfirm },
         ];
         _btnMap.forEach(function(b) {
             var el = document.getElementById(b.id);
             if (el) el.addEventListener('click', b.fn);
+        });
+
+        // EMM サイズ選択ラジオ初期化
+        initEmmSizeRadios();
+
+        // EMM インポート用隠し file input
+        emmImportInput = document.createElement('input');
+        emmImportInput.type = 'file';
+        emmImportInput.accept = '.mem,.MEM';
+        emmImportInput.style.display = 'none';
+        document.body.appendChild(emmImportInput);
+        emmImportInput.addEventListener('change', async function(e) {
+            var file = e.target.files[0];
+            e.target.value = '';
+            var slotNum = emmImportSlot;
+            emmImportSlot = -1;
+            if (!file || slotNum < 0) return;
+            if (!emmGuardStart(slotNum)) return;
+            var slotName = 'emm' + slotNum;
+            var fileName = 'EMM' + slotNum + '.MEM';
+            var wasExistingKey = null;
+            try {
+                if (file.size > 16 * 1024 * 1024) { alert('最大 16MB です'); return; }
+                var existingEntry = getLibrary().find(function(ent) {
+                    return ent.type === 'emm' && ent.name === fileName;
+                });
+                wasExistingKey = existingEntry ? existingEntry.key : null;
+                if (slotState[slotName]) await ejectSlot(slotName);
+                var data = await file.arrayBuffer();
+                var key = fileName;
+                await window.XmilStorage.write(key, data);
+                // 古いキーが異なる場合は OPFS の孤児データを削除
+                var oldLib2 = getLibrary();
+                for (var oi2 = 0; oi2 < oldLib2.length; oi2++) {
+                    var oe2 = oldLib2[oi2];
+                    if (oe2.key !== key && oe2.type === 'emm' && oe2.name === fileName) {
+                        try { await window.XmilStorage.remove(oe2.key); } catch(_) {}
+                    }
+                }
+                var lib = oldLib2.filter(function(ent) {
+                    return ent.key !== key && !(ent.type === 'emm' && ent.name === fileName);
+                });
+                lib.push({ key: key, name: fileName, type: 'emm', ext: 'MEM',
+                           size: data.byteLength, addedAt: new Date().toISOString() });
+                saveLibrary(lib);
+                await mountFromLibrary(key, slotName);
+                renderLibraryList();
+                updateCapacityDisplay();
+                updateStatus('インポート完了: ' + fileName);
+            } catch(err) {
+                console.error('EMM import failed:', err);
+                alert('インポートに失敗しました: ' + (err.message || err));
+                if (wasExistingKey && !slotState[slotName]) {
+                    try { await mountFromLibrary(wasExistingKey, slotName); } catch(_) {}
+                }
+                renderLibraryList();
+            } finally {
+                emmGuardEnd(slotNum);
+            }
         });
 
         // フルスクリーン
@@ -1796,6 +2185,13 @@
         if (overwriteItem) overwriteItem.addEventListener('click', function(e) {
             e.preventDefault();
             if (elements.stateOverwrite) elements.stateOverwrite.checked = !elements.stateOverwrite.checked;
+            syncToggleItems(); saveSettings();
+        });
+        var portableEmmItem = document.getElementById('cfg-portable-emm-item');
+        if (portableEmmItem) portableEmmItem.addEventListener('click', function(e) {
+            e.preventDefault();
+            var cb = document.getElementById('cfg-portable-emm');
+            if (cb) cb.checked = !cb.checked;
             syncToggleItems(); saveSettings();
         });
         if (elements.keyModeRadios) {
@@ -2126,7 +2522,7 @@
     // ----------------------------------------------------------------
     // ライブラリ UI
     // ----------------------------------------------------------------
-    var currentLibraryFilter = 'all'; // 'all' | 'fdd' | 'hdd' | 'cmt'
+    var currentLibraryFilter = 'all'; // 'all' | 'fdd' | 'hdd' | 'cmt' | 'emm'
     var pendingSlotName = null;       // ライブラリパネルを開いたスロット名
 
     function openLibraryPanel(type, index) {
@@ -2167,6 +2563,16 @@
         var filter = activeBtn ? activeBtn.dataset.type : 'all';
         currentLibraryFilter = filter;
 
+        // 「＋ 追加」ボタン: EMM タブ時は非表示
+        var addBtn = document.getElementById('lib-add-btn');
+        if (addBtn) addBtn.classList.toggle('hidden', filter === 'emm');
+
+        // EMM タブ → 専用 10 スロットビュー
+        if (filter === 'emm') {
+            renderEmmSlotList();
+            return;
+        }
+
         var lib = getLibrary();
         var filtered = filter === 'all' ? lib : lib.filter(function(e) { return e.type === filter; });
 
@@ -2187,7 +2593,7 @@
             var isMounted = !!mountedBy[entry.key];
             var mountedSlot = mountedBy[entry.key];
 
-            var typeBadge = { fdd: 'FDD', hdd: 'HDD', cmt: 'CMT' }[entry.type] || entry.type.toUpperCase();
+            var typeBadge = { fdd: 'FDD', hdd: 'HDD', cmt: 'CMT', emm: 'EMM' }[entry.type] || entry.type.toUpperCase();
             var typeClass  = 'lib-badge-' + entry.type;
 
             // マウントボタン生成 (data-* 属性でキー/スロットを渡す。onclick 文字列連結は使わない)
@@ -2207,6 +2613,14 @@
             } else if (entry.type === 'cmt') {
                 var cmtActive = mountedSlot === 'cmt';
                 mountBtns += '<button class="lib-mount-btn' + (cmtActive ? ' active' : '') + '" data-action="mount" data-key="' + ek + '" data-slot="cmt" title="CMTにマウント">CMT' + (cmtActive ? '✓' : '') + '</button>';
+            } else if (entry.type === 'emm') {
+                // EMM: ファイル名からスロットが一意に決まる
+                var emmSn = emmSlotFromName(entry.name);
+                if (emmSn) {
+                    var emmActive = mountedSlot === emmSn;
+                    var emmLabel = 'EMM' + emmSlotNum(emmSn);
+                    mountBtns += '<button class="lib-mount-btn' + (emmActive ? ' active' : '') + '" data-action="mount" data-key="' + ek + '" data-slot="' + emmSn + '" title="' + emmLabel + 'にマウント">' + emmLabel + (emmActive ? '✓' : '') + '</button>';
+                }
             }
 
             html += '<div class="lib-row' + (isMounted ? ' mounted' : '') + '">';
@@ -2425,18 +2839,27 @@
         }
     }
 
-    function onResetClick() {
-        if (module && module._js_xmil_reset) {
-            module._js_xmil_reset();
-            reinitAudioForReset();
-            updateStatus('リセット完了');
+    async function onResetClick() {
+        if (!module || !module._js_xmil_reset) return;
+        try {
+            await flushAllDirty();
+        } catch(e) {
+            if (!confirm('EMM データの保存に失敗しました。リセットするとデータが失われる可能性があります。続行しますか？')) return;
         }
+        module._js_xmil_reset();
+        reinitAudioForReset();
+        updateStatus('リセット完了');
     }
 
-    function onPowerToggle() {
+    async function onPowerToggle() {
         if (!module) return;
         if (isRunning) {
-            // 電源 OFF: 画面を黒にクリアして停止
+            // 電源 OFF: flush → 停止
+            try {
+                await flushAllDirty();
+            } catch(e) {
+                if (!confirm('EMM データの保存に失敗しました。電源を切るとデータが失われる可能性があります。続行しますか？')) return;
+            }
             if (module._js_xmil_power_off) { module._js_xmil_power_off(); }
             isRunning = false;
             updateStatus('電源 OFF');
@@ -2452,8 +2875,13 @@
         }
     }
 
-    function onIplResetClick() {
+    async function onIplResetClick() {
         if (!module) return;
+        try {
+            await flushAllDirty();
+        } catch(e) {
+            if (!confirm('EMM データの保存に失敗しました。IPL リセットするとデータが失われる可能性があります。続行しますか？')) return;
+        }
         if (module._js_xmil_reset) { module._js_xmil_reset(); reinitAudioForReset(); }
         updateStatus('IPL リセット');
     }
@@ -2629,6 +3057,9 @@
             saveBtn.classList.toggle('overwrite-on', owOn);
             saveBtn.title = owOn ? 'クイックセーブ（上書き）' : 'クイックセーブ';
         }
+        var peEl = document.getElementById('cfg-portable-emm-item');
+        var peCb = document.getElementById('cfg-portable-emm');
+        if (peEl) peEl.classList.toggle('on', !!(peCb && peCb.checked));
     }
 
     // ----------------------------------------------------------------

--- a/html/shell.html
+++ b/html/shell.html
@@ -1088,6 +1088,115 @@
         .hdd-btn-danger { color: #3a1c0a; border-color: #221408; background: #060400; }
         .hdd-btn-danger:hover:not(:disabled) { background: #120804; border-color: #883300; color: #cc5500; }
 
+        .emm-manage-btn { color: #553388; border-color: #2a1840; background: #0a0610; }
+        .emm-manage-btn:hover { background: #140e20; border-color: #7744bb; color: #aa88dd; }
+
+        /* EMM 10スロット固定ビュー */
+        .emm-slot-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 10px;
+            border-bottom: 1px solid #1a1a1a;
+        }
+        .emm-slot-row.mounted { background: #151d10; }
+        .emm-slot-label {
+            font-size: 0.75em;
+            font-family: 'Courier New', monospace;
+            color: #9966cc;
+            width: 40px;
+            flex-shrink: 0;
+            font-weight: bold;
+        }
+        .emm-slot-info {
+            flex: 1;
+            font-size: 0.75em;
+            color: #999;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .emm-unassigned { color: #cc4444; font-style: italic; }
+        .emm-slot-btns {
+            display: flex;
+            gap: 4px;
+            flex-shrink: 0;
+        }
+        .emm-action-btn {
+            font-size: 0.65em;
+            padding: 2px 8px;
+            border: 1px solid #333;
+            border-radius: 3px;
+            background: #1a1a1a;
+            color: #888;
+            cursor: pointer;
+            font-family: inherit;
+            transition: all 0.1s;
+        }
+        .emm-action-btn:hover:not(:disabled) {
+            border-color: #7744bb;
+            color: #bb99dd;
+            background: #1e1020;
+        }
+        .emm-action-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+        .emm-action-del { color: #994444; border-color: #331818; }
+        .emm-action-del:hover:not(:disabled) {
+            border-color: #aa3333;
+            color: #ff6666;
+            background: #1a0808;
+        }
+
+        /* EMM サイズ選択ラジオ */
+        .emm-size-radio {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            cursor: pointer;
+            user-select: none;
+            padding: 3px 8px;
+            border: 1px solid #333;
+            border-radius: 4px;
+            background: #1a1a1a;
+            transition: all 0.1s;
+        }
+        .emm-size-radio:hover { border-color: #666; }
+        .emm-size-radio input[type="radio"] { display: none; }
+        .emm-size-radio .emm-size-led {
+            width: 7px; height: 7px;
+            border-radius: 50%;
+            background: #1e1020;
+            border: 1px solid #2a1840;
+            flex-shrink: 0;
+            transition: background 0.15s, box-shadow 0.15s;
+        }
+        .emm-size-radio input[type="radio"]:checked ~ .emm-size-led {
+            background: #9966cc;
+            border-color: #bb88ee;
+            box-shadow: 0 0 4px rgba(153,102,204,0.6);
+        }
+        .emm-size-radio .emm-size-label {
+            font-size: 0.65em;
+            color: rgba(255,255,255,0.3);
+            letter-spacing: 0.5px;
+            font-family: 'Courier New', monospace;
+            transition: color 0.15s;
+        }
+        .emm-size-radio input[type="radio"]:checked ~ .emm-size-label {
+            color: #bb99dd;
+        }
+        .emm-custom-input {
+            width: 70px;
+            padding: 3px 6px;
+            background: #1a1a1a;
+            color: #ccc;
+            border: 1px solid #444;
+            border-radius: 4px;
+            font-family: inherit;
+            font-size: 0.75em;
+            text-align: right;
+        }
+        .emm-custom-input:disabled { opacity: 0.3; }
+
         .info { background: rgba(255,255,255,0.1); border-radius: 10px; padding: 20px; }
         .info h2 { font-size: 1.3em; margin-bottom: 10px; }
         .info p { line-height: 1.6; margin-bottom: 10px; }
@@ -1232,6 +1341,7 @@
         .lib-badge-fdd { background: #0d1e36; border: 1px solid #1a4a88; color: #5599ee; }
         .lib-badge-hdd { background: #281c00; border: 1px solid #775500; color: #ccaa44; }
         .lib-badge-cmt { background: #0a180a; border: 1px solid #1e4a1e; color: #44aa44; }
+        .lib-badge-emm { background: #1e1020; border: 1px solid #553388; color: #9966cc; }
 
         .lib-file-name {
             flex: 1;
@@ -1597,7 +1707,7 @@
     <header>
         <h1>X millennium Web</h1>
         <div class="subtitle">SHARP X1 Emulator for Web Browser</div>
-        <div class="based-on">v0.3.0 &mdash; based on X millennium t-tune Ver0.26 step1.43</div>
+        <div class="based-on">v0.4.0 &mdash; based on X millennium t-tune Ver0.26 step1.43</div>
     </header>
 
     <div id="loading" class="loading">
@@ -1970,6 +2080,8 @@
                     <button class="hdd-btn" id="hdd-open-1" title="ライブラリを開く">📂</button>
                     <button class="hdd-btn" id="btn-hdd1-eject" disabled title="イジェクト（アンマウント）">⏏</button>
                 </div>
+                <!-- EMM 管理 -->
+                <button class="hdd-btn emm-manage-btn" id="btn-emm-manage" title="EMM管理">EMM</button>
             </div>
 
             <!-- ROM スロット -->
@@ -2127,6 +2239,7 @@
             <button class="lib-filter" data-type="fdd">FDD</button>
             <button class="lib-filter" data-type="hdd">HDD</button>
             <button class="lib-filter" data-type="cmt">CMT</button>
+            <button class="lib-filter" data-type="emm">EMM</button>
             <button class="lib-drive-pick-btn hidden" id="btn-drive-pick"
                     title="アプリが保存済みのファイルを一覧表示">☁ 保存済み</button>
             <button class="lib-add-btn" id="lib-add-btn">＋ 追加</button>
@@ -2155,9 +2268,61 @@
                 <span class="cfg-led"></span>
                 <span class="cfg-toggle-label">OVERWRITE</span>
             </label>
+            <label class="cfg-toggle-item" id="cfg-portable-emm-item" title="ステートに EMM データを圧縮同梱">
+                <input type="checkbox" id="cfg-portable-emm" style="display:none">
+                <span class="cfg-led"></span>
+                <span class="cfg-toggle-label">PORTABLE EMM</span>
+            </label>
             <button class="hw-state-btn hw-state-btn-danger" id="state-delete-all">全削除</button>
         </div>
         <div id="state-list" class="lib-list"></div>
+    </div>
+</div>
+
+<!-- ================================================================
+     EMM 作成ダイアログ (モーダル)
+     ================================================================ -->
+<div id="emm-create-dialog" class="library-panel hidden">
+    <div class="library-panel-inner" style="max-width: 420px;">
+        <div class="lib-panel-header">
+            <span>EMM ファイル新規作成</span>
+            <button class="lib-close-btn" id="emm-create-close">✕ 閉じる</button>
+        </div>
+        <div style="padding: 12px 16px; display: flex; flex-direction: column; gap: 12px;">
+            <div>
+                <label style="color: #999; font-size: 0.85em; display: block; margin-bottom: 4px;">スロット</label>
+                <select id="emm-create-slot" style="width: 100%; padding: 6px 8px; background: #1a1a1a; color: #ccc; border: 1px solid #444; border-radius: 4px; font-family: inherit;">
+                    <option value="0">EMM0</option>
+                    <option value="1">EMM1</option>
+                    <option value="2">EMM2</option>
+                    <option value="3">EMM3</option>
+                    <option value="4">EMM4</option>
+                    <option value="5">EMM5</option>
+                    <option value="6">EMM6</option>
+                    <option value="7">EMM7</option>
+                    <option value="8">EMM8</option>
+                    <option value="9">EMM9</option>
+                </select>
+            </div>
+            <div>
+                <label style="color: #999; font-size: 0.85em; display: block; margin-bottom: 4px;">サイズ</label>
+                <div id="emm-size-presets" style="display: flex; flex-wrap: wrap; gap: 6px; align-items: center;">
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="327680"><span class="emm-size-led"></span><span class="emm-size-label">320KB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="524288"><span class="emm-size-led"></span><span class="emm-size-label">512KB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="1048576" checked><span class="emm-size-led"></span><span class="emm-size-label">1MB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="2097152"><span class="emm-size-led"></span><span class="emm-size-label">2MB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="4194304"><span class="emm-size-led"></span><span class="emm-size-label">4MB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="8388608"><span class="emm-size-led"></span><span class="emm-size-label">8MB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="16777216"><span class="emm-size-led"></span><span class="emm-size-label">16MB</span></label>
+                    <label class="emm-size-radio"><input type="radio" name="emm-size" value="custom"><span class="emm-size-led"></span><span class="emm-size-label">custom</span></label>
+                    <span style="display: inline-flex; align-items: center; gap: 4px;">
+                        <input type="number" id="emm-custom-size" class="emm-custom-input" min="1" max="16384" step="1" value="1024" disabled>
+                        <span style="color: #666; font-size: 0.7em;">KB</span>
+                    </span>
+                </div>
+            </div>
+            <button class="hw-state-btn" id="emm-create-confirm" style="align-self: flex-end; margin-top: 4px;">作成してマウント</button>
+        </div>
     </div>
 </div>
 

--- a/platform/platform_main.cpp
+++ b/platform/platform_main.cpp
@@ -23,6 +23,7 @@
 #include "X1_PCG.H"   // pcg (電源ON時のPCGクリア用)
 #include "X1_CRTC.H"  // crtc_cold_reset() (電源ON時のパレットリセット用)
 #include "state_save.h"
+#include "X1_EMM.H"
 
 // web_sound.cpp で定義されているサウンドパラメータ (dsounds.h より)
 extern WORD  ds_rate;
@@ -219,6 +220,7 @@ void js_xmil_stop() {
 
 EMSCRIPTEN_KEEPALIVE
 void js_xmil_reset() {
+    emm_flush_all_buffers();
     reset_x1(xmilcfg.ROM_TYPE, xmilcfg.SOUND_SW, xmilcfg.DIP_SW);
 }
 
@@ -340,6 +342,7 @@ void js_xmil_nmi() {
 // 電源 OFF: エミュレータ停止 + 画面を黒にクリア
 EMSCRIPTEN_KEEPALIVE
 void js_xmil_power_off() {
+    emm_flush_all_buffers();
     xmil_stop();
     Platform_Graphics_Clear(0);
     Platform_Graphics_Flip();
@@ -392,8 +395,25 @@ void js_reload_fonts(void) {
 // ---- State save/load ----
 
 EMSCRIPTEN_KEEPALIVE
-BYTE* js_save_state(int *out_size) {
-    return save_full_state(out_size);
+BYTE* js_save_state(int *out_size, int flags) {
+    return save_full_state(out_size, flags);
+}
+
+// ---- EMM ----
+
+EMSCRIPTEN_KEEPALIVE
+void js_emm_flush(void) {
+    emm_flush_all_buffers();
+}
+
+EMSCRIPTEN_KEEPALIVE
+void js_emm_reset_slot(int slot) {
+    emm_reset_slot(slot);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_emm_take_dirty_slots(void) {
+    return (int)emm_take_dirty_slots();
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/platform/state_save.cpp
+++ b/platform/state_save.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <zlib.h>
 #include "common.h"
 #include "x1.h"
 #include "X1_CRTC.H"
@@ -82,11 +83,24 @@ extern BYTE palandply;
 
 // --- Save ---
 
-BYTE* save_full_state(int *out_size)
+BYTE* save_full_state(int *out_size, int save_flags)
 {
-    // Allocate output: header(8) + ~30 sections * (8+data) + end(8)
-    // Largest: BANK=512KB, GVRA=128KB, MRAM=64KB → ~800KB total
-    int alloc_size = 0x100000; // 1MB
+    // Calculate buffer size: base 1MB + EMM data if Portable
+    int alloc_size = 0x100000; // 1MB base
+    if (save_flags & STATE_FLAG_PORTABLE_EMM) {
+        // Add space for each EMM file + 128KB margin
+        for (int i = 0; i < MAX_EMM; i++) {
+            char path[32];
+            sprintf(path, "/EMM%d.MEM", i);
+            FILE *fp = fopen(path, "rb");
+            if (fp) {
+                fseek(fp, 0, SEEK_END);
+                alloc_size += (int)ftell(fp);
+                fclose(fp);
+            }
+        }
+        alloc_size += 128 * 1024; // margin for headers, zlib overhead
+    }
     BYTE *buf = (BYTE*)malloc(alloc_size);
     if (!buf) { *out_size = 0; return NULL; }
 
@@ -96,11 +110,13 @@ BYTE* save_full_state(int *out_size)
     int pos = 0;
     int n;
 
-    // Header
+    // Header: flags = ROM_TYPE(bit0-1) | PORTABLE_EMM(bit2)
     memcpy(buf + pos, STATE_MAGIC, 4); pos += 4;
     WORD ver = STATE_VERSION;
     memcpy(buf + pos, &ver, 2); pos += 2;
     WORD flags = (WORD)(x1flg.ROM_TYPE & 0x03);
+    if (save_flags & STATE_FLAG_PORTABLE_EMM)
+        flags |= STATE_FLAG_PORTABLE_EMM;
     memcpy(buf + pos, &flags, 2); pos += 2;
 
     // FLAG (x1flg, lastmem, v_cnt, flame, events)
@@ -192,6 +208,68 @@ BYTE* save_full_state(int *out_size)
     // VRAM control
     n = vram_save_state(scratch, SECTION_BUF_SIZE);
     write_section(buf, pos, "VRAM", scratch, n);
+
+    // Portable EMM: compress EMM files into EMDn sections
+    if (save_flags & STATE_FLAG_PORTABLE_EMM) {
+        for (int i = 0; i < MAX_EMM; i++) {
+            char path[32];
+            sprintf(path, "/EMM%d.MEM", i);
+            FILE *fp = fopen(path, "rb");
+            if (!fp) continue;
+
+            fseek(fp, 0, SEEK_END);
+            long raw_size = ftell(fp);
+            fseek(fp, 0, SEEK_SET);
+
+            if (raw_size <= 0 || raw_size > 16 * 1024 * 1024) {
+                fclose(fp);
+                continue;
+            }
+
+            BYTE *raw = (BYTE*)malloc(raw_size);
+            if (!raw) { fclose(fp); continue; }
+            if ((long)fread(raw, 1, raw_size, fp) != raw_size) {
+                free(raw);
+                fclose(fp);
+                continue;
+            }
+            fclose(fp);
+
+            // Compress with zlib
+            uLongf comp_size = compressBound((uLong)raw_size);
+            BYTE *comp = (BYTE*)malloc(comp_size);
+            if (!comp) { free(raw); continue; }
+
+            if (compress2(comp, &comp_size, raw, (uLong)raw_size, Z_DEFAULT_COMPRESSION) != Z_OK) {
+                free(comp);
+                free(raw);
+                continue;
+            }
+            free(raw);
+
+            // Ensure buffer has room: section hdr(8) + raw_size(4) + comp_data
+            int need = pos + 8 + 4 + (int)comp_size + 8; // +8 for END marker
+            if (need > alloc_size) {
+                alloc_size = need + 64 * 1024;
+                BYTE *nbuf = (BYTE*)realloc(buf, alloc_size);
+                if (!nbuf) { free(comp); continue; }
+                buf = nbuf;
+            }
+
+            // Write EMDn section: tag(4) + len(4) + raw_size(4) + compressed_data
+            char tag[5];
+            sprintf(tag, "EMD%d", i);
+            int section_data_len = 4 + (int)comp_size;
+            memcpy(buf + pos, tag, 4); pos += 4;
+            DWORD slen = (DWORD)section_data_len;
+            memcpy(buf + pos, &slen, 4); pos += 4;
+            DWORD rs = (DWORD)raw_size;
+            memcpy(buf + pos, &rs, 4); pos += 4;
+            memcpy(buf + pos, comp, (int)comp_size); pos += (int)comp_size;
+
+            free(comp);
+        }
+    }
 
     // End marker
     write_end(buf, pos);
@@ -325,7 +403,23 @@ int load_full_state(const BYTE *data, int size)
     load_section_warn(data, size, body, "SIO0", sio_load_state, warn, wmax);
     load_section_warn(data, size, body, "8255", ppi_load_state, warn, wmax);
     load_memory(data, size, body, "SCPU", &scpu, sizeof(scpu));
-    load_memory(data, size, body, "EMM0", &emm, sizeof(emm));
+
+    // EMM0: safe load with zero-init for backward compat (dirty_slots field)
+    {
+        int emm0_len = 0;
+        const BYTE* emm0_sec = find_section(data, size, body, "EMM0", emm0_len);
+        if (emm0_sec && emm0_len > 0) {
+            EMM_TABLE tmp;
+            ZeroMemory(&tmp, sizeof(tmp));
+            tmp.sel = 0xff;
+            int copy_len = (emm0_len < (int)sizeof(tmp)) ? emm0_len : (int)sizeof(tmp);
+            memcpy(&tmp, emm0_sec, copy_len);
+            emm = tmp;
+        } else {
+            init_emm();
+        }
+    }
+
     load_memory(data, size, body, "SASI", &sasi, sizeof(sasi));
     load_memory(data, size, body, "PCG0", &pcg, sizeof(pcg));
 
@@ -369,6 +463,50 @@ int load_full_state(const BYTE *data, int size)
 
     // 15. VRAM control
     load_section_warn(data, size, body, "VRAM", vram_load_state, warn, wmax);
+
+    // 15.5. Portable EMM: decompress EMDn sections → VFS files
+    //       Only for v2+ states with PORTABLE_EMM flag
+    if (ver >= 2 && (flags & STATE_FLAG_PORTABLE_EMM)) {
+        for (int i = 0; i < MAX_EMM; i++) {
+            char tag[5];
+            sprintf(tag, "EMD%d", i);
+            int sec_len = 0;
+            const BYTE *sec = find_section(data, size, body, tag, sec_len);
+            if (!sec || sec_len < 4) continue;
+
+            DWORD raw_size;
+            memcpy(&raw_size, sec, 4);
+            if (raw_size == 0 || raw_size > 16 * 1024 * 1024) continue;
+
+            int comp_len = sec_len - 4;
+            if (comp_len <= 0) continue;
+
+            BYTE *raw = (BYTE*)malloc(raw_size);
+            if (!raw) continue;
+
+            uLongf dest_len = (uLongf)raw_size;
+            if (uncompress(raw, &dest_len, sec + 4, (uLong)comp_len) != Z_OK) {
+                free(raw);
+                int wl = (int)strlen(warn);
+                if (wl > 0 && wl + 1 < wmax) { warn[wl] = ','; warn[wl+1] = '\0'; wl++; }
+                if (wl + 4 < wmax) { memcpy(warn + wl, tag, 4); warn[wl + 4] = '\0'; }
+                continue;
+            }
+
+            // Write decompressed data to VFS
+            char path[32];
+            sprintf(path, "/EMM%d.MEM", i);
+            FILE *fp = fopen(path, "wb");
+            if (fp) {
+                fwrite(raw, 1, (size_t)dest_len, fp);
+                fclose(fp);
+            }
+            free(raw);
+
+            // Clear error flag and page cache for this slot
+            emm_reset_slot(i);
+        }
+    }
 
     // 16. Recalculate derived display mode from restored CRTC registers.
     //     dispmode, pal_bank, pal_disp are globals in X1_CRTC.CPP that

--- a/platform/state_save.h
+++ b/platform/state_save.h
@@ -11,7 +11,12 @@
  */
 
 #define STATE_MAGIC     "XMST"
-#define STATE_VERSION   1
+#define STATE_VERSION   2
+
+/* flags bit assignments */
+/* bit0-1: ROM_TYPE (0-3)  — existing, do not change */
+/* bit2:   Portable EMM    — v2: EMM file data compressed in EMDn sections */
+#define STATE_FLAG_PORTABLE_EMM  0x04
 
 /* ---- serialization helpers ---- */
 
@@ -197,8 +202,9 @@ extern WORD state_load_version;
 
 /* ---- main entry points ---- */
 
-/* Returns malloc'd buffer; caller must free(). *out_size receives byte count. */
-BYTE* save_full_state(int *out_size);
+/* Returns malloc'd buffer; caller must free(). *out_size receives byte count.
+ * flags: 0 = Fast mode, STATE_FLAG_PORTABLE_EMM = include compressed EMM data */
+BYTE* save_full_state(int *out_size, int flags);
 
 /* Returns 0 on success, 1 on success with ROM_TYPE mismatch, -1 on header error.
  * Section-level failures are skipped (not fatal); call get_load_warnings()

--- a/src/X1.cpp
+++ b/src/X1.cpp
@@ -32,7 +32,7 @@
 #if T_TUNE
 #include	"x1_event.h"
 #include	"x1_irq.h"
-#include	"x1_emm.h"
+#include	"X1_EMM.H"
 #include	"x1_sasi.h"
 #include	"drawinfo.h"
 #include	"fdd_mtr.h"

--- a/src/X1_EMM.H
+++ b/src/X1_EMM.H
@@ -16,11 +16,15 @@ typedef struct {
 	DWORD	page;			// current buffer page
 	WORD	buf_size;		// current buffer size
 	BYTE	dirty_buf;		// dirty flag of current page
+	WORD	dirty_slots;	// bitmask of slots written (bit0-9 = EMM0-9)
 } EMM_TABLE;
 
 extern EMM_TABLE emm;
 
 void init_emm(void);
+void emm_flush_all_buffers(void);
+void emm_reset_slot(int sel);
+WORD emm_take_dirty_slots(void);
 
 X1_IOW x1_emm_w(WORD port, BYTE value);
 X1_IOR x1_emm_r(WORD port);

--- a/src/X1_IO.CPP
+++ b/src/X1_IO.CPP
@@ -13,7 +13,7 @@
 #include	"x1_sio.h"
 #include	"x1_sound.h"
 #if T_TUNE
-#include	"x1_emm.h"
+#include	"X1_EMM.H"
 #include	"x1_sasi.h"
 #endif
 

--- a/src/X1_emm.cpp
+++ b/src/X1_emm.cpp
@@ -7,7 +7,7 @@
 #include	<stdio.h>
 #include	"x1.h"
 #include	"xmil.h"
-#include	"x1_emm.h"
+#include	"X1_EMM.H"
 #include	"dosio.h"
 
 #define EMM_FILENAME "EMM%d.MEM"
@@ -42,6 +42,9 @@ static int emm_flush_buffer(void)
 	}
 	if (file_close(hdr)) {
 		ret = -1;
+	}
+	if (ret == 0) {
+		emm.dirty_buf = 0;
 	}
 	return(ret);
 }
@@ -92,7 +95,7 @@ static BYTE *x1_emm_get_ptr(int sel)
 
 	cur_ptr = page * 256;
 	if(cur_ptr+256 > filesize )
-		emm.buf_size = (WORD)(emm.filesize - cur_ptr);
+		emm.buf_size = (WORD)(filesize - cur_ptr);
 	else
 		emm.buf_size = 256;
 
@@ -141,6 +144,7 @@ X1_IOW x1_emm_w(WORD port, BYTE value)
 		case 3:
 			*x1_emm_get_ptr(bd) = value;
 			emm.dirty_buf = 1;
+			emm.dirty_slots |= (1 << bd);
 			/* １レコード書き込み終了時にファイルを更新 */
 			if( (++emm.addr[bd] & 0xff) == 0x00)
 				emm_flush_buffer();
@@ -188,4 +192,27 @@ X1_IOR x1_rom_r(WORD port)
 		return *x1_emm_get_ptr(MAX_EMM);
 	return 0xff;
 }
+void emm_flush_all_buffers(void)
+{
+	emm_flush_buffer();
+}
+
+void emm_reset_slot(int sel)
+{
+	if (sel < 0 || sel >= MAX_EMM) return;
+	/* dirty バッファが対象スロットなら先にフラッシュ */
+	if (emm.sel == sel) emm_flush_buffer();
+	/* エラーフラグクリア */
+	emm.addr[sel] &= 0x00FFFFFF;
+	/* ページキャッシュ無効化 */
+	if (emm.sel == sel) emm.sel = 0xff;
+}
+
+WORD emm_take_dirty_slots(void)
+{
+	WORD mask = emm.dirty_slots;
+	emm.dirty_slots = 0;
+	return mask;
+}
+
 #endif /* T_TUNE */


### PR DESCRIPTION
## 概要

X1 エミュレータに EMM（Extended Memory Manager）の完全なエミュレーション・永続化・UI を追加します。

- **C++ EMM エミュレーション**: 10 スロット（EMM0〜9）、256 バイトページキャッシング、dirty トラッキング、flush/reset API
- **ステートセーブ/ロード**: Fast モード（ハッシュのみ）と Portable モード（zlib 圧縮で EMM データを埋め込み）を選択可能
- **OPFS 永続化**: VFS ↔ OPFS 間の同期、ライフサイクル flush（定期・タブ非表示・ページ離脱）、自動リストア
- **10 スロット固定 UI**: EMM タブ選択時に専用ビューを表示し、スロットごとに作成・エクスポート・インポート・削除を操作可能

## 変更ファイル（11 ファイル, +845/-53）

| ファイル | 変更内容 |
|---------|---------|
| `CMakeLists.txt` | zlib リンク/コンパイルフラグ追加 |
| `html/index.html` | バージョン v0.3.0 → v0.4.0 |
| `html/pre.js` | EMM スロット管理、dirty 同期、flush、ステート save/load、10 スロット UI、インポート（原子性保証）、二重クリック防止 |
| `html/shell.html` | EMM ボタン、フィルタ、作成ダイアログ、Portable トグル、10 スロット行 CSS、バージョン更新 |
| `platform/platform_main.cpp` | EMM flush/reset/dirty エクスポート関数 |
| `platform/state_save.cpp` | Portable モード: EMM データの zlib 圧縮保存・復元 |
| `platform/state_save.h` | Portable フラグ定数・ヘルパー宣言追加 |
| `src/X1.cpp` | EMM ヘッダ include パス修正 |
| `src/X1_EMM.H` | `emm_reset_slot()`, `emm_take_dirty_slots()` 宣言追加 |
| `src/X1_IO.CPP` | EMM ヘッダ include パス修正 |
| `src/X1_emm.cpp` | `emm_reset_slot()`, `emm_take_dirty_slots()`, `emm_flush_all_buffers()` 実装 |

## テスト計画

- [x] EMM タブで 10 スロットが常に表示される
- [x] 未割り当てスロットは赤字「未割り当て」、エクスポート disabled
- [x] 「作成」→ サイズ選択（プリセット/カスタム）→ 作成 & マウント
- [x] 「作成」→ 既存割り当て済みスロットで確認ダイアログ表示
- [x] 「エクスポート」→ ブラウザダウンロード
- [x] 「インポート」→ ファイル選択 → マウント（既存時は上書き確認）
- [x] 「削除」→ 確認ダイアログ → イジェクト & OPFS 削除
- [x] ステートセーブ: Fast/Portable 切替が正しく動作
- [x] ステートロード: Portable ステートから EMM データが復元される
- [x] 連打しても二重実行されない（emmSlotInFlight ガード）
- [x] ページ離脱・タブ切替で dirty EMM が自動保存される
- [x] リセット/電源 OFF 時に flush 失敗で確認ダイアログが出る
- [x] 他タブ（FDD/HDD/CMT）切替時は従来通りの汎用リスト表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)