### PR TITLE
fix: xmillennium.html にもキャッシュバスターを適用

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -245,9 +245,9 @@ XMIL_BUILD_HASH=$(git -C "${SCRIPT_DIR}" rev-parse --short HEAD 2>/dev/null || d
 sed -i.bak "s/@@XMIL_BUILD_HASH@@/${XMIL_BUILD_HASH}/g" "${DIST_DIR}/x1pen.js"
 rm -f "${DIST_DIR}/x1pen.js.bak"
 
-# x1pen.html の script タグにキャッシュバスター付与
-sed -i.bak "s|src=\"\([^\"]*\.js\)\"|src=\"\1?v=${XMIL_BUILD_HASH}\"|g" "${DIST_DIR}/x1pen.html"
-rm -f "${DIST_DIR}/x1pen.html.bak"
+# script タグにキャッシュバスター付与 (x1pen.html, xmillennium.html)
+sed -i.bak "s|src=\"\([^\"]*\.js\)\"|src=\"\1?v=${XMIL_BUILD_HASH}\"|g" "${DIST_DIR}/x1pen.html" "${DIST_DIR}/xmillennium.html"
+rm -f "${DIST_DIR}/x1pen.html.bak" "${DIST_DIR}/xmillennium.html.bak"
 
 # config.js: html/config.js があればそれを使用、なければ空の example を使用
 if [ -f "${SCRIPT_DIR}/html/config.js" ]; then


### PR DESCRIPTION
## Summary

build.sh のキャッシュバスター処理が x1pen.html のみに適用されていたため、xmillennium.html 経由でアクセスするユーザーが共通スクリプト（ui_fragments.js 等）の更新を受け取れない問題を修正。

## 背景

先日の iOS ファイルピッカー修正 (PR #42, `ui_fragments.js`) をデプロイしたが、xmillennium.html 側ではブラウザキャッシュで古い ui_fragments.js が使われ続けた。

## 修正

build.sh の sed 処理を `x1pen.html` と `xmillennium.html` の両方に適用するよう変更。

## Test plan

- [x] build.sh 実行後、dist/xmillennium.html の script タグに `?v=<hash>` が付くこと
- [x] dist/x1pen.html も従来通り動作すること

## 注意

既に古い ui_fragments.js をキャッシュしている iOS ユーザーは、このデプロイ後も初回アクセスで古いキャッシュを見る可能性がある（古い HTML が初期キャッシュから script をロードする場合）。対処としては HTML 自体のキャッシュをクリアするか、ハードリロードが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)