### PR TITLE
feat: SLANG コンパイラ同期 (1babc96 → 3394e75) - FLOAT バグ修正

### DIFF
--- a/assets/slang_runtime/libfloat.asm
+++ b/assets/slang_runtime/libfloat.asm
@@ -376,6 +376,8 @@ cp 18
 ret c
 return_exp_b:
 ld a,b
+or a       ; ZフラグをクリアしてC=0にする (差>=18時に
+           ; jr z,f24add_subtract_same_exp 等の誤発火を防ぐ)
 ret
 
 f24add_op1_inf_nan:

--- a/html/x1pen_slang_compiler.js
+++ b/html/x1pen_slang_compiler.js
@@ -1,6 +1,6 @@
 // x1pen_slang_compiler.js — SLANG Compiler for X1Pen
 // Ported from C# (SLANGCompiler.Core) to JavaScript
-// C# source snapshot: https://github.com/h-o-soft/SLANG-compiler @ 1babc96
+// C# source snapshot: https://github.com/h-o-soft/SLANG-compiler @ 3394e75
 // Lazy-loaded: window.X1PenSlangCompiler = { compile: ... }
 
 (function() {
@@ -3664,9 +3664,16 @@
                     return dest;
                 }
             }
+            // FLOAT即値の単項マイナスは符号反転して定数化
+            if (node.op === UnaryOp.Negate && node.operand.type === 'FloatLiteral') {
+                return emitLoadFloatConstValue(-node.operand.value);
+            }
 
             var operand = visitNode(node.operand);
             if (node.op === UnaryOp.Plus) return operand;
+
+            var operandDs = (operand.kind === IrOperandKind.Temp && _tempDataSize[operand.tempIndex] !== undefined)
+                ? _tempDataSize[operand.tempIndex] : 2;
 
             var dest2 = IrOperand.Temp(allocTemp());
             var op;
@@ -3674,7 +3681,10 @@
             else if (node.op === UnaryOp.Not) op = IrOp.LogNot;
             else if (node.op === UnaryOp.Cpl) op = IrOp.Not;
             else op = IrOp.Nop;
-            emit(op, dest2, operand);
+            // FLOAT の単項マイナスは f24 符号ビットを反転 (DataSize=3 で識別)
+            var destDs = (op === IrOp.Neg && operandDs === 3) ? 3 : 2;
+            emit(op, dest2, operand, undefined, destDs);
+            if (destDs === 3) _tempDataSize[dest2.tempIndex] = 3;
             return dest2;
         }
 
@@ -4235,6 +4245,12 @@
             visited[k] = true;
             var func = _functions[k];
             if (func) {
+                // エイリアス経由で呼ばれた場合に正規名(@name)も visited に記録して二重追加を防ぐ
+                var canonicalKey = lc(func.name);
+                if (canonicalKey !== k) {
+                    if (visited[canonicalKey]) return;
+                    visited[canonicalKey] = true;
+                }
                 for (var i = 0; i < func.dependencies.length; i++)
                     collectDependencies(func.dependencies[i], visited, result);
                 result.push(func);
@@ -5076,6 +5092,11 @@
         function emitDiv(inst, signed) { emitPopToDE(inst.dataSize); if (inst.dataSize === 3) callRuntime('f24div'); else callRuntime(signed ? 'SDIVHLDE' : 'DIVHLDE'); }
         function emitMod(inst, signed) { _e.instruction('POP', 'DE'); _e.instruction('EX', 'DE,HL'); callRuntime(signed ? 'SMODHLDE' : 'MODHLDE'); }
         function emitNeg(inst) {
+            if (inst.dataSize === 3) {
+                // FLOAT (f24): 符号ビット (A レジスタの bit7) を反転
+                _e.instruction('XOR', '$80');
+                return;
+            }
             _e.instruction('LD', 'A,H'); _e.instruction('CPL'); _e.instruction('LD', 'H,A');
             _e.instruction('LD', 'A,L'); _e.instruction('CPL'); _e.instruction('LD', 'L,A');
             _e.instruction('INC', 'HL');


### PR DESCRIPTION
## Summary

C# 版 SLANG コンパイラの FLOAT 関連バグ 3 件の修正を取り込む。
RunCPM で実機動作確認済み（上流側）。

- トラッキング SHA: `1babc96` → `3394e75`

## 取り込んだバグ修正

### 1. f24add: 指数差 18 ビット時の同指数加算誤分岐 (libfloat.asm)
`f24add_reorder` の `cp 18` で差==18 のとき Z=1 となり、呼び出し元の `jr z,f24add_subtract_same_exp` が誤って発火。結果、cos 多項式の最終ステップ `+1.0` で壊れた値を返し、`FCOS(3.1447)` 等が誤動作。
`return_exp_b` に `or a` を追加して Z をクリア。

### 2. FLOAT の単項マイナスが整数演算として展開 (visitUnaryExpr + emitNeg)
`visitUnaryExpr` / `emitNeg` ともに FLOAT (dataSize=3) を考慮しておらず、f24 値の HL を 16bit 整数として `CPL+INC HL` していた。
- `visitUnaryExpr`: operand の dataSize を見て `IR.Neg` に伝搬
- `emitNeg`: dataSize=3 のとき `XOR A,$80`（符号ビット反転）に分岐
- `FloatLiteral` の単項マイナスはコンパイル時に定数化

### 3. `@alias` と `@name` 両方使用で関数本体が重複 (collectDependencies)
`ITOF` と `i16tof24` のように同じ関数を別名で参照すると、visited が名前単位のため同じ RuntimeFunction が 2 回 result に追加され、ASM 出力でラベル重複エラー。
正規名 (`func.name`) も visited に登録して二重追加を防止。

## 検証

- [x] Z80 アセンブラテスト 322 件パス
- [x] X1GRP PERFECT MATCH 維持
- [x] `-FLOAT変数` で `XOR \$80` が出力される
- [x] `-3.14` リテラルが正しくアセンブル
- [x] `ITOF(x)` 経由でも `i16tof24` のラベル重複なく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)