### PR TITLE
fix: iOS でライブラリ追加時にファイルがグレーアウトする問題

### DIFF
--- a/html/ui_fragments.js
+++ b/html/ui_fragments.js
@@ -104,8 +104,10 @@
     '</div>' +
 
     // ── 隠しファイル入力 (ライブラリ追加用) ──
-    '<input type="file" id="file-add-to-library" multiple style="display:none"' +
-    '       accept=".d88,.2d,.d77,.xdf,.hdm,.dup,.hdi,.thd,.nhd,.hdd,.hdn,.t98,.bin,.cmt,.cas,.mem">';
+    // iOS/iPadOS では独自拡張子 (.d88 等) を accept に指定するとファイルが
+    // グレーアウトして選択できない。ファイル形式は addToLibrary() 側で
+    // detectFileType() により検証しているため、accept は省略する。
+    '<input type="file" id="file-add-to-library" multiple style="display:none">';
 
     document.body.appendChild(container);
 })();


### PR DESCRIPTION
## Summary

iOS/iPadOS Safari でライブラリの「＋ 追加」ボタンからファイル選択する際、FD/カセットイメージがグレーアウトして選択できない問題を修正。

## 原因

`<input type="file">` の `accept` 属性に `.d88` / `.2d` / `.hdd` などの独自拡張子を列挙しており、iOS の Safari がこれらを未知の拡張子として扱ってファイルピッカーでグレーアウトさせていました。

commit `6516279` (UI リファクタ: shared DOM panels → ui_fragments.js) で、X1Pen 側の HTML にあった `accept` 属性がそのまま `ui_fragments.js` にコピーされ、shell.html 側でも適用されるようになったため発現。

## 修正

`file-add-to-library` の `accept` 属性を削除。ファイル形式のバリデーションは `addToLibrary()` 内の `detectFileType()` で既に行われているため、accept は不要で有害（iOS 限定）でした。

ROM/フォント入力（`.X1` など）は iOS でも動作するので、そちらは触らず。

## Test plan

- [x] iOS/iPadOS Safari でライブラリ「＋ 追加」から `.d88` ファイルが選択できること
- [x] デスクトップ（Chrome/Safari）でも従来通り `.d88` ファイルが選択できること
- [x] 不正な拡張子のファイルを選んだ場合 `detectFileType()` で弾かれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)