### PR TITLE
fix: minify されたクォートなし src にもキャッシュバスター

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -246,8 +246,14 @@ sed -i.bak "s/@@XMIL_BUILD_HASH@@/${XMIL_BUILD_HASH}/g" "${DIST_DIR}/x1pen.js"
 rm -f "${DIST_DIR}/x1pen.js.bak"
 
 # script タグにキャッシュバスター付与 (x1pen.html, xmillennium.html)
-sed -i.bak "s|src=\"\([^\"]*\.js\)\"|src=\"\1?v=${XMIL_BUILD_HASH}\"|g" "${DIST_DIR}/x1pen.html" "${DIST_DIR}/xmillennium.html"
-rm -f "${DIST_DIR}/x1pen.html.bak" "${DIST_DIR}/xmillennium.html.bak"
+# minifier でクォートが外れるケース (src=foo.js) と付いたまま (src="foo.js") の両方に対応
+for _html in "${DIST_DIR}/x1pen.html" "${DIST_DIR}/xmillennium.html"; do
+    # クォート付き: src="foo.js" → src="foo.js?v=HASH"
+    sed -i.bak "s|src=\"\([^\"?]*\.js\)\"|src=\"\1?v=${XMIL_BUILD_HASH}\"|g" "${_html}"
+    # クォートなし: src=foo.js → src="foo.js?v=HASH"
+    sed -i.bak "s|src=\([A-Za-z_][A-Za-z0-9_./-]*\.js\)|src=\"\1?v=${XMIL_BUILD_HASH}\"|g" "${_html}"
+    rm -f "${_html}.bak"
+done
 
 # config.js: html/config.js があればそれを使用、なければ空の example を使用
 if [ -f "${SCRIPT_DIR}/html/config.js" ]; then


### PR DESCRIPTION
## Summary

前回の PR #43 でキャッシュバスター処理を xmillennium.html にも広げたが、実際には効いていなかった。

## 原因

xmillennium.html は minifier でクォートが外される（\`src=foo.js\`）のに対し、sed 正規表現は \`src="foo.js"\` のクォート付きしかマッチしなかった。

x1pen.html はクォートが残っていたため、そちらだけは動作していた。

## 修正

sed を 2 パスにして、クォート付き/なし両方に対応:
1. \`src="foo.js"\` → \`src="foo.js?v=HASH"\`
2. \`src=foo.js\` → \`src="foo.js?v=HASH"\` (クォートも追加)

## Test plan

- [x] ビルド後 dist/xmillennium.html と dist/x1pen.html の両方で script に \`?v=<hash>\` が付くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)