### PR TITLE
feat: sync with C# SLANG compiler (6147192 → c9e8f53)

### DIFF
--- a/assets/slang_include/CHIPLIB.LIB
+++ b/assets/slang_include/CHIPLIB.LIB
@@ -1,0 +1,1506 @@
+///
+/// CHIPLIB.SL — X1 総合グラフィックライブラリ (320x200, 8x8 チップ)
+///
+/// 役割:
+///   全部入り総合グラフィックライブラリ。マップ描画 + チップスプライト +
+///   マスク描画 + アニメ + ダブルバッファを、グラフィック VRAM 一括で管理する高機能版。
+///   PCG ベース (TILELIB) ではなく、グラフィック VRAM で直接描画したい場合に使う。
+///
+/// 特徴:
+///   - 仮想 VRAM (RAM) ダブルバッファ + 差分転送
+///   - マップ描画、単発チップ描画、マスク描画 (合成バッファ経由)
+///   - スプライト系 API (CHIP_SPR_*) で前景合成
+///   - アニメ対応 (CHIP_SET_ANIM 閾値以上のチップを自動サイクル)
+///   - 表示領域 / スクロール / マップサイズを個別指定可能
+///
+/// ユーザー設定:
+///   通常使用は CHIP_SET_SIZE() で VVRAM サイズが自動設定される (display + 2 マージン)。
+///   要求サイズが _CHIP_VVRAMW_MAX × _CHIP_VVRAMH_MAX を超えると自動で clamp。
+///   デフォルト MAX は 42x28。大画面マップが必要なら #include 前に上書き可能:
+///     CONST _CHIP_VVRAM_OVERRIDE = 1;
+///     CONST ASM _CHIP_VVRAMW_MAX = 50;
+///     CONST ASM _CHIP_VVRAMH_MAX = 30;
+///     #include "CHIPLIB.SL"
+///
+/// 公開 API 分類:
+///   [必須]    CHIP_INIT, CHIP_SET_MAP, CHIP_SET_MAPSIZE,
+///             CHIP_SET_SIZE, CHIP_SET_OFS, CHIP_SET_SCROLL,
+///             CHIP_FILL_MAP, CHIP_DRAW_VVRAM
+///   [アニメ]  CHIP_SET_ANIM, CHIP_SET_ANIM_RATE, CHIP_ANIM_TICK (VSYNC_PROC から)
+///   [スプライト] CHIP_SPR_START, CHIP_SPR_POS, CHIP_SPR_ADD, CHIP_SPR_FLASH
+///   [直接描画] CHIP_DRAW, CHIP_MASK_DRAW
+///   [上級者向け] CHIP_SET_VVRAMSIZE (通常は CHIP_SET_SIZE で自動設定)
+///
+
+// --- 初期化・描画 ---
+MACHINE CHIP_INIT(0): ChipInit;
+MACHINE CHIP_DRAW_VVRAM(0): ChipDrawVVRAM;
+MACHINE CHIP_FILL_MAP(0): ChipFillMap;
+MACHINE CHIP_DRAW(3): ChipDraw;
+MACHINE CHIP_MASK_DRAW(3): ChipMaskDraw;
+
+// --- 設定 ---
+MACHINE CHIP_SET_OFS(2): ChipSetOfs;
+MACHINE CHIP_SET_SIZE(2): ChipSetSize;
+MACHINE CHIP_SET_MAP(3): ChipSetMap;
+MACHINE CHIP_SET_MAPSIZE(2): ChipSetMapSize;
+MACHINE CHIP_SET_SCROLL(2): ChipSetScroll;
+MACHINE CHIP_SET_VVRAMSIZE(2): ChipSetVVRAMSize;
+MACHINE CHIP_SET_ANIM(1): ChipSetAnim;
+MACHINE CHIP_SET_ANIM_RATE(2): ChipSetAnimRate;
+MACHINE CHIP_ANIM_TICK(0): ChipAnimTick;
+
+// --- スプライト ---
+MACHINE CHIP_SPR_START(0): ChipSprStart;
+MACHINE CHIP_SPR_POS(2): ChipSprPos;
+MACHINE CHIP_SPR_ADD(3): ChipSprAdd;
+MACHINE CHIP_SPR_FLASH(1): ChipSprFlash;
+
+// ============================================================
+// ブロック 1: 実装
+// ============================================================
+//
+// VVRAM 最大サイズ (バッファ確保用)。デフォルト 42x28。
+// 大きいマップが必要な場合は #include 前に下記のように上書き可能:
+//   CONST _CHIP_VVRAM_OVERRIDE = 1;
+//   CONST ASM _CHIP_VVRAMW_MAX = 50;
+//   CONST ASM _CHIP_VVRAMH_MAX = 30;
+//   #include "CHIPLIB.SL"
+#IF (_CHIP_VVRAM_OVERRIDE != 1)
+CONST ASM _CHIP_VVRAMW_MAX = 42;
+CONST ASM _CHIP_VVRAMH_MAX = 28;
+#ENDIF
+
+#ASM
+; 初期値 (CHIP_SET_VVRAMSIZE で動的変更可)
+VVRAMWIDTH	EQU	42
+VVRAMHEIGHT	EQU	27
+MAPWIDTH	EQU	21	; 全画面: (40+1)/2+1
+MAPHEIGHT	EQU	14	; 全画面: (25+1)/2+1
+DRAWX		EQU	0
+DRAWY		EQU	0
+DRAWWCNT	EQU	40	; 全画面 320/8
+DRAWHCNT	EQU	25	; 全画面 200/8
+
+; データアドレス初期値 (CHIP_SET_MAP で動的設定される前提。ダミー 0)
+MAPGRPADR	EQU	0
+MAPIDXADR	EQU	0
+MAPCHIPADR	EQU	0
+MERGEBUFFER	EQU	0
+
+_CHIP_ANIMIDX:	DB	0
+
+;
+;  ChipInit
+;    仮想VRAMとその関連データの初期化
+; 
+ChipInit:
+	; 仮想VRAM (RAM ダブルバッファ) を $FF でクリア
+	; ($FF = 未使用値。チップ番号 0 との差分を出すため 0 ではなく $FF)
+	ld hl,_CHIP_VVRAM0
+	ld bc,VVRAM_SIZE
+	ld a,$FF
+	call _ChipClearRAM
+	ld hl,_CHIP_VVRAM1
+	ld bc,VVRAM_SIZE
+	ld a,$FF
+	call _ChipClearRAM
+	; マージバッファアドレスを自己書き換えで設定 (内部 _CHIP_MERGEBUF を参照)
+	ld a,HIGH _CHIP_MERGEBUF
+	ld (VramDrawAddress.ref_mergebuf1+1),a
+	ld (ChipSprAdd.ref_mergebuf2+1),a
+	ld (ChipSprAdd.ref_mergebuf3+1),a
+	; Primary をページ 0 にしておく
+	xor a
+	ld (_CHIP_PRIMARY),a
+	ret
+
+; RAM を A の値でクリア (HL=先頭, BC=サイズ)
+_ChipClearRAM:
+	ld (hl),a
+	ld d,h
+	ld e,l
+	inc de
+	dec bc
+	ldir
+	ret
+
+; 仮想 VRAM / チップ定数
+VVRAM_SIZE	EQU	_CHIP_VVRAMW_MAX * _CHIP_VVRAMH_MAX	; 最大サイズでクリア
+CHIP_SIZE	EQU	24	; 通常チップ: B8+R8+G8
+MASK_CHIP_SIZE	EQU	32	; マスク付き: mask8+B8+R8+G8
+MERGE_UNIT	EQU	32	; 合成バッファ 1 個
+
+;;; X1 版 Phase 0: 最小描画プリミティブ (320x200, 8x8 チップ)
+
+;
+; _ChipGetVRAMAdr
+;   X1 の非線形 VRAM I/O アドレスを計算する (320x200, WIDTH=40)
+;   Y%8==0 前提で簡略化: (Y&7)<<11 の項は常に 0
+;
+;   入力: HL = X (ピクセル単位), DE = Y (ピクセル単位、8の倍数のみ)
+;   出力: HL = B プレーン ($4000 ベース) の I/O アドレス
+;   破壊: AF, BC, DE
+;
+;   計算: $4000 + X + Y * 40 (入力はチップ単位 = 8ドット単位)
+;
+_ChipGetVRAMAdr:
+	push hl			; X を保存
+	; Y * 40 = Y*8 + Y*32
+	ex de,hl		; HL = Y
+	ld d,h
+	ld e,l			; DE = Y
+	add hl,hl
+	add hl,hl
+	add hl,hl		; HL = Y*8
+	ld b,h
+	ld c,l			; BC = Y*8
+	add hl,hl
+	add hl,hl		; HL = Y*32
+	add hl,bc		; HL = Y*40
+	ex de,hl		; DE = Y*40
+	pop hl			; HL = X
+	; 合算
+	add hl,de		; HL = X + Y*40
+	ld de,$4000
+	add hl,de		; HL = $4000 + X + Y*40
+	ret
+
+;
+; ChipSetMap
+;   マップデータのアドレスを設定 (自己書き換え)
+;   HL = MAPCHIPADR, DE = MAPIDXADR, BC = MAPGRPADR
+;
+ChipSetMap:
+	ld (ChipFillMap.ref_mapchipadr+2),hl	; ld ix,imm の即値は +2
+	ld (ChipFillMap.ref_mapidxadr+1),de
+	ld (VramDrawAddress.ref_mapgrpadr1+1),bc
+	ld (ChipSprAdd.ref_mapgrpadr2+1),bc
+	ret
+
+;
+; ChipDraw
+;   指定座標に 1 チップ (8x8) を描画
+;   HL = X (チップ単位), DE = Y (チップ単位)
+;   BC = チップ画像データアドレス (24 bytes: B8+R8+G8)
+;
+ChipDraw:
+	push bc			; 画像データアドレスを保存
+	call _ChipGetVRAMAdr	; HL = VRAM I/O アドレス
+	call _ChipSetDrawAddr	; 自己書き換え
+	pop hl			; HL = 画像データ
+	call _ChipDrawOne
+	ret
+
+;
+; _ChipSetDrawAddr
+;   _ChipDrawOne 内の ld bc 即値を自己書き換えして描画先を設定
+;
+;   入力: HL = B プレーンの VRAM I/O アドレス (_ChipGetVRAMAdr の戻り値)
+;   破壊: なし
+;
+_ChipSetDrawAddr:
+	ld (_ChipDrawOne.bc_init+1),hl
+	ret
+
+;
+; _ChipDrawInner
+;   8x8 チップ 1 プレーンを VRAM に描画 (アンロール展開)
+;
+;   前提: BC = VRAM I/O アドレス、SP = 画像データ先頭
+;   動作: POP で 2 行分 (2 bytes) を一括読み → OUT (C),A でライン描画
+;         各行で B += $08 (X1 インターリーブの次ライン)
+;         8 行完了時 B は +$40 されており、次プレーンの先頭に自動遷移
+;   破壊: AF, HL, BC (B += $40)
+;
+_ChipDrawInner:
+	ld (.stacksave+1),sp
+	ld sp,hl		; SP = 画像データ
+	; ---- line 0, 1 ----
+	pop hl
+	ld a,l
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	ld a,h
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	; ---- line 2, 3 ----
+	pop hl
+	ld a,l
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	ld a,h
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	; ---- line 4, 5 ----
+	pop hl
+	ld a,l
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	ld a,h
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	; ---- line 6, 7 ----
+	pop hl
+	ld a,l
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a
+	ld a,h
+	out (c),a
+	ld a,b
+	add a,$08
+	ld b,a		; 計 B += $08*8 = $40 → 次プレーンへ
+	; SP 現在値 (= 次の画像データ位置) を HL に保存
+	ld hl,0
+	add hl,sp
+.stacksave:
+	ld sp,0		; SP 復帰
+	ret
+
+;
+; _ChipDrawOne
+;   8x8 チップを 3 プレーン (B/R/G) 描画する
+;
+;   前提: _ChipSetDrawAddr で描画先が設定済み
+;   入力: HL = 画像データ先頭 (24 bytes: B[8] + R[8] + G[8])
+;   動作: _ChipDrawInner を 3 回呼ぶ (内部で SP 保存/復帰)
+;         _ChipDrawInner 内で B += $40 されるため、
+;         B→R→G のプレーン切替はオーバーヘッドゼロ
+;   破壊: AF, HL, BC
+;
+_ChipDrawOne:
+	di
+.bc_init:
+	ld bc,$0000		; ← _ChipSetDrawAddr で自己書き換え
+	call _ChipDrawInner	; B プレーン ($4000+offset)
+	call _ChipDrawInner	; R プレーン (自動: B += $40 → $8000+offset)
+	call _ChipDrawInner	; G プレーン (自動: B += $40 → $C000+offset)
+	ei
+	ret
+
+
+;
+; ChipFillMap
+;   マップデータを元に現在書き込み有効な仮想VRAMに転送
+; 
+ChipFillMap:
+	; 入力
+	; (Work) _CHIP_MAPX  描画左上座標(8x8を1単位とした座標
+	; (Work) _CHIP_MAPY  描画左上座標
+	; (Work) _CHIP_PRIMARY 描画対象の仮想VRAM番号とMAPX、MAPYのオフセット位置(各1ビット)
+	push iy
+
+	ld iy,_CHIP_MAPY
+.ref_mapchipadr:
+	ld ix,MAPCHIPADR
+
+	; deにPrimary(描画先VVRAM)のアドレスを入れる (RAM ダブルバッファ)
+	ld a,(_CHIP_PRIMARY)
+	and 1
+	jr nz,.usepage1
+	ld de,_CHIP_VVRAM0
+	jr .pagesel_done
+.usepage1:
+	ld de,_CHIP_VVRAM1
+.pagesel_done:
+
+	; IY = _CHIP_MAPY(IY+2がMAPX)
+	; IX = MAPCHIPADR(圧縮マップ)
+	; DE = 描画先VVRAMアドレス(Primary/Secondary考慮済)
+
+
+	push de
+	; backup sp
+	ld (.tileMapSp+1),sp
+
+	;Calculate Y-offset
+	ld a,(IY+1)	; High _CHIP_MAPY
+	srl a
+	ld h,a
+	ld a,(IY+0)	; Low _CHIP_MAPY
+	rr a
+	ld l,a
+	ld e,(IY+4)	; _CHIP_MAPW。 可変サイズなので……
+	ld d,0
+	call MULHLDE	; 素朴に掛け算する
+	ex de,hl
+	add ix,de
+
+	ld a,(IY+3)	; High _CHIP_MAPX
+	srl a
+	ld d,a
+	ld a,(IY+2)	; Low _CHIP_MAPX
+	rr a
+	ld e,a
+	add ix,de
+	; ここでixに描画元のMAPCHIPADR先頭が入る(ここから最大20x12を拾って描画する)
+
+	pop de
+	push de
+	; deには描画先仮想VRAM先頭アドレスが入っている
+
+
+	exx
+	; 縦のループ数
+	ld c,MAPHEIGHT
+.tileTransferY
+	exx
+	; 仮想VRAMアドレス先頭を保存しておく
+	ld (.DeRestore+1),de
+	exx
+	; 圧縮マップの横のループ数
+	ld b,MAPWIDTH
+.tileTransferX
+	exx
+
+	ld a,(ix)	; 圧縮マップのタイル番号
+	and $3f		; 上位2ビットは無視
+	inc ix		; 右に移動
+
+	; 4倍してやる(2x2でマップチップが4バイト構成なので)
+	ld l,a
+	ld h,0
+	add hl,hl
+	add hl,hl
+	ld c,l
+	ld b,h
+	; ld c,a
+	; xor a
+	; sla c
+	; rla
+	; sla c
+	; rla
+	; ld b,a
+.ref_mapidxadr:
+	ld hl,MAPIDXADR
+	add hl,bc
+
+	; ここまでで
+	; iy = マップ座標の先頭
+	; ix = 描画元のMAPCHIPADR(これはしばらく使わない)
+	; hl = マップチップ先頭(2x2の先頭)
+	; de = 描画先仮想VRAM先頭
+	; が、入っている。
+
+	di
+	ld sp,hl
+	
+	ex de,hl
+	; 入れ替えてこうなる
+	; hl = 描画先仮想VRAM先頭
+	; de = マップチップ先頭(2x2の先頭)
+
+	
+
+	; bcには仮想VRAM改行幅を入れる
+.ref_vvw_m1:
+	ld bc,VVRAMWIDTH-1
+
+	; 2x2を描画する(クリッピングを考慮していない)
+	; VVRAMチップ番号を2つ得る
+	pop de
+	ld (hl),e
+	inc hl
+	ld (hl),d
+	add hl,bc
+	pop de
+	ld (hl),e
+	inc hl
+	ld (hl),d
+	xor a
+	sbc hl,bc	; これで右に移動している
+
+	; ここまでで2x2が描画出来ている
+
+	ex de,hl
+	; hl = (pop deで壊れているので使われない)
+	; de = 仮想VRAM先頭
+
+	exx
+	dec b
+	jr nz,.tileTransferX
+	exx
+
+	; ここでDE(描画先)を戻す
+.DeRestore
+	ld de,0
+
+.ref_vvw_x2:
+	ld hl,VVRAMWIDTH*2	; 横一行の2行ぶん足す
+	add hl,de
+	ex de,hl
+	; これでdeに描画先VVRAMアドレスが入る
+
+	ld a,(_CHIP_MAPW)
+	ld c,a
+	ld b,0
+	; 本来は圧縮マップの横描画数なので-20あるいは-18になるはず(IXが進んだ数を引いてやって、次の行の先頭に移動させる)
+	add ix,bc		;Move to the next row of the Supertilemap
+	ld bc,-MAPWIDTH
+	add ix,bc		;Move to the next row of the Supertilemap
+
+	exx
+	dec c
+	jr nz,.tileTransferY
+	exx
+
+.tileMapSp
+	ld	sp,0
+
+	pop hl	; DEに入れておいた描画先VVRAMアドレス
+
+
+	
+
+	pop IY
+	ei
+	ret
+
+
+; マップチップ描画の左上座標を指定
+; X1 版: X, Y ともにチップ単位 (8x8 = 1)
+ChipSetOfs:
+	; hl = x (チップ単位)
+	; de = y (チップ単位)
+	call _ChipGetVRAMAdr
+	call _ChipSetDrawAddr
+	ld (VramDrawAddress+1),hl	; ChipDrawVVRAM 裏レジスタ初期値も設定
+	ret
+
+; マップチップ描画の縦横の個数を指定 (X1 8x8 版)
+;   通常はこの関数だけで VVRAM サイズも自動設定される (display + 2 マージン、MAX で clamp)。
+;   特殊用途で VVRAM サイズを明示制御したい場合は、本関数の後に CHIP_SET_VVRAMSIZE を呼ぶ。
+;   要求サイズが _CHIP_VVRAMW_MAX × _CHIP_VVRAMH_MAX を超えた場合は MAX に clamp される。
+;   大画面が必要なら ライブラリ取り込み前に MAX を上書き定義すること。
+ChipSetSize:
+	; hl = 横個数 (8x8 チップ数)
+	; de = 縦個数
+
+	; --- 内部 VVRAM サイズも自動設定 (display + 2, MAX で clamp) ---
+	push hl
+	push de
+	; VVRAM W = HL + 2 (clamp to _CHIP_VVRAMW_MAX)
+	ld a,l
+	add a,2
+	cp _CHIP_VVRAMW_MAX + 1
+	jr c,.cssz_wok
+	ld a,_CHIP_VVRAMW_MAX
+.cssz_wok:
+	ld l,a
+	ld h,0
+	; VVRAM H = DE + 2 (clamp to _CHIP_VVRAMH_MAX)
+	ld a,e
+	add a,2
+	cp _CHIP_VVRAMH_MAX + 1
+	jr c,.cssz_hok
+	ld a,_CHIP_VVRAMH_MAX
+.cssz_hok:
+	ld e,a
+	ld d,0
+	call ChipSetVVRAMSize
+	pop de
+	pop hl
+
+	; VVRAM マージン = VVRAMWIDTH - 横個数
+.ref_vvw:
+	ld a,VVRAMWIDTH
+	sub l
+	ld (VramDrawAddress.vvrammargin+1),a
+
+	; 縦サイズを入れておく
+	ld a,e
+	ld (VramDrawAddress.drawhcnt1+1),a
+
+	; 横サイズを入れておく
+	ld a,l
+	ld (VramDrawAddress.drawwcnt0+1),a
+	ld (VramDrawAddress.drawwcnt1+1),a
+	ld (VramDrawAddress.drawwcnt2+1),a
+	ld (VramDrawAddress.drawwcnt3+1),a
+
+	; 行間 VRAM アドレスジャンプ = 40 - 横個数 (X1 WIDTH=40, 8x8=1byte/chip)
+	ld a,40
+	sub l
+	ld l,a
+	ld h,0
+	ld (VramDrawAddress+4),hl
+
+	ret
+
+ChipSetAnim:
+	; hl = anim parts start index
+	ld a,l
+	ld (VramDrawAddress.animstart+1),a
+	ld (ChipSprAdd.ref_animstart2+1),a	; SpriteAdd 内のアニメ判定も同期
+	ret
+
+;
+; ChipSetAnimRate — アニメ進行レート設定
+;   HL = ticks (1 フレーム進めるのに必要な vsync 数)
+;   DE = period (アニメ周期、1-4 が実用範囲)
+;   範囲外 (0) は内部で 1 にクランプ
+;   実行中にレート変更すると内部カウンタ/フレームが新範囲を逸脱しないよう、
+;   _CHIP_ANIMCNT / _CHIP_ANIMFRAME / _CHIP_ANIMIDX を 0 に初期化する
+;
+ChipSetAnimRate:
+	ld a,l
+	or a
+	jr nz,.tickok
+	ld a,1			; ticks=0 → 1 にクランプ
+.tickok:
+	ld (_CHIP_ANIMTICKS),a
+	ld a,e
+	or a
+	jr nz,.perok
+	ld a,1			; period=0 → 1 にクランプ
+.perok:
+	ld (_CHIP_ANIMPERIOD),a
+	; 内部状態を整合する値 (0) にリセット
+	xor a
+	ld (_CHIP_ANIMCNT),a
+	ld (_CHIP_ANIMFRAME),a
+	ld (_CHIP_ANIMIDX),a
+	ret
+
+;
+; ChipAnimTick — VSYNC_PROC から呼ぶ。アニメカウンタ進行 + フレーム更新
+;   _CHIP_ANIMIDX を必要に応じて更新する
+;
+ChipAnimTick:
+	ld hl,_CHIP_ANIMCNT
+	inc (hl)
+	ld a,(hl)
+	ld b,a
+	ld a,(_CHIP_ANIMTICKS)
+	cp b
+	ret nz			; counter < ticks → 何もしない
+	; counter == ticks → リセットしてフレーム進行
+	ld (hl),0
+	ld hl,_CHIP_ANIMFRAME
+	inc (hl)
+	ld a,(hl)
+	ld b,a
+	ld a,(_CHIP_ANIMPERIOD)
+	cp b
+	jr nz,.notwrap
+	ld (hl),0		; frame == period → ラップ
+.notwrap:
+	ld a,(_CHIP_ANIMFRAME)
+	ld (_CHIP_ANIMIDX),a
+	ret
+
+
+
+; ChipDrawVVRAM
+;  仮想VRAMのキャラクターコードを元に描画を行う
+;  ダブルバッファのSWAPも実行する
+;
+ChipDrawVVRAM:
+	; 裏レジスタに実 VRAM I/O アドレスを入れておく (X1: B プレーンベース)
+	exx
+VramDrawAddress:
+	ld hl,$4000		; ← ChipSetOfs で自己書き換え (_ChipGetVRAMAdr の戻り値)
+	ld de,40-DRAWWCNT	; ← ChipSetSize で自己書き換え (行間マージン)
+.drawwcnt0
+	ld c,DRAWWCNT		; ← ChipSetSize で自己書き換え
+	exx
+
+	; 横描画数
+.drawwcnt1
+	ld b,DRAWWCNT		; ← ChipSetSize
+	; 縦描画数
+.drawhcnt1
+	ld c,DRAWHCNT		; ← ChipSetSize
+
+	; VVRAM のオフセット計算 (X/Y のサブチップオフセット)
+	ld a,(_CHIP_MAPY)
+	and 1
+	sla a
+	sla a
+	ld e,a
+	ld a,(_CHIP_MAPX)
+	and 1
+	sla a
+	or e
+
+	; 新データ (ChipFillMap/ChipSprAdd が書いた側 = PRIMARY ページ)
+	push af
+	ld a,(_CHIP_PRIMARY)
+	and 1
+	jr nz,.draw_new_page1
+	ld hl,_CHIP_VVRAM0	; PRIMARY=0 → 新データ=PAGE0
+	jr .draw_new_done
+.draw_new_page1:
+	ld hl,_CHIP_VVRAM1	; PRIMARY=1 → 新データ=PAGE1
+.draw_new_done:
+	pop af
+	call _ChipSetVAdrOfs
+	push hl
+
+	; 旧データ (前回描画 = PRIMARY の逆ページ)
+	; ★ A は _CHIP_PRIMARY を使う (bit 2-1 に前回のオフセット情報が入っている)
+	ld a,(_CHIP_PRIMARY)
+	push af			; _CHIP_PRIMARY を保存
+	and 1			; bit 0 でページ選択
+	jr z,.draw_old_page1
+	ld hl,_CHIP_VVRAM0	; PRIMARY=1 → 旧データ=PAGE0
+	jr .draw_old_done
+.draw_old_page1:
+	ld hl,_CHIP_VVRAM1	; PRIMARY=0 → 旧データ=PAGE1
+.draw_old_done:
+	pop af			; _CHIP_PRIMARY 復帰 (前回のオフセット)
+	call _ChipSetVAdrOfs
+	pop de
+	; DE = 新データ (PRIMARY), HL = 旧データ (前回)
+
+.drawvvram_loop
+	
+
+	ld a,(de)	; DE が secondary 側
+	; 128以上の場合(合成チップの場合)は必ず描画する
+.animstart
+	cp 80
+	jr nc,.combdraw
+	; 128未満の場合は前の画面と比較する
+	cp (hl)
+
+	; 一致している場合は描画しない
+	jr z,.nodraw
+.mapdraw
+	; マップ描画
+	push de
+	push hl
+	; aにチップ番号があるので24倍してからMAPGRPADRを足す (8x8: CHIP_SIZE=24)
+	ld l,a
+	ld h,0
+.mapanimdraw
+	add hl,hl
+	add hl,hl
+	add hl,hl	; ×8
+	ld e,l
+	ld d,h
+	add hl,hl
+	add hl,de	; ×24
+.ref_mapgrpadr1:
+	ld de,MAPGRPADR
+	add hl,de
+	ex de,hl
+	; deがチップアドレスになっている
+	exx
+	push hl
+	exx
+	pop hl
+	jr .chipdraw
+.animdraw
+	; マップ描画だがチップアドレス下位2ビットを差し替えてやる
+	push de
+	push hl
+	and $fc
+	ld l,a
+	ld a,(_CHIP_ANIMIDX)
+	or l
+	ld l,a
+	ld h,0
+	jr .mapanimdraw
+.combdraw
+	cp $80
+	jr c,.animdraw
+
+	; 合成チップ描画
+	push de
+	push hl
+
+	ex de,hl
+	; 合成バッファ位置を算出 (8x8: MERGE_UNIT=32)
+	and $7f
+	ld l,a
+	ld h,0
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl	; 32倍
+.ref_mergebuf1:
+	ld a,HIGH MERGEBUFFER
+	add a,h
+	ld h,a
+	ex de,hl
+
+	exx
+	push hl
+	exx
+	pop hl
+	;jr .chipdraw
+.chipdraw
+	; この時点で HL=実VRAM I/Oアドレス、DE=画像アドレス になっている
+	push bc
+	call _ChipSetDrawAddr	; HL を _ChipDrawOne.bc_init に書き換え
+	ex de,hl		; HL = 画像データ (_ChipDrawOne は HL で受ける)
+	call _ChipDrawOne
+
+	pop bc
+	pop hl
+	pop de
+.nodraw
+	inc hl
+	inc de
+
+	; 裏レジスタ側で実VRAM I/Oアドレスを計算
+	exx
+	dec c
+	; 1行ぶんは単に横移動
+	jr	nz,.yoko2add
+	; 右端に到達したら次の char row (+40) に進む
+	add hl,de
+.drawwcnt2
+	ld c,DRAWWCNT		; ← ChipSetSize
+.yoko2add
+	; 横 8 ドットおきなので 1 バイト (8x8)
+	inc hl
+	exx
+
+	djnz .drawvvram_loop
+
+.drawwcnt3
+	ld b,DRAWWCNT		; ← ChipSetSize
+
+	; hl と de を VVRAMWIDTH - DRAWWCNT 足して次の行先頭に
+	push bc
+.vvrammargin
+	ld bc,VVRAMWIDTH-DRAWWCNT	; ← ChipSetSize で自己書き換え
+	add hl,bc
+	ex de,hl
+	add hl,bc
+	ex de,hl
+	pop bc
+
+	dec c
+	jp nz,.drawvvram_loop
+
+	; 今回のオフセットを保存しておく
+	ld a,(_CHIP_MAPY)
+	and 1
+	sla a
+	sla a
+	ld b,a
+	ld a,(_CHIP_MAPX)
+	and 1
+	sla a
+	or b
+	ld b,a
+
+	; 描画対象をSWAPしておく
+	ld a,(_CHIP_PRIMARY)
+	xor 1
+	and 1
+	; 前回オフセットを保存
+	or b
+	ld (_CHIP_PRIMARY),a
+
+	ret
+
+; _CHIP_MAPX, _CHIP_MAPYのオフセットを考慮して仮想VRAMの参照先頭位置をズラす
+; X1版: HL は呼び出し元で _CHIP_VVRAM0 or _CHIP_VVRAM1 を設定済み
+_ChipSetVAdrOfs:
+	push de
+	bit 2,a
+	jr z,.noyofs
+	; オフセットされている場合は一行ぶん足す
+.ref_vvw:
+	ld de,VVRAMWIDTH
+	add hl,de
+.noyofs
+	; 横位置オフセットの場合は2バイトズラして開始する
+	bit 1,a
+	jr  z,.offsetx1
+	inc hl
+.offsetx1
+	pop de
+	ret
+
+
+
+
+; ChipMaskDraw
+;   マスクデータつきの8x8画像を合成バッファに書き込む
+;   点滅描画を行う場合はChipSprFlashで点滅状態設定をしてから呼ぶ事
+ChipMaskDraw:
+	; hl = source, de = dest
+	; sourceの32バイト(8バイトマスク、24バイトRGB)をdeに描画 (X1 8x8版)
+	; 先頭のマスクでマスクしてからRGBをorして格納する
+
+	push hl
+	ld bc,8		; mask 8 bytes (8x8)
+	add hl,bc
+	ld c,l
+	ld b,h
+	pop hl
+
+	; hl  = mask address
+	; bc  = color address
+	; de = or描画対象dest
+
+	; call後、hlは変化なく、bcとdeは16バイト進んでいる
+	; なので連続して呼び出すとマスクされた上でRGBが正しく描画される
+	; スタックいじるので割り込み禁止
+.noflash
+	push hl
+FlashOrDraw1:
+	call _ChipMaskDrawPlane
+	; call _ChipMaskFlashPlane
+	pop hl
+	push hl
+FlashOrDraw2:
+	call _ChipMaskDrawPlane
+	; call _ChipMaskFlashPlane
+	pop hl
+FlashOrDraw3:
+	call _ChipMaskDrawPlane
+	; call _ChipMaskFlashPlane
+	ret
+
+_ChipMaskDrawPlane:
+	; 8x8版: 8 bytes/plane (4 POP × 2 bytes)
+	; SP = mask, HL = color, DE = dest (合成バッファ、RAM)
+	di
+	ld (.stackadr+1),sp
+	ld sp,hl
+	ld l,c
+	ld h,b
+
+	; --- 4 POP (8 bytes) ---
+	pop bc
+	ld a,(de)
+	and c
+	or (hl)
+	ld (de),a
+	inc hl
+	inc de
+	ld a,(de)
+	and b
+	or (hl)
+	ld (de),a
+	pop bc
+	inc hl
+	inc de
+	ld a,(de)
+	and c
+	or (hl)
+	ld (de),a
+	inc hl
+	inc de
+	ld a,(de)
+	and b
+	or (hl)
+	ld (de),a
+	pop bc
+	inc hl
+	inc de
+	ld a,(de)
+	and c
+	or (hl)
+	ld (de),a
+	inc hl
+	inc de
+	ld a,(de)
+	and b
+	or (hl)
+	ld (de),a
+	pop bc
+	inc hl
+	inc de
+	ld a,(de)
+	and c
+	or (hl)
+	ld (de),a
+	inc hl
+	inc de
+	ld a,(de)
+	and b
+	or (hl)
+	ld (de),a
+	inc hl
+	inc de
+
+	; hlはcolorの次の色になっている
+	ld c,l
+	ld b,h
+
+	; hlを8バイト戻す(マスクの先頭) (8x8: mask=8 bytes)
+	ld hl,-8
+	add hl,sp
+.stackadr
+	ld sp,0
+	ei
+	ret
+
+_ChipMaskFlashPlane:
+	di
+	push bc
+
+	ld (.fstackadr+1),sp
+	ld sp,hl
+
+	; 8x8版: 4 回ループ (2 bytes × 4 = 8 bytes/plane)
+	ld b,4
+.flashloop
+	pop hl
+	ld a,h
+	cpl
+	ld h,a
+	ld a,l
+	cpl
+	ld l,a
+	ld a,(de)
+	or l
+	ld (de),a
+	inc de
+	ld a,(de)
+	or h
+	ld (de),a
+	inc de
+
+	djnz .flashloop
+.fstackadr
+	ld sp,0
+
+	; deは維持する
+	; hlはそのまま
+	; bcは8バイト進める (8x8: 8 bytes/plane)
+	pop hl
+
+	ld bc,8
+	add hl,bc
+	ld c,l
+	ld b,h
+
+	ei
+	ret
+
+
+; ChipSprFlash
+; 次に ChipMaskDraw した時の点滅状態を設定する
+; L :
+;     bit0 = Rプレーンを点滅させるか
+;     bit1 = Gプレーンを点滅させるか
+;     bit2 = Bプレーンを点滅させるか
+; 
+; プレーンについては0だと点滅せず、7だと真っ白になる
+ChipSprFlash:
+	ld a,l
+	; bit 7,a
+	; jr z,.noflash
+
+	ld hl,_ChipMaskDrawPlane
+	ld de,_ChipMaskFlashPlane
+
+	srl a
+	jr nc,.normaldraw1
+	ex de,hl
+.normaldraw1
+	ld (FlashOrDraw1+1),hl
+
+	ld hl,_ChipMaskDrawPlane
+	ld de,_ChipMaskFlashPlane
+
+	srl a
+	jr nc,.normaldraw2
+	ex de,hl
+.normaldraw2
+	ld (FlashOrDraw2+1),hl
+
+	ld hl,_ChipMaskDrawPlane
+	ld de,_ChipMaskFlashPlane
+
+	srl a
+	jr nc,.normaldraw3
+	ex de,hl
+.normaldraw3
+	ld (FlashOrDraw3+1),hl
+.noflash
+	ret
+
+; 合成パーツ番号を初期化する
+ChipSprStart:
+	ld a,128
+	ld (_CHIP_EXIDX),a
+	ret
+
+; スプライトの書き込み開始位置を設定(VVRAMの座標)
+ChipSprPos:
+	; hl = X
+	; de = Y
+	ld a,l
+	ld (_CHIP_SPRX),a
+	ld a,e
+	ld (_CHIP_SPRY),a
+	ret
+
+ChipSprAdd:
+	; hl = image address with mask
+	; de = sw
+	; bc = sh
+
+	; 保存しておく
+	ld a,e
+	ld (_CHIP_SWBAK),a
+
+	ld b,e
+	; b = SW
+	; c = SH
+	push bc
+
+	; 画像アドレスは保存しておく(後で使う)
+	ld (_CHIP_SIMGADR),hl
+
+	; ; _CHIP_VADRについては描画開始位置計算を後で行う
+	; ld hl,0
+	; ld (_CHIP_VADR),hl
+
+	;-----------------------------
+
+	; スプライトのYが縦方向上にハミ出しているか？
+	ld a,(_CHIP_MAPY)
+	and $fe
+	ld b,a
+	ld a,(_CHIP_SPRY)
+	cp b
+	jr nc,.sy_ge_MAPY	; はみ出していない
+	; はみ出しているので描画が開始されるところまで下に下げていく
+
+	; SW * 32を計算して入れてやる(マスクあり画像横ぶんスキップ: 8x8版は32bytes/chip)
+	; deにはまだSWが入っているはず
+	ex de,hl	; deをhlに移す
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl	; 32倍
+	ld (.sw_mul_64 + 1),hl
+
+.yclip_loop
+	; ADR = ADR + TMP1
+	ld hl,(_CHIP_SIMGADR)
+.sw_mul_64
+	ld de,0
+	add hl,de
+	ld (_CHIP_SIMGADR),hl
+	;; _CHIP_VADR = _CHIP_VADR + VVRAMWIDTH
+	;ld hl,(_CHIP_VADR)
+	;ld de,VVRAMWIDTH
+	;add hl,de
+	;ld (_CHIP_VADR),hl
+	; _CHIP_SPRY++
+	ld a,(_CHIP_SPRY)
+	inc a
+	ld (_CHIP_SPRY),a
+	; SH--
+	pop bc
+	; pushしたものの下位がSH
+	dec c
+	jp z,.spradd_end2	; IF SH==0 GOTO .spradd_end
+				; 描画するものがなければここで終了
+	push bc			; SW, SHを保存しなおす
+	; UNTIL (SY >= _CHIP_MAPY)
+	; aには_CHIP_SPRYが入ったままのはず
+	; ld a,(_CHIP_SPRY)
+	ld c,a
+	ld a,(_CHIP_MAPY)
+	and $fe
+	ld b,a
+	ld a,c
+	cp b
+	jr c,.yclip_loop	; IF SY < _CHIP_MAPY goto .ycliploop
+.sy_ge_MAPY
+
+	; 描画可能な状況でVVRAMの先頭アドレスを計算してやる
+	ld a,(_CHIP_MAPY)
+	and $fe
+	ld b,a
+	ld a,(_CHIP_SPRY)
+	sub b
+	ld l,a
+	ld h,0
+.ref_vvw1:
+	ld de,VVRAMWIDTH
+	call MULHLDE	; HL = Y * VVRAMWIDTH
+	ex de,hl
+
+	; _CHIP_SPRXがMAPXより小さい場合は負値になるが計算上問題ないはず
+	ld a,(_CHIP_SPRX)
+	ld l,a
+	ld h,0
+	ld a,(_CHIP_MAPX)
+	and $fe
+	ld c,a
+	ld b,0
+	or a
+	sbc hl,bc
+	add hl,de		; 縦位置を足す
+	; VVRAM先頭アドレス (RAM ダブルバッファ)
+	push af
+	ld a,(_CHIP_PRIMARY)
+	and 1
+	jr nz,.spr_usepage1
+	ld de,_CHIP_VVRAM0
+	jr .spr_pagesel_done
+.spr_usepage1:
+	ld de,_CHIP_VVRAM1
+.spr_pagesel_done:
+	pop af
+	add hl,de
+	; VVRAMの開始アドレスを保存しておく
+	ld (_CHIP_VADR),hl
+
+	;-----------------------------------------------
+	; ループ内での計算は無駄なので事前計算しておく
+	;-----------------------------------------------
+	; _CHIP_MAPY_MAPH2 = _CHIP_MAPY + VVRAMHEIGHT
+	ld a,(_CHIP_MAPY)
+	and $fe
+.ref_vvh:
+	add a,VVRAMHEIGHT
+	ld (.mapy_maph2 + 1),a
+
+	; _CHIP_MAPX_MAPW2 = _CHIP_MAPX + MAPWIDTH*2;
+	ld a,(_CHIP_MAPX)
+	and $fe
+	add a,MAPWIDTH*2
+; 	ld a,b
+	ld (.mapx_mapw2 + 1),a
+
+	
+	;-----------------------------------------------
+
+.yloop
+	; 画面下にハミ出したらもう描画する事はないので終了
+	;IF (SY >= _CHIP_MAPY_MAPH2) GOTO .spradd_end
+	ld a,(_CHIP_SPRY)
+.mapy_maph2
+	cp 0
+	jp nc,.spradd_end
+	jp z,.spradd_end
+
+.xloop
+;	if (_CHIP_SPRX < _CHIP_MAPX) OR (_CHIP_SPRX >= _CHIP_MAPX_MAPW2)
+;	{
+;		GOTO SPRADD_HSKIP;
+;	}
+	ld a,(_CHIP_MAPX)
+	and $fe
+	ld b,a
+	ld a,(_CHIP_SPRX)
+	cp b
+	jr c,.spradd_hskip
+.mapx_mapw2
+	cp 0
+	jr nc,.spradd_hskip
+	jr z,.spradd_hskip
+
+	
+	; VC = MEM[_CHIP_VADR];
+	ld hl,(_CHIP_VADR)
+	ld a,(hl)
+	cp $80
+	jr nc,.extraparts
+	; 通常チップ (アニメチップの場合は下位2ビットをANIMIDXで差し替え)
+.ref_animstart2:
+	cp 0		; ← ChipSetAnim で自己書き換え (アニメ閾値)
+	jr c,.not_anim_spr
+	and $fc
+	push hl
+	ld hl,_CHIP_ANIMIDX
+	or (hl)
+	pop hl
+.not_anim_spr:
+	; マップチップ番号をbに入れておく
+	ld b,a
+	; 合成チップ番号を新規発行して書き込む
+	; MEM[_CHIP_VADR] = _CHIP_EXIDX;
+	; _CHIP_EXIDX++;
+	ld a,(_CHIP_EXIDX)
+	ld (hl),a
+	inc a
+	ld (_CHIP_EXIDX),a
+
+	; // 合成バッファのアドレス
+	; CADR = $A000 + _CHIP_EXIDX * 64;
+	dec a
+	and $7f
+	call _ChipCalcMergeAdr
+	push hl
+.ref_mergebuf2:
+	ld a,HIGH MERGEBUFFER
+	add a,h
+	ld h,a
+	; hlに合成バッファアドレス
+
+	; // BG画像を合成バッファにコピー
+	; MEMCPY(CADR, MAPGRPADR + VC * 48, 48);
+	ex de,hl
+	pop hl
+	; 合成チップアドレスCADRを保存
+	push de
+	; MAPGRPADR + VC * 24を計算する (8x8: CHIP_SIZE=24)
+	ld l,b
+	ld h,0
+	add hl,hl
+	add hl,hl
+	add hl,hl	; ×8
+	ld c,l
+	ld b,h
+	add hl,hl
+	add hl,bc	; ×24
+.ref_mapgrpadr2:
+	ld bc,MAPGRPADR
+	add hl,bc
+
+	ld bc,CHIP_SIZE
+	ldir		; マップチップ画像を合成バッファにコピー
+	pop de
+	; deに合成チップアドレス(CADR)が入っている
+	jr .execmerge
+.extraparts
+	; 合成チップ
+	; CADR = $A000 + (VC AND $7F) * 64;
+	and $7f
+	call _ChipCalcMergeAdr
+.ref_mergebuf3:
+	ld a,HIGH MERGEBUFFER
+	add a,h
+	ld h,a
+	ex de,hl
+.execmerge
+	
+	; hl = source, de = dest
+	ld hl,(_CHIP_SIMGADR)
+	call ChipMaskDraw
+
+.spradd_hskip
+;	_CHIP_VADR++;
+	ld hl,(_CHIP_VADR)
+	inc hl
+	ld (_CHIP_VADR),hl
+;	ADR = ADR + MASK_CHIP_SIZE (32 for 8x8);
+	ld hl,(_CHIP_SIMGADR)
+	ld de,MASK_CHIP_SIZE
+	add hl,de
+	ld (_CHIP_SIMGADR),hl
+;	SX++;
+	ld a,(_CHIP_SPRX)
+	inc a
+	ld (_CHIP_SPRX),a
+;	SW--;
+	pop bc
+	dec b
+	push bc
+	jr nz,.xloop
+.spradd_vskip
+	pop bc
+;	SH--;
+	dec c
+	jr z,.spradd_end2
+;	SW = _CHIP_SWBAK;
+	ld a,(_CHIP_SWBAK)
+	ld b,a
+	push bc
+	; _CHIP_SPRXを戻す(クリッピングに必要)
+	ld a,(_CHIP_SPRX)
+	sub a,b
+	ld (_CHIP_SPRX),a
+;	_CHIP_VADR = _CHIP_VADR + VVRAMWIDTH - _CHIP_SWBAK;
+.ref_vvw2:
+	ld a,VVRAMWIDTH
+	sub a,b
+	ld l,a
+	ld h,0
+	ex de,hl
+	ld hl,(_CHIP_VADR)
+	add hl,de
+	ld (_CHIP_VADR),hl
+;	SY++;
+	ld a,(_CHIP_SPRY)
+	inc a
+	ld (_CHIP_SPRY),a
+	jp .yloop
+
+.spradd_end
+	pop bc
+.spradd_end2
+
+	ret
+
+_ChipCalcMergeAdr:
+	ld l,a
+	ld h,0
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	add hl,hl	; 32倍 (8x8: MERGE_UNIT=32)
+	ret
+
+; ============================================================
+; ユーティリティ
+; ============================================================
+
+; RangeCheck — 値が範囲内かチェック
+; input: c=値, hl=開始値アドレス (hl+1=終了値)
+; output: cf=1 → 範囲内
+RangeCheck:
+    ld a, c
+    cp (hl)
+    jr c, .out_of_range
+    inc hl
+    ld a, c
+    cp (hl)
+    jr c, .in_range
+    jr z, .in_range
+.out_of_range2:
+    inc hl
+    and a
+    ret
+.out_of_range:
+    inc hl
+    jr .out_of_range2
+.in_range:
+    inc hl
+    scf
+    ret
+
+; IsScreenInside — 画面内判定
+; input: e=x, d=y
+; output: cf=1 → 画面外
+IsScreenInside:
+	sla e
+	sla d
+	ld	hl, _CHIP_MAPY
+	ld	a, d
+	cp	(hl)
+	jr	c, .screen_out
+	ld	a, (hl)
+	add	a, DRAWHCNT
+	cp	d
+	jr	c, .screen_out
+	inc	hl
+	inc	hl
+	ld	a, e
+	cp	(hl)
+	jr	c, .screen_out
+	ld	a, (hl)
+	add	a, DRAWWCNT
+	cp	e
+	jr	c, .screen_out
+.screen_out
+	ret
+
+; ============================================================
+; 動的設定 API
+; ============================================================
+
+; ChipSetVVRAMSize — 仮想 VRAM サイズを動的に設定 (全参照箇所を自己書き換え)
+; HL = width, DE = height
+ChipSetVVRAMSize:
+	; width 関連の自己書き換え
+	; ChipFillMap: ld bc,width-1
+	push hl
+	dec l
+	ld h,0
+	ld (ChipFillMap.ref_vvw_m1+1),hl
+	pop hl
+	; ChipFillMap: ld hl,width*2
+	push hl
+	ld h,0
+	add hl,hl
+	ld (ChipFillMap.ref_vvw_x2+1),hl
+	pop hl
+	; ChipSetSize: ld a,width
+	ld a,l
+	ld (ChipSetSize.ref_vvw+1),a
+	; _ChipSetVAdrOfs: ld de,width
+	push hl
+	ld h,0
+	ld (_ChipSetVAdrOfs.ref_vvw+1),hl
+	pop hl
+	; ChipSprAdd: ld de,width (MULHLDE用)
+	push hl
+	ld h,0
+	ld (ChipSprAdd.ref_vvw1+1),hl
+	pop hl
+	; ChipSprAdd: ld a,width
+	ld a,l
+	ld (ChipSprAdd.ref_vvw2+1),a
+
+	; height 関連の自己書き換え
+	; ChipSprAdd: add a,height
+	ld a,e
+	ld (ChipSprAdd.ref_vvh+1),a
+
+	ret
+
+; ChipSetScroll — スクロール位置を設定
+; HL = _CHIP_MAPX, DE = _CHIP_MAPY
+ChipSetScroll:
+	ld (_CHIP_MAPX),hl
+	ld (_CHIP_MAPY),de
+	ret
+
+; ChipSetMapSize — _CHIP_MAPW/MAPH を動的に設定
+; HL = width, DE = height
+ChipSetMapSize:
+	ld a,l
+	ld (_CHIP_MAPW),a
+	ld a,e
+	ld (_CHIP_MAPH),a
+	ret
+
+#END
+
+// ============================================================
+// ブロック 2: ワークエリア
+// ============================================================
+#ASM
+
+; --- 内部ワーク ---
+_CHIP_PRIMARY:	DB	0	; ダブルバッファ ページ番号 + 前回オフセット
+_CHIP_FLASHFLG:	DB	0	; 点滅状態
+_CHIP_ANIMCNT:	DB	0	; vsync カウンタ (CHIP_ANIM_TICK 用)
+_CHIP_ANIMTICKS: DB	8	; フレーム進行間隔 (vsync数, デフォルト 8)
+_CHIP_ANIMFRAME: DB	0	; 現在のアニメフレーム
+_CHIP_ANIMPERIOD: DB	4	; アニメ周期 (フレーム数, デフォルト 4)
+_CHIP_SWBAK:	DS	1	; スプライト幅バックアップ
+_CHIP_SIMGADR:	DS	2	; スプライト画像アドレス
+_CHIP_VADR:	DS	2	; VVRAM アドレスワーク
+_CHIP_SPRX:	DS	1	; スプライト X 座標
+_CHIP_SPRY:	DS	1	; スプライト Y 座標
+_CHIP_EXIDX:	DB	128	; 合成パーツインデックス
+
+; --- マップ座標・サイズ ---
+_CHIP_MAPY:	DW	0	; スクロール Y (チップ単位、LSB=サブオフセット)
+_CHIP_MAPX:	DW	0	; スクロール X (同上)
+_CHIP_MAPW:	DB	50	; マップデータ横幅 (スーパーチップ数)
+_CHIP_MAPH:	DB	40	; マップデータ縦幅
+
+; --- 仮想 VRAM ダブルバッファ ---
+_CHIP_VVRAM0:	DS	_CHIP_VVRAMW_MAX * _CHIP_VVRAMH_MAX
+_CHIP_VVRAM1:	DS	_CHIP_VVRAMW_MAX * _CHIP_VVRAMH_MAX
+
+; --- マージバッファ (ALIGN 256, 4KB 固定 = 128 合成チップ × 32 byte) ---
+ALIGN 256
+_CHIP_MERGEBUF:	DS	4096
+
+#END

--- a/assets/slang_include/SPRLIB.LIB
+++ b/assets/slang_include/SPRLIB.LIB
@@ -1,0 +1,646 @@
+///
+/// SPRLIB.SL — X1 前景スプライトライブラリ (グラフィック VRAM)
+///
+/// 役割:
+///   前景スプライトレイヤ。ダブルバッファ + old1 erase 方式。
+///   グラフィック VRAM はスプライト専用層として扱い、背景は他のレイヤで管理する。
+///   背景は TILELIB (PCG/テキスト VRAM) または CHIPLIB (グラフィック VRAM 直接) と併用想定。
+///
+/// 特徴:
+///   - ダブルバッファ (CRTC reg12 でページ切替)
+///   - OR 描画: データ 0 = 透過 (背景/他スプライト保持)
+///   - 座標: X, Y ともに 4 ドット単位
+///   - old1 (2 フレーム前座標) を消去、now (現在) を描画、座標シフトでフレーム履歴管理
+///   - 最大 8 スプライト (SPR_MAX)
+///
+/// スプライトデータ形式 (96 bytes/sprite):
+///   B プレーン: 16 lines x 2 bytes = 32 bytes
+///   R プレーン: 32 bytes
+///   G プレーン: 32 bytes
+///
+/// SPR_INIT の副作用:
+///   - テキスト VRAM ($3000-$37FF) + GVRAM ($4000-$FFFF) を 0 クリア
+///     テキスト VRAM も消すのは、背面プライオリティで色 0 越しに
+///     テキスト残骸が透けてちらつくのを防ぐため。
+///   - CRTC reg12 = 0, reg13 = 0 (表示開始位置リセット)
+///   - パレット priority $1300 = $FE (パレット 0 のみ後面、1-7 は前面)
+///   - デフォルト draw page = 4 (back buffer)
+///   TILELIB と併用する場合: SPR_INIT() を先に呼んでから TILE_INIT() を
+///   呼ぶ順序が必須 (TILE_INIT がテキスト VRAM を再初期化するので
+///   SPR_INIT の text クリアは上書きされて問題なし)。
+///   WIDTH / GRPSETUP / GRDISP 後に呼ぶこと。
+///
+
+// --- API ---
+// SPR_SET_POS(id, x, y): x/y とも 4dot 単位。範囲は画面内に収める必要がある:
+//   x: 0..78 (= 0..312px, 16px幅ぶん余裕)
+//   y: 0..46 (= 0..184px, 16line幅ぶん余裕)
+// 範囲外を指定すると VRAM 表示外領域に描画してチラつきや表示崩れの原因になる。
+MACHINE SPR_INIT(0): SprInit;
+MACHINE SPR_SET_PATTERN(2): SprSetPattern;
+MACHINE SPR_SET_POS(3): SprSetPos;
+MACHINE SPR_SET_SHOW(2): SprSetShow;
+MACHINE SPR_IS_ACTIVE(1): SprIsActive;
+MACHINE SPR_UPDATE(0): SprUpdate;
+
+// ============================================================
+// ブロック 1: 実装
+// ============================================================
+#ASM
+
+SPR_GVRAM	EQU $4000
+SPR_MAX		EQU 8
+SPR_ENTRY	EQU 10
+
+; ============================================================
+; SprInit
+; ============================================================
+SprInit:
+	; テキスト VRAM ($3000-$37FF) を空白 ($20) でクリア
+	; (0x00 はグリフ 0 が見えてしまうので不可)。
+	; 色 0 の背面プライオリティ設定下で、WIDTH が 40×24 しか埋めない
+	; 残骸 (最下行など) が透けてちらつくのを防ぐため。
+	ld bc,$3000
+	ld e,$20
+.tclr:
+	out (c),e
+	inc c
+	jr nz,.tclr
+	inc b
+	ld a,b
+	cp $38
+	jr nz,.tclr
+
+	; GVRAM ($4000-$FFFF) を 0 クリア
+	ld bc,$4000
+	ld e,0
+.gclr:
+	out (c),e
+	inc bc
+	ld a,b
+	or c
+	jr nz,.gclr
+	ld bc,$1800
+	ld a,12
+	out (c),a
+	inc c
+	xor a
+	out (c),a
+	dec c
+	ld a,13
+	out (c),a
+	inc c
+	xor a
+	out (c),a
+
+	; グラフィック優先: パレット 1-7 を前面、0 は背面 (透過)
+	ld bc,$1300
+	ld a,$FE
+	out (c),a
+
+	ld a,4
+	ld (_SPR_PAGEOFS),a
+	ld hl,_SPR_TABLE
+	ld b,SPR_MAX * SPR_ENTRY
+	xor a
+.clr_tbl:
+	ld (hl),a
+	inc hl
+	djnz .clr_tbl
+	ret
+
+; ============================================================
+; SprSetPattern — HL=id, DE=pattern
+; ============================================================
+SprSetPattern:
+	push de
+	call _SprGetEntry
+	pop de
+	ld (hl),e
+	inc hl
+	ld (hl),d
+	ret
+
+; ============================================================
+; SprSetPos — HL=id, DE=x(4dot), BC=y(4dot)
+; ============================================================
+SprSetPos:
+	push de
+	push bc
+	call _SprGetEntry
+	pop bc
+	pop de
+	inc hl
+	inc hl
+	ld (hl),e
+	inc hl
+	ld (hl),c
+	ret
+
+; ============================================================
+; SprSetShow — HL=id, DE=visible
+; ============================================================
+SprSetShow:
+	push de
+	call _SprGetEntry
+	pop de
+	ld bc,8
+	add hl,bc		; → flags
+	ld a,e
+	or a
+	jr z,.hide
+	ld (hl),$01		; visible, old flags クリア
+	ret
+.hide:
+	ld a,(hl)
+	and $FE
+	ld (hl),a
+	ret
+
+; ============================================================
+; SprIsActive — fadeout 完了チェック
+; HL=id → HL: 0=完了(再利用可), 1=処理中
+; ============================================================
+SprIsActive:
+	call _SprGetEntry
+	ld bc,8
+	add hl,bc
+	ld a,(hl)
+	ld hl,0
+	or a
+	ret z			; flags==0 → 完了
+	inc hl			; flags!=0 → 処理中
+	ret
+
+; ============================================================
+; SprUpdate — 2 パス: 全消去 → 全描画+シフト → フリップ
+; ============================================================
+SprUpdate:
+	push ix
+
+	; === Pass 1: 全スプライト old1 消去 ===
+	ld ix,_SPR_TABLE
+	ld a,SPR_MAX
+	ld (.cnt1+1),a
+.loop1:
+	ld a,(ix+8)
+	bit 2,a			; old1_valid?
+	jr z,.skip1
+	ld a,(ix+6)
+	and 1
+	ld (_SPR_XODD),a
+	ld a,(ix+7)
+	and 1
+	ld (_SPR_YODD),a
+	ld d,(ix+6)
+	ld e,(ix+7)
+	push ix
+	call _SprCalcAddr
+	call _SprErase
+	pop ix
+.skip1:
+	ld bc,SPR_ENTRY
+	add ix,bc
+.cnt1:	ld a,0
+	dec a
+	ld (.cnt1+1),a
+	jp nz,.loop1
+
+	; === Pass 2: 全スプライト描画 + 座標シフト ===
+	ld ix,_SPR_TABLE
+	ld a,SPR_MAX
+	ld (.cnt2+1),a
+.loop2:
+	ld a,(ix+8)
+	or a
+	jp z,.skip2
+
+	; --- 描画 ---
+	bit 0,a
+	jr z,.no_draw
+	ld a,(ix+2)
+	and 1
+	ld (_SPR_XODD),a
+	ld a,(ix+3)
+	and 1
+	ld (_SPR_YODD),a
+	ld d,(ix+2)
+	ld e,(ix+3)
+	push ix
+	call _SprCalcAddr
+	ld l,(ix+0)
+	ld h,(ix+1)
+	call _SprDraw
+	pop ix
+.no_draw:
+
+	; --- 座標シフト ---
+	ld a,(ix+8)
+	bit 0,a
+	jr z,.fadeout
+	; visible: old1=old0, old0=now
+	ld d,(ix+4)
+	ld (ix+6),d
+	ld d,(ix+5)
+	ld (ix+7),d
+	ld d,(ix+2)
+	ld (ix+4),d
+	ld d,(ix+3)
+	ld (ix+5),d
+	bit 1,a
+	jr z,.first_frame
+	set 2,a
+.first_frame:
+	set 1,a
+	ld (ix+8),a
+	jr .skip2
+.fadeout:
+	bit 2,a
+	jr z,.fo_no_old1
+	bit 1,a
+	jr z,.fo_old1_only
+	ld d,(ix+4)
+	ld (ix+6),d
+	ld d,(ix+5)
+	ld (ix+7),d
+	res 1,a
+	ld (ix+8),a
+	jr .skip2
+.fo_old1_only:
+	res 2,a
+	ld (ix+8),a
+	jr .skip2
+.fo_no_old1:
+	bit 1,a
+	jr z,.fo_done
+	ld d,(ix+4)
+	ld (ix+6),d
+	ld d,(ix+5)
+	ld (ix+7),d
+	res 1,a
+	set 2,a
+	ld (ix+8),a
+	jr .skip2
+.fo_done:
+	ld (ix+8),0
+.skip2:
+	ld bc,SPR_ENTRY
+	add ix,bc
+.cnt2:	ld a,0
+	dec a
+	ld (.cnt2+1),a
+	jp nz,.loop2
+
+	; === ページフリップ ===
+	ld bc,$1800
+	ld a,12
+	out (c),a
+	inc c
+	ld a,(_SPR_PAGEOFS)
+	out (c),a
+	xor 4
+	ld (_SPR_PAGEOFS),a
+	pop ix
+	ret
+
+; ============================================================
+; 内部ユーティリティ
+; ============================================================
+
+_SprGetEntry:
+	ld h,0
+	add hl,hl
+	ld d,h
+	ld e,l
+	add hl,hl
+	add hl,hl
+	add hl,de
+	ld de,_SPR_TABLE
+	add hl,de
+	ret
+
+; _SprCalcAddr — D=X(4dot), E=Y(4dot) → BC=Bプレーン VRAM addr
+_SprCalcAddr:
+	ld a,e
+	srl a
+	ld l,a
+	ld h,0
+	ld c,l
+	ld b,h
+	add hl,hl
+	add hl,hl
+	add hl,bc
+	add hl,hl
+	add hl,hl
+	add hl,hl
+	ld a,d
+	srl a
+	add a,l
+	ld c,a
+	ld a,0
+	adc a,h
+	ld b,a
+	ld a,e
+	and 1
+	rrca
+	rrca
+	rrca
+	add a,b
+	add a,$40
+	ld b,a
+	ld a,(_SPR_PAGEOFS)
+	add a,b
+	ld b,a
+	ret
+
+; キャラクタ行遷移
+_SprNextCharRow:
+	ld a,b
+	sub $40
+	ld b,a
+	ld a,c
+	add a,40
+	ld c,a
+	ret nc
+	inc b
+	ret
+
+; ============================================================
+; _SprDraw — OR 描画 (data=0 は透過)
+; HL=pattern, BC=Bプレーン addr
+; ============================================================
+_SprDraw:
+	ld a,(_SPR_XODD)
+	ld e,a
+	ld a,(_SPR_YODD)
+	add a,a
+	or e
+	or a
+	jr z,.sel_ee
+	dec a
+	jr z,.sel_oe
+	dec a
+	jr z,.sel_eo
+	ld de,.draw16_oo
+	jr .sel_done
+.sel_ee:
+	ld de,.draw16_ee
+	jr .sel_done
+.sel_oe:
+	ld de,.draw16_oe
+	jr .sel_done
+.sel_eo:
+	ld de,.draw16_eo
+.sel_done:
+	ld (.dc1+1),de
+	ld (.dc2+1),de
+	ld (.dj3+1),de
+	push bc
+.dc1:	call .draw16_ee
+	pop bc
+	ld a,b
+	add a,$40
+	ld b,a
+	push bc
+.dc2:	call .draw16_ee
+	pop bc
+	ld a,b
+	add a,$40
+	ld b,a
+.dj3:	jp .draw16_ee
+
+; --- draw16 variants ---
+.draw16_ee:
+	call .draw8
+	call _SprNextCharRow
+	jp .draw8
+.draw16_oe:
+	call .drawS8
+	call _SprNextCharRow
+	jp .drawS8
+.draw16_eo:
+	call .draw4
+	call _SprNextCharRow
+	call .draw8
+	call _SprNextCharRow
+	jp .draw4
+.draw16_oo:
+	call .drawS4
+	call _SprNextCharRow
+	call .drawS8
+	call _SprNextCharRow
+	jp .drawS4
+
+; --- Even X: OR 描画 (data=0 は透過) ---
+.draw8:	ld d,8
+	jr .dline
+.draw4:	ld d,4
+.dline:
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	inc bc
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	dec bc
+	ld a,b
+	add a,8
+	ld b,a
+	dec d
+	jr nz,.dline
+	ret
+
+; --- Odd X: ニブルシフト + OR 描画 ---
+.drawS8:
+	ld d,8
+	jr .dsline
+.drawS4:
+	ld d,4
+.dsline:
+	; data byte 0 → D'(>>4), E'(<<4)
+	ld a,(hl)
+	inc hl
+	exx
+	ld d,a
+	ld e,0
+	srl d
+	rr e
+	srl d
+	rr e
+	srl d
+	rr e
+	srl d
+	rr e
+	exx
+	; data byte 1 → H'(>>4), L'(<<4)
+	ld a,(hl)
+	inc hl
+	exx
+	ld h,a
+	ld l,0
+	srl h
+	rr l
+	srl h
+	rr l
+	srl h
+	rr l
+	srl h
+	rr l
+	exx			; → main に戻る
+	; 左端: OR (data upper nibble=0 → 隣接保護)
+	in a,(c)
+	exx
+	or d
+	exx
+	out (c),a
+	inc bc
+	; 中央: OR
+	exx
+	ld a,e
+	or h
+	exx
+	ld e,a
+	in a,(c)
+	or e
+	out (c),a
+	inc bc
+	; 右端: OR (data lower nibble=0 → 隣接保護)
+	in a,(c)
+	exx
+	or l
+	exx
+	out (c),a
+	dec bc
+	dec bc
+	; 次のスキャンライン
+	ld a,b
+	add a,8
+	ld b,a
+	dec d
+	jr nz,.dsline
+	ret
+
+; ============================================================
+; _SprErase — 消去 (0 クリア)
+; BC=Bプレーン addr
+; ============================================================
+_SprErase:
+	ld a,(_SPR_XODD)
+	ld e,a
+	ld a,(_SPR_YODD)
+	add a,a
+	or e
+	or a
+	jr z,.esel_ee
+	dec a
+	jr z,.esel_oe
+	dec a
+	jr z,.esel_eo
+	ld de,.erase16_oo
+	jr .esel_done
+.esel_ee:
+	ld de,.erase16_ee
+	jr .esel_done
+.esel_oe:
+	ld de,.erase16_oe
+	jr .esel_done
+.esel_eo:
+	ld de,.erase16_eo
+.esel_done:
+	ld (.ec1+1),de
+	ld (.ec2+1),de
+	ld (.ej3+1),de
+	push bc
+.ec1:	call .erase16_ee
+	pop bc
+	ld a,b
+	add a,$40
+	ld b,a
+	push bc
+.ec2:	call .erase16_ee
+	pop bc
+	ld a,b
+	add a,$40
+	ld b,a
+.ej3:	jp .erase16_ee
+
+.erase16_ee:
+	call .erase8
+	call _SprNextCharRow
+	jp .erase8
+.erase16_oe:
+	call .eraseS8
+	call _SprNextCharRow
+	jp .eraseS8
+.erase16_eo:
+	call .erase4
+	call _SprNextCharRow
+	call .erase8
+	call _SprNextCharRow
+	jp .erase4
+.erase16_oo:
+	call .eraseS4
+	call _SprNextCharRow
+	call .eraseS8
+	call _SprNextCharRow
+	jp .eraseS4
+
+; Even X erase
+.erase8:
+	ld d,8
+	jr .eline
+.erase4:
+	ld d,4
+.eline:
+	xor a
+	out (c),a
+	inc bc
+	out (c),a
+	dec bc
+	ld a,b
+	add a,8
+	ld b,a
+	dec d
+	jr nz,.eline
+	ret
+
+; Odd X erase (ニブル保護)
+.eraseS8:
+	ld d,8
+	jr .esline
+.eraseS4:
+	ld d,4
+.esline:
+	in a,(c)
+	and $F0
+	out (c),a
+	inc bc
+	xor a
+	out (c),a
+	inc bc
+	in a,(c)
+	and $0F
+	out (c),a
+	dec bc
+	dec bc
+	ld a,b
+	add a,8
+	ld b,a
+	dec d
+	jr nz,.esline
+	ret
+
+#END
+
+// ============================================================
+// ブロック 2: ワークエリア
+// ============================================================
+#ASM
+_SPR_PAGEOFS:	DB 4
+_SPR_XODD:	DB 0
+_SPR_YODD:	DB 0
+_SPR_TABLE:	DS 80
+#END

--- a/assets/slang_include/TILELIB.LIB
+++ b/assets/slang_include/TILELIB.LIB
@@ -1,0 +1,534 @@
+///
+/// TILELIB.SL — X1 背景タイルマップライブラリ (PCG/テキスト VRAM)
+///
+/// 役割:
+///   背景レイヤ。テキスト VRAM + PCG で 40x24 文字を描画する。
+///   単独使用可だが、ダブルバッファ運用では別途ページ管理が必要。
+///   SPRLIB と組み合わせる場合は apps/tilespr/TILESPR.SL の
+///   TILE_SYNC_SPR_PAGE() で SPRLIB の描画ページに同期する。
+///
+/// 特徴:
+///   - スクロール: 1 文字 (8 ピクセル) 単位
+///   - スーパーチップ (2x2 PCG) によるマップ圧縮
+///   - ダブルバッファ対応 (TILE_SET_PAGE で裏ページ指定)
+///   - 差分描画 (TILE_DIRTY カウンタ、スクロール/アニメ変化時のみ再描画)
+///   - アニメ対応 (TILE_SET_ANIM 閾値以上のチップを自動サイクル)
+///
+/// 構造:
+///   マップ: 圧縮スーパーチップ番号 (1 byte = 1 SC)
+///   タイルインデックス: SC ごとに 4 バイト (TL, TR, BL, BR)
+///   PCG: タイル番号 = PCG キャラクタ番号 (ユーザーが PCGDEF で定義)
+///
+
+// --- API ---
+MACHINE TILE_INIT(0): TileInit;
+MACHINE TILE_FILL_MAP(0): TileFillMap;
+MACHINE TILE_SET_MAP(3): TileSetMap;
+MACHINE TILE_SET_MAPSIZE(2): TileSetMapSize;
+MACHINE TILE_SET_SCROLL(2): TileSetScroll;
+MACHINE TILE_SET_ANIM(1): TileSetAnim;
+MACHINE TILE_SET_ANIM_RATE(2): TileSetAnimRate;
+MACHINE TILE_ANIM_TICK(0): TileAnimTick;
+MACHINE TILE_SET_PAGE(1): TileSetPage;
+MACHINE TILE_SET_OFS(2): TileSetOfs;
+MACHINE TILE_SET_SIZE(2): TileSetSize;
+MACHINE TILE_INVALIDATE(0): TileInvalidate;
+
+// ============================================================
+// ブロック 1: 実装
+// ============================================================
+#ASM
+
+; --- 定数 ---
+TILE_TVRAM	EQU	$3000	; テキスト VRAM (I/O, $3000-$37FF)
+TILE_ATTR	EQU	$2000	; アトリビュート VRAM (I/O, $2000-$27FF)
+TILE_ATTR_PCG7	EQU	$27	; PCG 有効 + カラー 7
+TILE_WIDTH	EQU	40	; 画面横文字数
+TILE_HEIGHT	EQU	25	; 画面縦文字数
+TILE_CHARROWS	EQU	24	; 描画行数 (上 24 行)
+TILE_MAPWIDTH	EQU	20	; 横スーパーチップ数 (20×2=40 文字)
+
+; ============================================================
+; TileInit — テキスト VRAM/アトリビュート初期化 (両ページ)
+; ============================================================
+TileInit:
+	; アトリビュート $2000-$27FF を $27 で埋める (両ページ分)
+	ld bc,TILE_ATTR
+	ld d,TILE_ATTR_PCG7
+	ld hl,$0800
+.attr_loop:
+	ld a,d
+	out (c),a
+	inc bc
+	dec hl
+	ld a,h
+	or l
+	jr nz,.attr_loop
+
+	; テキスト VRAM $3000-$37FF を空白 ($20) で埋める (両ページ分)。
+	; attribute が PCG=1 の状態で char code $00 を置くと「定義済み PCG
+	; glyph 0 (= PCGDEF で最初に定義したタイル)」がそこに表示されてしまう。
+	; 特に TILE_SET_SIZE の表示範囲外は TileFillMap が描かないため
+	; そのままタイル 0 が残る (turbo/turboZ の CRTC では画面下端に露出)。
+	; $20 を入れておけば未定義 PCG glyph (通常 0 初期化) = ブランクとして扱われ、
+	; CTRL0C のテキストクリア値とも整合する。
+	ld bc,TILE_TVRAM
+	ld hl,$0800
+.text_loop:
+	ld a,$20
+	out (c),a
+	inc bc
+	dec hl
+	ld a,h
+	or l
+	jr nz,.text_loop
+
+	; 状態クリア
+	xor a
+	ld (_TILE_SCROLLX),a
+	ld (_TILE_SCROLLX+1),a
+	ld (_TILE_SCROLLY),a
+	ld (_TILE_SCROLLY+1),a
+	ld (_TILE_PAGEOFS),a
+	; dirty=2 で初回描画を強制
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; ============================================================
+; TileFillMap — 現在の描画ページに 40×24 文字描画
+;   ペア処理: 2 文字単位でスーパーチップ参照を共有
+;   sub_x 奇数時は端 1 文字を別処理
+; ============================================================
+TileFillMap:
+	; アニメ変化検出: ANIMIDX != ANIMSNAP なら dirty = 2 にする
+	ld a,(_TILE_ANIMIDX)
+	ld hl,_TF_ANIMSNAP
+	cp (hl)
+	jr z,.no_anim_change
+	ld a,2
+	ld (_TILE_DIRTY),a
+.no_anim_change:
+	; dirty == 0 なら何もしない
+	ld a,(_TILE_DIRTY)
+	or a
+	ret z
+	dec a
+	ld (_TILE_DIRTY),a
+
+	push ix
+
+	; アニメインデックスをスナップショット (割り込み対策)
+	ld a,(_TILE_ANIMIDX)
+	ld (_TF_ANIMSNAP),a
+
+	; sub_x = SCROLLX & 1 (行内ループで参照)
+	ld a,(_TILE_SCROLLX)
+	and 1
+	ld (_TF_SUBX),a
+
+	; absY = SCROLLY
+	ld hl,(_TILE_SCROLLY)
+	ld (_TF_ABSY),hl
+
+	; DE = テキスト VRAM ベース + OFS + ページオフセット
+	ld hl,(_TILE_DE_BASE)	; = OFS_Y*40 + OFS_X
+	ld bc,TILE_TVRAM
+	add hl,bc
+	ex de,hl		; DE = $3000 + OFS
+	ld a,(_TILE_PAGEOFS)
+	add a,d
+	ld d,a			; + page offset
+
+	; 行ループカウンタ (shadow C')
+	exx
+	ld a,(_TILE_SIZE_H)
+	ld c,a
+	exx
+
+.rowLoop:
+	; sub_y = absY & 1, タイルオフセット = sub_y * 2 (0 or 2)
+	ld hl,(_TF_ABSY)
+	ld a,l
+	and 1
+	add a,a			; 0 or 2
+
+	; 行用 IDXBASE = TileIdx + tile_offset を事前計算
+	push de
+	ld c,a
+	ld b,0
+	ld hl,(_TILE_IDXADR)
+	add hl,bc
+	ld (_TF_IDXBASE),hl
+
+	; HL = absY >> 1 (マップ行番号)
+	ld hl,(_TF_ABSY)
+	srl h
+	rr l
+
+	; HL = HL * MAPW
+	ld a,(_TILE_MAPW)
+	ld e,a
+	ld d,0
+	call _TileMulHLDE
+	; HL = (absY/2) * MAPW
+
+	; HL += SCROLLX/2 (行内オフセット)
+	ld de,(_TILE_SCROLLX)
+	srl d
+	rr e
+	add hl,de
+
+	; IX = MAPCHIPADR + HL (描画開始 SC のアドレス)
+	ex de,hl
+.ref_mapchipadr:
+	ld ix,0			; パッチされる
+	add ix,de
+	pop de			; DE 復元 (テキスト VRAM ポインタ)
+
+	; sub_x で分岐
+	ld a,(_TF_SUBX)
+	or a
+	jr nz,.oddRow
+
+	; --- 偶数 X: HALFW ペア (SIZE_W 文字) ---
+	exx
+	ld a,(_TILE_HALFW)
+	ld b,a
+	exx
+	jr .pairLoop
+
+.oddRow:
+	; --- 奇数 X: 右半分1文字 + (HALFW-1)ペア + 左半分1文字 ---
+	call _TileDrawRight
+	inc ix
+	exx
+	ld a,(_TILE_HALFW)
+	dec a
+	ld b,a
+	exx
+
+.pairLoop:
+	; SC を読んで左右 2 タイル出力
+	ld a,(ix)
+	and $3f
+	add a,a
+	add a,a			; A = SC * 4
+	ld c,a
+	ld b,0
+	ld hl,(_TF_IDXBASE)
+	add hl,bc		; HL = &tile[SC*4 + offset]
+
+	; 左タイル
+	ld a,(hl)
+	call _TileAnimCheck
+	ld b,d
+	ld c,e
+	out (c),a
+	inc de
+
+	; 右タイル
+	inc hl
+	ld a,(hl)
+	call _TileAnimCheck
+	ld b,d
+	ld c,e
+	out (c),a
+	inc de
+
+	inc ix
+
+	exx
+	dec b
+	exx
+	jp nz,.pairLoop
+
+	; 奇数開始時: 末尾 SC の左半分 1 文字
+	ld a,(_TF_SUBX)
+	or a
+	call nz,_TileDrawLeft
+
+	; DE を次の行頭へ (DE += 40 - SIZE_W)
+	ld hl,(_TILE_DE_ROWSTEP)
+	add hl,de
+	ex de,hl
+
+	; absY++
+	ld hl,(_TF_ABSY)
+	inc hl
+	ld (_TF_ABSY),hl
+
+	exx
+	dec c
+	exx
+	jp nz,.rowLoop
+
+	pop ix
+	ret
+
+; ============================================================
+; ヘルパー: 端1文字描画 (奇数 X 開始時)
+; ============================================================
+
+; IX のスーパーチップ右半分 (offset+1) を 1 文字出力
+_TileDrawRight:
+	ld a,(ix)
+	and $3f
+	add a,a
+	add a,a
+	ld c,a
+	ld b,0
+	ld hl,(_TF_IDXBASE)
+	add hl,bc
+	inc hl			; +1 = 右列
+	ld a,(hl)
+	call _TileAnimCheck
+	ld b,d
+	ld c,e
+	out (c),a
+	inc de
+	ret
+
+; IX のスーパーチップ左半分 (offset+0) を 1 文字出力
+_TileDrawLeft:
+	ld a,(ix)
+	and $3f
+	add a,a
+	add a,a
+	ld c,a
+	ld b,0
+	ld hl,(_TF_IDXBASE)
+	add hl,bc
+	ld a,(hl)
+	call _TileAnimCheck
+	ld b,d
+	ld c,e
+	out (c),a
+	inc de
+	ret
+
+; ============================================================
+; アニメチップ判定
+;   閾値以上のチップは下位 2 ビットを ANIMSNAP で差し替える
+; ============================================================
+_TileAnimCheck:
+.ref_animstart:
+	cp 255			; 閾値 (TileSetAnim でパッチ, 初期値=無効)
+	ret c			; 閾値未満 → そのまま
+	and $fc
+	push hl
+	ld hl,_TF_ANIMSNAP
+	or (hl)
+	pop hl
+	ret
+
+; ============================================================
+; HL = HL * DE (16bit unsigned)
+; ============================================================
+_TileMulHLDE:
+	ld b,h
+	ld c,l
+	ld hl,0
+.mulLoop:
+	srl d
+	rr e
+	jr nc,.mulNoadd
+	add hl,bc
+.mulNoadd:
+	sla c
+	rl b
+	ld a,d
+	or e
+	jr nz,.mulLoop
+	ret
+
+; ============================================================
+; 設定 API
+; ============================================================
+
+; TileSetMap — HL = マップチップデータ, DE = タイルインデックステーブル, BC = 予約
+;   第 3 引数は CHIP_SET_MAP (チップグラフィックデータ) と並びを揃えるための予約。
+;   TILELIB では PCG を PCGDEF で別途定義するため現状未使用。0 を渡しておくこと。
+TileSetMap:
+	ld (TileFillMap.ref_mapchipadr+2),hl
+	ld (_TILE_IDXADR),de
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; TileSetMapSize — HL = 幅, DE = 高さ (スーパーチップ単位)
+TileSetMapSize:
+	ld a,l
+	ld (_TILE_MAPW),a
+	ld a,e
+	ld (_TILE_MAPH),a
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; TileSetScroll — HL = X, DE = Y (キャラクタ単位)
+;   X か Y が変化していたら dirty=2 (両ページ再描画)
+TileSetScroll:
+	; 新値を保存しつつ旧値と比較
+	push hl
+	push de
+	; X 比較
+	ld bc,(_TILE_SCROLLX)
+	or a
+	sbc hl,bc
+	jr nz,.changed
+	; Y 比較
+	ex de,hl	; HL = 新 Y
+	ld bc,(_TILE_SCROLLY)
+	or a
+	sbc hl,bc
+	jr nz,.changed
+	; 変化なし
+	pop de
+	pop hl
+	ret
+.changed:
+	pop de
+	pop hl
+	ld (_TILE_SCROLLX),hl
+	ld (_TILE_SCROLLY),de
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; TileSetAnim — HL = アニメ閾値 (この番号以上が対象)
+TileSetAnim:
+	ld a,l
+	ld (_TileAnimCheck.ref_animstart+1),a
+	ret
+
+; TileSetAnimRate — アニメ進行レート設定
+;   HL = ticks (vsync 数), DE = period (フレーム数, 1-4 が実用範囲)
+;   範囲外 (0) は内部で 1 にクランプ
+;   実行中にレート変更すると内部カウンタ/フレームが新範囲を逸脱しないよう、
+;   _TILE_ANIMCNT / _TILE_ANIMFRAME / _TILE_ANIMIDX を 0 に初期化する
+TileSetAnimRate:
+	ld a,l
+	or a
+	jr nz,.tickok
+	ld a,1
+.tickok:
+	ld (_TILE_ANIMTICKS),a
+	ld a,e
+	or a
+	jr nz,.perok
+	ld a,1
+.perok:
+	ld (_TILE_ANIMPERIOD),a
+	; 内部状態を整合する値 (0) にリセット
+	xor a
+	ld (_TILE_ANIMCNT),a
+	ld (_TILE_ANIMFRAME),a
+	ld (_TILE_ANIMIDX),a
+	ret
+
+; TileAnimTick — VSYNC_PROC から呼ぶ。アニメフレーム更新
+TileAnimTick:
+	ld hl,_TILE_ANIMCNT
+	inc (hl)
+	ld a,(hl)
+	ld b,a
+	ld a,(_TILE_ANIMTICKS)
+	cp b
+	ret nz
+	ld (hl),0
+	ld hl,_TILE_ANIMFRAME
+	inc (hl)
+	ld a,(hl)
+	ld b,a
+	ld a,(_TILE_ANIMPERIOD)
+	cp b
+	jr nz,.notwrap
+	ld (hl),0
+.notwrap:
+	ld a,(_TILE_ANIMFRAME)
+	ld (_TILE_ANIMIDX),a
+	ret
+
+; TileSetPage — HL = ページオフセット (0 or 4)
+TileSetPage:
+	ld a,l
+	ld (_TILE_PAGEOFS),a
+	ret
+
+; TileSetOfs — HL = X, DE = Y (キャラクタ単位)
+;   描画開始位置をテキスト VRAM 内でずらす
+TileSetOfs:
+	ld a,l
+	ld (_TILE_OFS_X),a
+	ld a,e
+	ld (_TILE_OFS_Y),a
+	; DE_BASE = Y * 40 + X
+	push hl
+	ex de,hl		; HL = Y
+	ld de,40
+	call _TileMulHLDE	; HL = Y * 40
+	pop de			; DE = X
+	add hl,de
+	ld (_TILE_DE_BASE),hl
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; TileSetSize — HL = W, DE = H (キャラクタ単位, W は偶数推奨)
+TileSetSize:
+	ld a,l
+	ld (_TILE_SIZE_W),a
+	; HALFW = W / 2
+	srl a
+	ld (_TILE_HALFW),a
+	; DE_ROWSTEP = 40 - W
+	ld a,40
+	sub l
+	ld (_TILE_DE_ROWSTEP),a
+	xor a
+	ld (_TILE_DE_ROWSTEP+1),a
+	ld a,e
+	ld (_TILE_SIZE_H),a
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+; TileInvalidate — 強制再描画フラグ (両ページ)
+TileInvalidate:
+	ld a,2
+	ld (_TILE_DIRTY),a
+	ret
+
+#END
+
+// ============================================================
+// ブロック 2: ワークエリア
+// ============================================================
+#ASM
+
+_TILE_ANIMIDX:	DB 0	; アニメフレーム (0-3, TILE_ANIM_TICK で更新)
+_TILE_ANIMCNT:	DB 0	; vsync カウンタ (TILE_ANIM_TICK 用)
+_TILE_ANIMTICKS: DB 8	; フレーム進行間隔 (vsync数, デフォルト 8)
+_TILE_ANIMFRAME: DB 0	; 現在のアニメフレーム
+_TILE_ANIMPERIOD: DB 4	; アニメ周期 (フレーム数, デフォルト 4)
+_TILE_SCROLLX:	DW 0
+_TILE_SCROLLY:	DW 0
+_TILE_MAPW:	DB 32
+_TILE_MAPH:	DB 32
+_TILE_PAGEOFS:	DB 0	; 描画ページオフセット (0 or 4)
+_TILE_IDXADR:	DW 0	; タイルインデックステーブルアドレス
+_TF_ANIMSNAP:	DB 0	; アニメインデックス スナップショット
+_TF_ABSY:	DW 0	; 描画中の絶対 Y 座標
+_TF_SUBX:	DB 0	; sub_x (0 or 1, 行間で固定)
+_TF_IDXBASE:	DW 0	; 行ごと: TileIdx + tile_offset
+_TILE_DIRTY:	DB 2	; 残り再描画ページ数 (0=不要, 1-2=必要)
+_TILE_OFS_X:	DB 0	; 描画開始 X (キャラクタ単位)
+_TILE_OFS_Y:	DB 0	; 描画開始 Y (キャラクタ単位)
+_TILE_SIZE_W:	DB 40	; 描画幅 (キャラクタ単位)
+_TILE_SIZE_H:	DB 24	; 描画高さ (キャラクタ単位)
+_TILE_HALFW:	DB 20	; SIZE_W / 2 (ペア数)
+_TILE_DE_BASE:	DW 0	; OFS_Y * 40 + OFS_X
+_TILE_DE_ROWSTEP: DW 0	; 40 - SIZE_W (行末→次行頭の加算量)
+
+#END

--- a/assets/slang_include/TILESPR.LIB
+++ b/assets/slang_include/TILESPR.LIB
@@ -1,0 +1,21 @@
+///
+/// TILESPR.LIB — TILELIB + SPRLIB 統合 shim
+///
+/// 注意: これは TILELIB と SPRLIB の内部シンボル (_SPR_PAGEOFS, _TILE_PAGEOFS) に
+/// 意図的に依存する統合専用 shim です。両ライブラリのバージョンが揃っている前提で使う。
+/// 公開 API ライブラリではなく、TILELIB+SPRLIB を組み合わせるアプリ向けの薄いブリッジ。
+///
+
+#include TILELIB.LIB
+#include SPRLIB.LIB
+
+// SPRLIB の現在の描画ページを TILELIB に同期する。
+// 毎フレーム TILE_FILL_MAP の前に呼ぶこと。
+MACHINE TILE_SYNC_SPR_PAGE(0): _TileSyncSprPage;
+
+#ASM
+_TileSyncSprPage:
+	ld a,(_SPR_PAGEOFS)
+	ld (_TILE_PAGEOFS),a
+	ret
+#END

--- a/assets/slang_include/UILIB.LIB
+++ b/assets/slang_include/UILIB.LIB
@@ -1,0 +1,791 @@
+///
+/// UILIB.LIB — X1 GVRAM 静的 HUD ライブラリ
+///
+/// 役割:
+///   SPRLIB / TILELIB / CHIPLIB とは独立した「静的 HUD 専用」レイヤ。
+///   GVRAM (B/R/G 3 プレーン) にテキスト・塗り・枠を描画する。
+///   両ページ (page 0 / page 4) へ同時書き込みするので、1 回描けば
+///   SPRLIB のダブルバッファが切り替わっても消えない。
+///
+/// 前提 (重要):
+///   SPRLIB と併用する場合、SPR_INIT() は GVRAM を全クリアするため、
+///   UILIB の各描画は必ず SPR_INIT() の後に呼ぶこと。順序は
+///   WIDTH → GRPSETUP → GRDISP → SPR_INIT → UILIB 描画 → メインループ。
+///
+/// 制約 (重要):
+///   UI 領域にスプライトを侵入させないこと。SPRLIB の old1 erase 処理で
+///   スプライトが通った領域は 0 クリアされるため、UI が消える。
+///   HUD は画面端 (Y=0 や Y=24 等) に寄せてスプライト範囲と物理的に分離する。
+///
+/// 座標と色:
+///   座標: 8x8 チップ単位 (x: 0..39, y: 0..24)
+///   色:   3 bit BRG (bit0=B, bit1=R, bit2=G)。0 = 黒, 7 = 白
+///   描画モード: SET (色の bit が立つプレーンにパターン、立たないプレーンは 0)
+///
+/// 文字コード空間:
+///   glyph 0..255 (256 種)。ただし glyph 0 は UI_PUTS の終端予約。
+///   UI_PUTC(0) は単発描画として許可 (glyph 0 の内容を描く)。
+///   CHARMAP では 0 を割り当てないこと。
+///
+/// 公開 API:
+///   UI_AT(x, y)          カーソル位置設定
+///   UI_SET_COLOR(c)      色設定 (0..7, BRG)
+///   UI_PUTC(ch)          1 文字描画 (カーソル X+1)
+///   UI_PUTS(ptr)         ゼロ終端文字列描画 (画面右端で打ち止め)
+///   UI_FILL(w, h)        カーソル位置を左上に w×h チップ塗り
+///   UI_BOX(w, h)         外枠のみ描画 (w,h >= 2)
+///   UI_FONT_ADDR()       内蔵フォント先頭アドレス (HL)
+///
+
+// --- API ---
+MACHINE UI_AT(2):        UiAt;
+MACHINE UI_SET_COLOR(1): UiSetColor;
+MACHINE UI_PUTC(1):      UiPutC;
+MACHINE UI_PUTS(1):      UiPuts;
+MACHINE UI_FILL(2):      UiFill;
+MACHINE UI_BOX(2):       UiBox;
+MACHINE UI_FONT_ADDR(0): UiFontAddr;
+
+#ASM
+
+; ============================================================
+; UiAt — HL=x, DE=y
+; ============================================================
+UiAt:
+	ld a,l
+	ld (_UI_CURSOR_X),a
+	ld a,e
+	ld (_UI_CURSOR_Y),a
+	ret
+
+; ============================================================
+; UiSetColor — HL=color (0..7)
+; ============================================================
+UiSetColor:
+	ld a,l
+	and 7
+	ld (_UI_COLOR),a
+	ret
+
+; ============================================================
+; UiFontAddr — returns HL = &_UI_FONT_DATA
+; ============================================================
+UiFontAddr:
+	ld hl,_UI_FONT_DATA
+	ret
+
+; ============================================================
+; UiPutC — HL = char code. 1 文字描画してカーソル X++
+; ============================================================
+UiPutC:
+	ld a,l
+	call _UiSetFontFromChar
+	call _UiDrawAtCursor
+	ld a,(_UI_CURSOR_X)
+	inc a
+	ld (_UI_CURSOR_X),a
+	ret
+
+; ============================================================
+; UiPuts — HL = zero-terminated string.
+;   1 文字ずつ描画して X++, 0 で終了。x>=40 でも停止。
+; ============================================================
+UiPuts:
+.loop:
+	ld a,(hl)
+	or a
+	ret z
+	push hl
+	call _UiSetFontFromChar
+	call _UiDrawAtCursor
+	pop hl
+	inc hl
+	ld a,(_UI_CURSOR_X)
+	inc a
+	ld (_UI_CURSOR_X),a
+	cp 40
+	jr nc,.end
+	jr .loop
+.end:
+	ret
+
+; ============================================================
+; UiFill — HL=w, DE=h. カーソル位置を左上に w×h を fill パターンで塗る
+; ============================================================
+UiFill:
+	ld a,l
+	ld (_UI_TMP_W),a
+	ld a,e
+	ld (_UI_TMP_H),a
+	ld a,(_UI_CURSOR_X)
+	ld (_UI_TMP_OX),a
+	ld a,(_UI_CURSOR_Y)
+	ld (_UI_TMP_OY),a
+
+	; パターン = _UI_FILL_PATTERN (全 $FF)
+	ld hl,_UI_FILL_PATTERN
+	ld (_UI_PATTERN_PTR),hl
+
+.rowLoop:
+	; X = OX
+	ld a,(_UI_TMP_OX)
+	ld (_UI_CURSOR_X),a
+
+	ld a,(_UI_TMP_W)
+	or a
+	jr z,.nextRow
+	ld (_UI_TMP_CNT),a
+.colLoop:
+	call _UiDrawAtCursor
+	ld a,(_UI_CURSOR_X)
+	inc a
+	ld (_UI_CURSOR_X),a
+	ld a,(_UI_TMP_CNT)
+	dec a
+	ld (_UI_TMP_CNT),a
+	jr nz,.colLoop
+
+.nextRow:
+	ld a,(_UI_CURSOR_Y)
+	inc a
+	ld (_UI_CURSOR_Y),a
+	ld a,(_UI_TMP_H)
+	dec a
+	ld (_UI_TMP_H),a
+	jr nz,.rowLoop
+
+	; カーソルは (OX, OY + h) に残す (後続描画しやすい形)
+	ld a,(_UI_TMP_OX)
+	ld (_UI_CURSOR_X),a
+	ret
+
+; ============================================================
+; UiBox — HL=w, DE=h. 外周 8 箇所を _UI_BOX_DATA (9-slice) から描画。
+;   内部 (M 相当エリア) は描かない (呼び出し側で UI_FILL 等で塗る想定)。
+;   不透明な背景が欲しい場合は、パレットで 1 色を黒にリマップしてから
+;   その色で UI_FILL → UI_BOX → UI_PUTS の順で重ねる:
+;     UI_SET_COLOR(3); UI_AT(x,y); UI_FILL(w,h);  ; 背景 (色 3 = 黒に remap 済み)
+;     UI_SET_COLOR(7); UI_AT(x,y); UI_BOX(w,h);   ; 枠 (白)
+;     UI_SET_COLOR(7); UI_AT(x+1,y+1); UI_PUTS(S) ; テキスト
+;
+;   9-slice のスロット割り当て (_UI_BOX_DATA 内のインデックス):
+;     0=TL, 1=T,  2=TR
+;     3=L,  4=M,  5=R
+;     6=BL, 7=B,  8=BR
+;   フォントとは独立した 9 × 8 バイト = 72 バイトの画像データを参照する。
+;   window.png 等から tools/png_to_asm.py --box で再生成可能。
+;   w, h ≧ 2。
+; ============================================================
+; 9-slice スロットインデックス定数
+_UI_9S_TL EQU 0
+_UI_9S_T  EQU 1
+_UI_9S_TR EQU 2
+_UI_9S_L  EQU 3
+_UI_9S_M  EQU 4
+_UI_9S_R  EQU 5
+_UI_9S_BL EQU 6
+_UI_9S_B  EQU 7
+_UI_9S_BR EQU 8
+
+UiBox:
+	ld a,l
+	ld (_UI_TMP_W),a
+	ld a,e
+	ld (_UI_TMP_H),a
+	ld a,(_UI_CURSOR_X)
+	ld (_UI_TMP_OX),a
+	ld a,(_UI_CURSOR_Y)
+	ld (_UI_TMP_OY),a
+
+	; --- Top row ---
+	ld a,_UI_9S_TL
+	call _UiPutBoxAdvX
+
+	ld a,(_UI_TMP_W)
+	sub 2
+	jr z,.topDone
+	ld (_UI_TMP_CNT),a
+.topLoop:
+	ld a,_UI_9S_T
+	call _UiPutBoxAdvX
+	ld a,(_UI_TMP_CNT)
+	dec a
+	ld (_UI_TMP_CNT),a
+	jr nz,.topLoop
+.topDone:
+	ld a,_UI_9S_TR
+	call _UiPutBoxAdvX
+
+	; --- Middle rows (h-2 回, 内部 M で塗る) ---
+	ld a,(_UI_TMP_H)
+	sub 2
+	jr z,.noMid
+	ld (_UI_TMP_CNT),a
+.midLoop:
+	; 次行へ
+	ld a,(_UI_CURSOR_Y)
+	inc a
+	ld (_UI_CURSOR_Y),a
+	ld a,(_UI_TMP_OX)
+	ld (_UI_CURSOR_X),a
+
+	; L (left edge)
+	ld a,_UI_9S_L
+	call _UiPutBoxAdvX
+
+	; 内部は描画しない (呼び出し側で UI_FILL 等で塗る想定)。
+	; カーソルを右端列 (OX + W - 1) までスキップ。
+	ld a,(_UI_TMP_OX)
+	ld c,a
+	ld a,(_UI_TMP_W)
+	add a,c
+	dec a
+	ld (_UI_CURSOR_X),a
+
+	; R (right edge)
+	ld a,_UI_9S_R
+	call _UiPutBoxAdvX
+
+	ld a,(_UI_TMP_CNT)
+	dec a
+	ld (_UI_TMP_CNT),a
+	jr nz,.midLoop
+.noMid:
+
+	; --- Bottom row ---
+	ld a,(_UI_CURSOR_Y)
+	inc a
+	ld (_UI_CURSOR_Y),a
+	ld a,(_UI_TMP_OX)
+	ld (_UI_CURSOR_X),a
+
+	ld a,_UI_9S_BL
+	call _UiPutBoxAdvX
+
+	ld a,(_UI_TMP_W)
+	sub 2
+	jr z,.botDone
+	ld (_UI_TMP_CNT),a
+.botLoop:
+	ld a,_UI_9S_B
+	call _UiPutBoxAdvX
+	ld a,(_UI_TMP_CNT)
+	dec a
+	ld (_UI_TMP_CNT),a
+	jr nz,.botLoop
+.botDone:
+	ld a,_UI_9S_BR
+	call _UiPutBoxAdvX
+
+	; カーソルは開始位置に戻しておく
+	ld a,(_UI_TMP_OX)
+	ld (_UI_CURSOR_X),a
+	ld a,(_UI_TMP_OY)
+	ld (_UI_CURSOR_Y),a
+	ret
+
+; 内部: A = glyph code, カーソル位置に描画して X++
+_UiPutcAdvX:
+	call _UiSetFontFromChar
+	call _UiDrawAtCursor
+	ld a,(_UI_CURSOR_X)
+	inc a
+	ld (_UI_CURSOR_X),a
+	ret
+
+; 内部: A = 9-slice スロット index (0..8), _UI_BOX_DATA からパターンを取得し
+; カーソル位置に描画して X++
+_UiPutBoxAdvX:
+	ld h,0
+	ld l,a
+	add hl,hl
+	add hl,hl
+	add hl,hl		; HL = A*8
+	ld de,_UI_BOX_DATA
+	add hl,de
+	ld (_UI_PATTERN_PTR),hl
+	call _UiDrawAtCursor
+	ld a,(_UI_CURSOR_X)
+	inc a
+	ld (_UI_CURSOR_X),a
+	ret
+
+; ============================================================
+; _UiSetFontFromChar
+;   入力: A = char code (0..255)
+;   _UI_PATTERN_PTR = &_UI_FONT_DATA[A*8]
+; ============================================================
+_UiSetFontFromChar:
+	ld h,0
+	ld l,a
+	add hl,hl
+	add hl,hl
+	add hl,hl           ; HL = A*8
+	ld de,_UI_FONT_DATA
+	add hl,de
+	ld (_UI_PATTERN_PTR),hl
+	ret
+
+; ============================================================
+; _UiDrawAtCursor
+;   (_UI_PATTERN_PTR) の 8 バイトを (_UI_CURSOR_X, _UI_CURSOR_Y) に
+;   両ページ (page 0, page 4) で描画する。色は (_UI_COLOR)。
+; ============================================================
+_UiDrawAtCursor:
+	; HL = Y*40 + X (16-bit)
+	ld a,(_UI_CURSOR_Y)
+	ld h,0
+	ld l,a
+	add hl,hl           ; Y*2
+	add hl,hl           ; Y*4
+	add hl,hl           ; Y*8
+	ld b,h
+	ld c,l              ; BC = Y*8
+	add hl,hl           ; Y*16
+	add hl,hl           ; Y*32
+	add hl,bc           ; Y*40
+	ld a,(_UI_CURSOR_X)
+	add a,l
+	ld l,a
+	jr nc,.nocarry
+	inc h
+.nocarry:
+	; BC = $4000 + HL (page 0, B plane, line 0)
+	ld bc,$4000
+	add hl,bc
+	ld b,h
+	ld c,l
+
+	di
+	; --- Page 0 ---
+	push bc
+	call _UiDrawOnePage
+	pop bc
+	; --- Page 4 ---
+	ld a,b
+	add a,$04
+	ld b,a
+	call _UiDrawOnePage
+	ei
+	ret
+
+; ============================================================
+; _UiDrawOnePage
+;   入力: BC = 現ページ B プレーン line 0 の I/O アドレス
+;         (_UI_PATTERN_PTR) = 8 バイトパターン先頭
+;         (_UI_COLOR) = 3-bit BRG
+;   OR 描画: 色 bit が立っているプレーンだけ OR で書き込む。
+;   bit が立っていないプレーンは一切触らず既存のピクセルを保持する。
+;   関数終了時、BC は 3 プレーン分 ($C0 ぶん) B が進んでいる。
+; ============================================================
+_UiDrawOnePage:
+	ld a,(_UI_COLOR)
+	ld e,a              ; E = color bits (保存)
+
+	; Plane B (bit 0)
+	bit 0,e
+	jr z,.skipB
+	ld hl,(_UI_PATTERN_PTR)
+	call _UiWrite8Lines
+	jr .rPlane
+.skipB:
+	ld a,b
+	add a,$40
+	ld b,a
+
+.rPlane:
+	bit 1,e
+	jr z,.skipR
+	ld hl,(_UI_PATTERN_PTR)
+	call _UiWrite8Lines
+	jr .gPlane
+.skipR:
+	ld a,b
+	add a,$40
+	ld b,a
+
+.gPlane:
+	bit 2,e
+	jr z,.skipG
+	ld hl,(_UI_PATTERN_PTR)
+	call _UiWrite8Lines
+	ret
+.skipG:
+	ld a,b
+	add a,$40
+	ld b,a
+	ret
+
+; ============================================================
+; _UiWrite8Lines
+;   入力: HL = パターン先頭 (8 bytes)
+;         BC = I/O アドレス (line 0)
+;   OR 描画: IN → OR パターン → OUT で既存ピクセルを保持したまま
+;   パターン bit を足し込む。
+;   出力: HL += 8, BC: B += $40 (= 次プレーン line 0)
+; ============================================================
+_UiWrite8Lines:
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+
+	in a,(c)
+	or (hl)
+	out (c),a
+	inc hl
+	ld a,b
+	add a,$08
+	ld b,a
+	ret
+
+; ============================================================
+; 内部状態
+; ============================================================
+_UI_CURSOR_X:     DB 0
+_UI_CURSOR_Y:     DB 0
+_UI_COLOR:        DB 7
+
+_UI_PATTERN_PTR:  DW 0
+
+_UI_TMP_OX:       DB 0
+_UI_TMP_OY:       DB 0
+_UI_TMP_W:        DB 0
+_UI_TMP_H:        DB 0
+_UI_TMP_CNT:      DB 0
+_UI_TMP_CNT2:     DB 0
+
+; ============================================================
+; パターンデータ
+; ============================================================
+_UI_ZERO_PATTERN:
+	DB $00, $00, $00, $00, $00, $00, $00, $00
+
+_UI_FILL_PATTERN:
+	DB $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF
+
+; === BOX DATA BEGIN (generated by tools/png_to_asm.py --box, do not edit) ===
+_UI_BOX_DATA:
+    DB $00, $1F, $30, $60, $40, $40, $40, $40	; slot 0: TL
+    DB $00, $FF, $00, $00, $00, $00, $00, $00	; slot 1: T
+    DB $00, $F8, $0C, $06, $02, $02, $02, $02	; slot 2: TR
+    DB $40, $40, $40, $40, $40, $40, $40, $40	; slot 3: L
+    DB $00, $00, $00, $00, $00, $00, $00, $00	; slot 4: M
+    DB $02, $02, $02, $02, $02, $02, $02, $02	; slot 5: R
+    DB $40, $40, $40, $40, $60, $30, $1F, $00	; slot 6: BL
+    DB $00, $00, $00, $00, $00, $00, $FF, $00	; slot 7: B
+    DB $02, $02, $02, $02, $06, $0C, $F8, $00	; slot 8: BR
+; === BOX DATA END ===
+
+; === FONT DATA BEGIN (generated by tools/png_to_asm.py, do not edit by hand) ===
+_UI_FONT_DATA:
+    DB $40, $A0, $8C, $12, $06, $0A, $0E, $00	; glyph 0
+    DB $40, $A0, $A4, $0A, $0E, $0A, $0A, $00	; glyph 1
+    DB $40, $A0, $AC, $0A, $0C, $0A, $0C, $00	; glyph 2
+    DB $40, $A0, $A6, $08, $08, $08, $06, $00	; glyph 3
+    DB $40, $A0, $AC, $0A, $0A, $0A, $0C, $00	; glyph 4
+    DB $40, $A0, $AE, $08, $0E, $08, $0E, $00	; glyph 5
+    DB $40, $A0, $AE, $08, $0E, $08, $08, $00	; glyph 6
+    DB $40, $A0, $AC, $10, $16, $12, $1E, $00	; glyph 7
+    DB $40, $A0, $AA, $0A, $0E, $0A, $0A, $00	; glyph 8
+    DB $40, $A0, $AE, $04, $04, $04, $0E, $00	; glyph 9
+    DB $40, $A0, $A2, $02, $12, $12, $0C, $00	; glyph 10
+    DB $40, $A0, $92, $14, $18, $14, $12, $00	; glyph 11
+    DB $40, $A0, $A8, $08, $08, $08, $0E, $00	; glyph 12
+    DB $40, $A0, $80, $22, $36, $2A, $22, $00	; glyph 13
+    DB $40, $A0, $A0, $12, $1A, $16, $12, $00	; glyph 14
+    DB $40, $A0, $AC, $12, $12, $12, $0C, $00	; glyph 15
+    DB $40, $A0, $AE, $0A, $0E, $08, $08, $00	; glyph 16
+    DB $40, $A0, $AC, $12, $12, $14, $0E, $00	; glyph 17
+    DB $40, $A0, $AC, $0A, $0C, $0A, $0A, $00	; glyph 18
+    DB $40, $A0, $A6, $08, $04, $02, $0C, $00	; glyph 19
+    DB $40, $A0, $AE, $04, $04, $04, $04, $00	; glyph 20
+    DB $40, $A0, $80, $12, $12, $12, $0C, $00	; glyph 21
+    DB $40, $A0, $80, $22, $12, $14, $08, $00	; glyph 22
+    DB $40, $A0, $80, $22, $2A, $36, $22, $00	; glyph 23
+    DB $40, $A0, $AA, $0A, $04, $0A, $0A, $00	; glyph 24
+    DB $40, $A0, $AA, $0A, $04, $04, $04, $00	; glyph 25
+    DB $40, $A0, $AE, $02, $04, $08, $0E, $00	; glyph 26
+    DB $E0, $80, $CC, $92, $F0, $12, $0C, $00	; glyph 27
+    DB $00, $08, $04, $FE, $04, $08, $00, $00	; glyph 28
+    DB $00, $20, $40, $FE, $40, $20, $00, $00	; glyph 29
+    DB $10, $38, $54, $10, $10, $10, $10, $00	; glyph 30
+    DB $10, $10, $10, $10, $54, $38, $10, $00	; glyph 31
+    DB $00, $00, $00, $00, $00, $00, $00, $00	; glyph 32
+    DB $10, $10, $10, $10, $10, $00, $10, $00	; glyph 33
+    DB $6C, $24, $48, $00, $00, $00, $00, $00	; glyph 34
+    DB $14, $7E, $28, $28, $28, $FC, $50, $00	; glyph 35
+    DB $08, $3E, $48, $3C, $12, $7C, $10, $00	; glyph 36
+    DB $42, $A4, $48, $10, $24, $4A, $84, $00	; glyph 37
+    DB $30, $48, $50, $24, $54, $88, $76, $00	; glyph 38
+    DB $60, $20, $40, $00, $00, $00, $00, $00	; glyph 39
+    DB $04, $08, $10, $10, $10, $08, $04, $00	; glyph 40
+    DB $40, $20, $10, $10, $10, $20, $40, $00	; glyph 41
+    DB $10, $54, $38, $10, $38, $54, $10, $00	; glyph 42
+    DB $10, $10, $10, $FE, $10, $10, $10, $00	; glyph 43
+    DB $00, $00, $00, $00, $60, $20, $40, $00	; glyph 44
+    DB $00, $00, $00, $FE, $00, $00, $00, $00	; glyph 45
+    DB $00, $00, $00, $00, $00, $60, $60, $00	; glyph 46
+    DB $00, $04, $08, $10, $20, $40, $00, $00	; glyph 47
+    DB $3C, $42, $46, $5A, $62, $42, $3C, $00	; glyph 48
+    DB $10, $30, $10, $10, $10, $10, $38, $00	; glyph 49
+    DB $3C, $42, $02, $0C, $30, $40, $7E, $00	; glyph 50
+    DB $3C, $42, $02, $1C, $02, $42, $3C, $00	; glyph 51
+    DB $04, $0C, $14, $24, $44, $7E, $04, $00	; glyph 52
+    DB $7E, $40, $7C, $42, $02, $42, $3C, $00	; glyph 53
+    DB $1C, $20, $40, $7C, $42, $42, $3C, $00	; glyph 54
+    DB $7E, $02, $04, $08, $08, $10, $10, $00	; glyph 55
+    DB $3C, $42, $42, $3C, $42, $42, $3C, $00	; glyph 56
+    DB $3C, $42, $42, $3E, $02, $04, $38, $00	; glyph 57
+    DB $00, $30, $30, $00, $30, $30, $00, $00	; glyph 58
+    DB $00, $30, $30, $00, $30, $10, $20, $00	; glyph 59
+    DB $04, $08, $10, $20, $10, $08, $04, $00	; glyph 60
+    DB $00, $00, $FE, $00, $FE, $00, $00, $00	; glyph 61
+    DB $40, $20, $10, $08, $10, $20, $40, $00	; glyph 62
+    DB $3C, $42, $02, $0C, $10, $00, $10, $00	; glyph 63
+    DB $38, $44, $9A, $AA, $B4, $40, $38, $00	; glyph 64
+    DB $10, $28, $28, $44, $7C, $82, $82, $00	; glyph 65
+    DB $7C, $42, $42, $7C, $42, $42, $7C, $00	; glyph 66
+    DB $3C, $42, $40, $40, $40, $42, $3C, $00	; glyph 67
+    DB $78, $44, $42, $42, $42, $44, $78, $00	; glyph 68
+    DB $7E, $40, $40, $7C, $40, $40, $7E, $00	; glyph 69
+    DB $7E, $40, $40, $7C, $40, $40, $40, $00	; glyph 70
+    DB $3C, $42, $40, $4E, $42, $42, $3C, $00	; glyph 71
+    DB $42, $42, $42, $7E, $42, $42, $42, $00	; glyph 72
+    DB $38, $10, $10, $10, $10, $10, $38, $00	; glyph 73
+    DB $02, $02, $02, $02, $02, $42, $3C, $00	; glyph 74
+    DB $42, $44, $48, $50, $68, $44, $42, $00	; glyph 75
+    DB $40, $40, $40, $40, $40, $40, $7E, $00	; glyph 76
+    DB $82, $C6, $AA, $AA, $92, $92, $82, $00	; glyph 77
+    DB $42, $62, $52, $4A, $46, $42, $42, $00	; glyph 78
+    DB $3C, $42, $42, $42, $42, $42, $3C, $00	; glyph 79
+    DB $7C, $42, $42, $7C, $40, $40, $40, $00	; glyph 80
+    DB $3C, $42, $42, $42, $4A, $44, $3A, $00	; glyph 81
+    DB $7C, $42, $42, $7C, $48, $44, $42, $00	; glyph 82
+    DB $3C, $42, $40, $3C, $02, $42, $3C, $00	; glyph 83
+    DB $FE, $10, $10, $10, $10, $10, $10, $00	; glyph 84
+    DB $42, $42, $42, $42, $42, $42, $3C, $00	; glyph 85
+    DB $82, $82, $44, $44, $28, $28, $10, $00	; glyph 86
+    DB $82, $92, $92, $AA, $AA, $44, $44, $00	; glyph 87
+    DB $82, $44, $28, $10, $28, $44, $82, $00	; glyph 88
+    DB $82, $44, $28, $10, $10, $10, $10, $00	; glyph 89
+    DB $7E, $02, $04, $08, $10, $20, $7E, $00	; glyph 90
+    DB $1C, $10, $10, $10, $10, $10, $1C, $00	; glyph 91
+    DB $44, $44, $28, $7C, $10, $7C, $10, $00	; glyph 92
+    DB $70, $10, $10, $10, $10, $10, $70, $00	; glyph 93
+    DB $10, $28, $00, $00, $00, $00, $00, $00	; glyph 94
+    DB $00, $00, $00, $00, $00, $00, $FE, $00	; glyph 95
+    DB $40, $20, $00, $00, $00, $00, $00, $00	; glyph 96
+    DB $00, $00, $38, $04, $3C, $44, $3C, $00	; glyph 97
+    DB $40, $40, $58, $64, $44, $44, $78, $00	; glyph 98
+    DB $00, $00, $38, $44, $40, $44, $38, $00	; glyph 99
+    DB $04, $04, $34, $4C, $44, $44, $3C, $00	; glyph 100
+    DB $00, $00, $38, $44, $7C, $40, $38, $00	; glyph 101
+    DB $0C, $10, $38, $10, $10, $10, $10, $00	; glyph 102
+    DB $00, $00, $3C, $44, $3C, $04, $38, $00	; glyph 103
+    DB $40, $40, $58, $64, $44, $44, $44, $00	; glyph 104
+    DB $10, $00, $10, $10, $10, $10, $10, $00	; glyph 105
+    DB $08, $00, $08, $08, $08, $48, $30, $00	; glyph 106
+    DB $20, $20, $24, $28, $30, $28, $24, $00	; glyph 107
+    DB $30, $10, $10, $10, $10, $10, $10, $00	; glyph 108
+    DB $00, $00, $68, $54, $54, $54, $54, $00	; glyph 109
+    DB $00, $00, $58, $64, $44, $44, $44, $00	; glyph 110
+    DB $00, $00, $38, $44, $44, $44, $38, $00	; glyph 111
+    DB $00, $00, $78, $44, $78, $40, $40, $00	; glyph 112
+    DB $00, $00, $3C, $44, $3C, $04, $04, $00	; glyph 113
+    DB $00, $00, $58, $64, $40, $40, $40, $00	; glyph 114
+    DB $00, $00, $3C, $40, $38, $04, $78, $00	; glyph 115
+    DB $00, $20, $78, $20, $20, $24, $18, $00	; glyph 116
+    DB $00, $00, $44, $44, $44, $4C, $34, $00	; glyph 117
+    DB $00, $00, $44, $44, $28, $28, $10, $00	; glyph 118
+    DB $00, $00, $44, $54, $54, $28, $28, $00	; glyph 119
+    DB $00, $00, $44, $28, $10, $28, $44, $00	; glyph 120
+    DB $00, $00, $44, $28, $28, $10, $60, $00	; glyph 121
+    DB $00, $00, $7C, $08, $10, $20, $7C, $00	; glyph 122
+    DB $0C, $10, $10, $20, $10, $10, $0C, $00	; glyph 123
+    DB $10, $10, $10, $00, $10, $10, $10, $00	; glyph 124
+    DB $60, $10, $10, $08, $10, $10, $60, $00	; glyph 125
+    DB $FE, $00, $00, $00, $00, $00, $00, $00	; glyph 126
+    DB $00, $00, $3E, $54, $14, $24, $46, $00	; glyph 127
+    DB $00, $00, $00, $00, $00, $00, $00, $FF	; glyph 128
+    DB $00, $00, $00, $00, $00, $00, $FF, $FF	; glyph 129
+    DB $00, $00, $00, $00, $00, $FF, $FF, $FF	; glyph 130
+    DB $00, $00, $00, $00, $FF, $FF, $FF, $FF	; glyph 131
+    DB $00, $00, $00, $FF, $FF, $FF, $FF, $FF	; glyph 132
+    DB $00, $00, $FF, $FF, $FF, $FF, $FF, $FF	; glyph 133
+    DB $00, $FF, $FF, $FF, $FF, $FF, $FF, $FF	; glyph 134
+    DB $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF	; glyph 135
+    DB $80, $80, $80, $80, $80, $80, $80, $80	; glyph 136
+    DB $C0, $C0, $C0, $C0, $C0, $C0, $C0, $C0	; glyph 137
+    DB $E0, $E0, $E0, $E0, $E0, $E0, $E0, $E0	; glyph 138
+    DB $F0, $F0, $F0, $F0, $F0, $F0, $F0, $F0	; glyph 139
+    DB $F8, $F8, $F8, $F8, $F8, $F8, $F8, $F8	; glyph 140
+    DB $FC, $FC, $FC, $FC, $FC, $FC, $FC, $FC	; glyph 141
+    DB $FE, $FE, $FE, $FE, $FE, $FE, $FE, $FE	; glyph 142
+    DB $01, $02, $04, $08, $10, $20, $40, $80	; glyph 143
+    DB $00, $00, $00, $FF, $00, $00, $00, $00	; glyph 144
+    DB $10, $10, $10, $10, $10, $10, $10, $10	; glyph 145
+    DB $10, $10, $10, $FF, $00, $00, $00, $00	; glyph 146
+    DB $00, $00, $00, $FF, $10, $10, $10, $10	; glyph 147
+    DB $10, $10, $10, $F0, $10, $10, $10, $10	; glyph 148
+    DB $10, $10, $10, $1F, $10, $10, $10, $10	; glyph 149
+    DB $10, $10, $10, $FF, $10, $10, $10, $10	; glyph 150
+    DB $00, $00, $00, $F0, $10, $10, $10, $10	; glyph 151
+    DB $10, $10, $10, $F0, $00, $00, $00, $00	; glyph 152
+    DB $10, $10, $10, $1F, $00, $00, $00, $00	; glyph 153
+    DB $00, $00, $00, $1F, $10, $10, $10, $10	; glyph 154
+    DB $00, $00, $00, $C0, $20, $10, $10, $10	; glyph 155
+    DB $10, $10, $08, $07, $00, $00, $00, $00	; glyph 156
+    DB $10, $10, $20, $C0, $00, $00, $00, $00	; glyph 157
+    DB $00, $00, $00, $07, $08, $10, $10, $10	; glyph 158
+    DB $80, $40, $20, $10, $08, $04, $02, $01	; glyph 159
+    DB $00, $00, $00, $00, $00, $00, $00, $00	; glyph 160
+    DB $00, $00, $00, $00, $40, $A0, $40, $00	; glyph 161
+    DB $1E, $10, $10, $10, $10, $10, $00, $00	; glyph 162
+    DB $00, $10, $10, $10, $10, $10, $F0, $00	; glyph 163
+    DB $00, $00, $00, $00, $00, $80, $40, $00	; glyph 164
+    DB $00, $00, $00, $30, $30, $00, $00, $00	; glyph 165
+    DB $7E, $02, $3E, $02, $04, $08, $30, $00	; glyph 166
+    DB $00, $00, $7C, $14, $18, $10, $20, $00	; glyph 167
+    DB $00, $00, $04, $08, $18, $68, $08, $00	; glyph 168
+    DB $00, $00, $10, $7C, $44, $08, $30, $00	; glyph 169
+    DB $00, $00, $00, $38, $10, $10, $7C, $00	; glyph 170
+    DB $00, $00, $08, $7C, $18, $68, $18, $00	; glyph 171
+    DB $00, $00, $20, $3C, $64, $10, $10, $00	; glyph 172
+    DB $00, $00, $00, $38, $08, $08, $7C, $00	; glyph 173
+    DB $00, $00, $3C, $04, $1C, $04, $3C, $00	; glyph 174
+    DB $00, $00, $00, $54, $54, $08, $30, $00	; glyph 175
+    DB $00, $00, $80, $7E, $00, $00, $00, $00	; glyph 176
+    DB $7E, $02, $14, $18, $10, $10, $20, $00	; glyph 177
+    DB $02, $04, $08, $18, $68, $08, $08, $00	; glyph 178
+    DB $10, $7E, $42, $02, $04, $08, $30, $00	; glyph 179
+    DB $00, $7C, $10, $10, $10, $FE, $00, $00	; glyph 180
+    DB $08, $FE, $08, $18, $28, $C8, $18, $00	; glyph 181
+    DB $10, $7E, $12, $12, $12, $22, $46, $00	; glyph 182
+    DB $10, $7C, $10, $10, $7E, $08, $08, $00	; glyph 183
+    DB $10, $1E, $22, $42, $04, $08, $30, $00	; glyph 184
+    DB $40, $7E, $48, $88, $08, $10, $20, $00	; glyph 185
+    DB $00, $7E, $02, $02, $02, $02, $7E, $00	; glyph 186
+    DB $24, $FE, $24, $24, $04, $08, $30, $00	; glyph 187
+    DB $40, $20, $42, $22, $04, $08, $70, $00	; glyph 188
+    DB $00, $7C, $04, $08, $08, $34, $C2, $00	; glyph 189
+    DB $20, $20, $FE, $22, $24, $20, $1E, $00	; glyph 190
+    DB $42, $22, $22, $02, $04, $08, $30, $00	; glyph 191
+    DB $10, $1E, $22, $5A, $04, $08, $30, $00	; glyph 192
+    DB $0C, $70, $10, $FE, $10, $10, $20, $00	; glyph 193
+    DB $00, $A2, $52, $52, $04, $08, $30, $00	; glyph 194
+    DB $7C, $00, $FE, $10, $10, $10, $20, $00	; glyph 195
+    DB $20, $20, $20, $38, $24, $20, $20, $00	; glyph 196
+    DB $10, $10, $FE, $10, $10, $20, $40, $00	; glyph 197
+    DB $00, $7C, $00, $00, $00, $FE, $00, $00	; glyph 198
+    DB $7C, $04, $34, $08, $18, $24, $C0, $00	; glyph 199
+    DB $10, $7C, $08, $10, $34, $D2, $10, $00	; glyph 200
+    DB $04, $04, $04, $08, $10, $20, $C0, $00	; glyph 201
+    DB $00, $28, $24, $24, $42, $42, $82, $00	; glyph 202
+    DB $40, $40, $46, $78, $40, $40, $3E, $00	; glyph 203
+    DB $00, $7E, $02, $02, $04, $08, $30, $00	; glyph 204
+    DB $00, $20, $50, $88, $04, $02, $00, $00	; glyph 205
+    DB $10, $10, $FE, $10, $54, $92, $30, $00	; glyph 206
+    DB $00, $FE, $02, $04, $28, $10, $08, $00	; glyph 207
+    DB $70, $0C, $20, $18, $00, $70, $0C, $00	; glyph 208
+    DB $10, $10, $20, $20, $48, $44, $FA, $00	; glyph 209
+    DB $04, $04, $74, $08, $14, $24, $C0, $00	; glyph 210
+    DB $3C, $10, $10, $7E, $10, $10, $0E, $00	; glyph 211
+    DB $20, $2E, $F2, $24, $10, $10, $10, $00	; glyph 212
+    DB $00, $78, $08, $08, $08, $FE, $00, $00	; glyph 213
+    DB $00, $7E, $02, $3E, $02, $02, $7E, $00	; glyph 214
+    DB $3C, $00, $7E, $02, $04, $08, $30, $00	; glyph 215
+    DB $44, $44, $44, $44, $04, $08, $30, $00	; glyph 216
+    DB $08, $28, $28, $28, $2A, $4C, $88, $00	; glyph 217
+    DB $20, $20, $20, $22, $24, $28, $30, $00	; glyph 218
+    DB $00, $7E, $42, $42, $42, $42, $7E, $00	; glyph 219
+    DB $00, $7E, $42, $02, $04, $08, $30, $00	; glyph 220
+    DB $40, $20, $02, $02, $04, $08, $70, $00	; glyph 221
+    DB $A0, $50, $00, $00, $00, $00, $00, $00	; glyph 222
+    DB $40, $A0, $40, $00, $00, $00, $00, $00	; glyph 223
+    DB $38, $7C, $FE, $FE, $FE, $7C, $38, $00	; glyph 224
+    DB $38, $44, $82, $82, $82, $44, $38, $00	; glyph 225
+    DB $10, $38, $7C, $FE, $FE, $10, $38, $00	; glyph 226
+    DB $6C, $FE, $FE, $FE, $7C, $38, $10, $00	; glyph 227
+    DB $10, $38, $7C, $FE, $7C, $38, $10, $00	; glyph 228
+    DB $38, $38, $D6, $FE, $D6, $10, $38, $00	; glyph 229
+    DB $01, $03, $07, $0F, $1F, $3F, $7F, $FF	; glyph 230
+    DB $80, $C0, $E0, $F0, $F8, $FC, $FE, $FF	; glyph 231
+    DB $81, $42, $24, $18, $18, $24, $42, $81	; glyph 232
+    DB $F0, $F0, $F0, $F0, $00, $00, $00, $00	; glyph 233
+    DB $00, $00, $00, $00, $F0, $F0, $F0, $F0	; glyph 234
+    DB $0F, $0F, $0F, $0F, $00, $00, $00, $00	; glyph 235
+    DB $00, $00, $00, $00, $0F, $0F, $0F, $0F	; glyph 236
+    DB $0F, $0F, $0F, $0F, $F0, $F0, $F0, $F0	; glyph 237
+    DB $F0, $F0, $F0, $F0, $0F, $0F, $0F, $0F	; glyph 238
+    DB $FF, $81, $81, $81, $81, $81, $81, $FF	; glyph 239
+    DB $AA, $55, $AA, $55, $AA, $55, $AA, $55	; glyph 240
+    DB $10, $10, $7C, $10, $10, $10, $FE, $00	; glyph 241
+    DB $10, $28, $FE, $10, $FE, $54, $FE, $00	; glyph 242
+    DB $10, $FE, $10, $38, $54, $92, $10, $00	; glyph 243
+    DB $10, $12, $F4, $38, $54, $92, $30, $00	; glyph 244
+    DB $10, $10, $54, $58, $10, $28, $C6, $00	; glyph 245
+    DB $3E, $22, $3E, $22, $3E, $42, $86, $00	; glyph 246
+    DB $7E, $42, $42, $7E, $42, $42, $7E, $00	; glyph 247
+    DB $08, $FC, $A8, $FE, $A4, $FE, $14, $00	; glyph 248
+    DB $28, $28, $44, $BE, $14, $24, $CC, $00	; glyph 249
+    DB $C8, $5C, $DA, $68, $CA, $C4, $58, $00	; glyph 250
+    DB $40, $7E, $90, $7C, $50, $FE, $10, $00	; glyph 251
+    DB $FE, $92, $92, $FE, $82, $82, $86, $00	; glyph 252
+    DB $10, $10, $10, $28, $28, $44, $82, $00	; glyph 253
+    DB $50, $7E, $90, $10, $7C, $10, $FE, $00	; glyph 254
+    DB $FE, $00, $FE, $10, $10, $10, $10, $00	; glyph 255
+; === FONT DATA END ===
+
+#END

--- a/assets/slang_runtime/libx1_pcg.asm
+++ b/assets/slang_runtime/libx1_pcg.asm
@@ -1,6 +1,34 @@
 ; Converted from lib/libdef/libx1_pcg.yml
 ; SLANG Runtime Library (new format)
 
+; @name PCGDEFS
+; @param_count 3
+; @calls PCGDEF
+; HL = STARTIDX (ascii code), DE = ADDR (24 bytes/tile), BC = COUNT
+; ADDR から 24 バイト × COUNT バイトの連続 PCG パターンを STARTIDX から順に登録。
+; 各タイル定義毎に CRTC vblank 待ちが入るため COUNT 個の処理に約 COUNT/60 秒かかる。
+.pcgdefs_loop:
+LD A,B
+OR C
+RET Z
+
+PUSH HL
+PUSH DE
+PUSH BC
+CALL PCGDEF
+POP BC
+POP DE
+POP HL
+
+INC L
+PUSH HL
+LD HL,24
+ADD HL,DE
+EX DE,HL
+POP HL
+DEC BC
+JR .pcgdefs_loop
+
 ; @name PCGDEF
 ; HL = ascii code DE = address
 PUSH DE

--- a/assets/slang_runtime/libx1_print.asm
+++ b/assets/slang_runtime/libx1_print.asm
@@ -52,24 +52,36 @@ CALL	CTRL0C
 POP	HL
 POP	DE
 POP	BC
+
+; LSX-Dodgers の CRTCD 領域 (LSX_base + $B0, 16 byte) を同期する。
+; これにより LSX 内部の _WIDTH ($+$B1), _PAGE_MINUS ($+$BA),
+; _WIDTH_MINUS ($+$BC), WK1FD0 ($+$BF) が一括更新され、プログラム終了後
+; に LSX がプロンプト再描画で CRTC を再設定しても画面が崩れない
+; (refs/MODE.ASM X1 パスと同じ考え方)。
+; LSX 基底は WBOOT の JP 先アドレス ($0001 のワード) から動的に取得する。
+; WBOOTBK は SLANGINIT の直後に WORK ゼロクリアされて使えないため
+; 直接 ($0001) を読む必要がある。
+; ※ 本実装は LSX_HEIGHT を 25 に固定して運用する (X1 CRTC が 25 行表示
+;   なので物理画面を使い切れる形)。LSX デフォルト (24) から 25 に書き換え
+;   られるので、WIDTH 呼出し以降 LSX 内部の HEIGHT も 25 になる点に注意。
+LD	HL,($0001)		; HL = WBOOT の JP 先 (= LSX 基底 + 微小オフセット)
+LD	L,$B0			; HL = LSX_base + $B0 (CRTCD 先頭)
+EX	DE,HL			; DE = dest (LSX CRTCD)
+LD	HL,_CRTCD		; HL = source (ローカル 16 byte)
+LD	BC,16
+LDIR
+
+; LSX の _HEIGHT ($+$97) を 25 に書き込む。
+; テンプレート側の _PAGE_MINUS = -WIDTH*25 と整合が取れ、LSX が 25 行目も
+; 使い切るようになる。
+LD	HL,($0001)
+LD	L,$97
+LD	(HL),25
+
 LD	A,(WK1FD0)
 LD	(_WK1FD0),A
 LD	A,(_CRTCD+1)
 LD	(AT_WIDTH),A
-; LSX-Dodgers 1.62c のワーク変数を同期
-LD	(LSX_WIDTH),A		; _WIDTH ($EEB1)
-NEG
-LD	L,A
-LD	H,$FF			; HL = -(WIDTH) (符号拡張)
-LD	(LSX_WIDTH_MINUS),HL	; _WIDTH_MINUS ($EEBC)
-; _PAGE_MINUS = -(WIDTH*24)
-LD	D,H
-LD	E,L			; DE = -(WIDTH)
-LD	B,23			; 24倍 = 元の1倍 + 23回加算
-.wlsx1
-ADD	HL,DE
-DJNZ	.wlsx1
-LD	(LSX_PAGE_MINUS),HL	; _PAGE_MINUS ($EEBA)
 AND	A
 RET
 
@@ -469,9 +481,8 @@ RET
 ; @name X1WORK
 ; LSX-Dodgers 1.62c ワーク共有
 _TXADR		EQU	$EE8E	; テキストカーソルVRAMアドレス
-LSX_PAGE_MINUS	EQU	$EEBA	; -(WIDTH*24) ページ末尾判定
-LSX_WIDTH	EQU	$EEB1	; 画面幅(40/80)
-LSX_WIDTH_MINUS	EQU	$EEBC	; -(WIDTH) 行送り用
+; CRTCD 関連 (_WIDTH / _PAGE_MINUS / _WIDTH_MINUS / WK1FD0) は WIDTH 内で
+; LSX_base + $B0 へ 16 byte LDIR することで同期するため、個別 EQU は不要。
 
 AT_COLORF:
 DB	7
@@ -479,6 +490,9 @@ AT_WIDTH:
 DB	80
 _WK1FD0:DB  0
 
+; X1 の CRTC は 25 行表示。LSX-Dodgers のデフォルト _HEIGHT は 24 だが、
+; WIDTH 関数内で LSX の _HEIGHT を 25 に書き換えて整合を取り、25 行
+; すべてを使えるようにする (下記 WIDTH 末尾の _HEIGHT 書き込みを参照)。
 CRTC_LINE EQU 25
 _CRTCD:
 DB	06FH,050H,059H,038H,01FH,002H,019H,01CH
@@ -510,3 +524,5 @@ DB	000H,00FH
 DW	0-40*CRTC_LINE,0-40
 DB	00DH
 DB	0A3H
+
+

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -585,7 +585,10 @@ window.__X1PEN_MODE = true;
                     } catch(e) { /* optional file */ }
                 }
                 // インクルードファイルも読み込み
-                var includeFiles = ['GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB'];
+                var includeFiles = [
+                    'GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB',
+                    'CHIPLIB.LIB', 'SPRLIB.LIB', 'TILELIB.LIB', 'TILESPR.LIB', 'UILIB.LIB',
+                ];
                 for (var ii = 0; ii < includeFiles.length; ii++) {
                     try {
                         var iresp = await fetch('slang_include/' + includeFiles[ii] + vBust);

--- a/html/x1pen_slang_compiler.js
+++ b/html/x1pen_slang_compiler.js
@@ -1,6 +1,6 @@
 // x1pen_slang_compiler.js — SLANG Compiler for X1Pen
 // Ported from C# (SLANGCompiler.Core) to JavaScript
-// C# source snapshot: https://github.com/h-o-soft/SLANG-compiler @ 6147192
+// C# source snapshot: https://github.com/h-o-soft/SLANG-compiler @ c9e8f53
 // Lazy-loaded: window.X1PenSlangCompiler = { compile: ... }
 
 (function() {
@@ -3024,6 +3024,23 @@
                 gvi.initialItems = initItems;
                 gvi.storageKind = VarStorageKind.CodeConst;
                 _module.globalVars.push(gvi);
+            } else if (node.isAsmEqu) {
+                // CONST ASM NAME = expr; → アセンブラの EQU として出力
+                var sym = globalSymbols ? globalSymbols.resolve(node.name) : null;
+                if (sym && sym.kind === SymbolKind.Constant && typeof sym.constValue === 'number') {
+                    var hex = (sym.constValue & 0xFFFF).toString(16).toUpperCase();
+                    while (hex.length < 4) hex = '0' + hex;
+                    emit(IrOp.InlineAsm, IrOperand.Asm(node.name + ' EQU $' + hex));
+                } else if (sym && sym.kind === SymbolKind.Constant && sym.constAst) {
+                    var result = exprToAsmString(sym.constAst, globalSymbols, diagnostics);
+                    if (result) {
+                        emit(IrOp.InlineAsm, IrOperand.Asm(node.name + ' EQU ' + result.expr));
+                    } else {
+                        diagnostics.error('CONST ASM ' + node.name + ' requires compile-time evaluable value', node.span);
+                    }
+                } else {
+                    diagnostics.error('CONST ASM ' + node.name + ' requires compile-time evaluable value', node.span);
+                }
             } else {
                 emit(IrOp.Comment, IrOperand.Asm('CONST ' + node.name));
             }
@@ -6370,34 +6387,43 @@
                 var tokens = Lexer(source).tokenize();
 
                 // #INCLUDE 展開: PreprocInclude トークンをファイル内容のトークンに置換
+                // ネスト #INCLUDE (LIB 内の #INCLUDE) にも対応。同一ファイルは 1 度だけ展開 (循環防止)。
                 if (virtualFS) {
-                    var expanded = [];
-                    for (var ti = 0; ti < tokens.length; ti++) {
-                        if (tokens[ti].kind === TK.PreprocInclude) {
-                            var incPath = tokens[ti].value || tokens[ti].text;
+                    var includedFiles = {};
+                    function expandTokens(inputTokens) {
+                        var out = [];
+                        for (var ti = 0; ti < inputTokens.length; ti++) {
+                            if (inputTokens[ti].kind !== TK.PreprocInclude) {
+                                out.push(inputTokens[ti]);
+                                continue;
+                            }
+                            var incPath = inputTokens[ti].value || inputTokens[ti].text;
+                            var incPathUpper = incPath.toUpperCase();
+                            if (includedFiles[incPathUpper]) continue; // 重複/循環を抑止
+                            includedFiles[incPathUpper] = true;
                             // virtualFS からファイル内容を取得（大文字小文字非依存）
                             var incContent = null;
-                            var incPathUpper = incPath.toUpperCase();
                             for (var vk in virtualFS) {
                                 if (vk.toUpperCase() === incPathUpper || vk.toUpperCase().replace(/.*[\/\\]/, '') === incPathUpper) {
                                     incContent = typeof virtualFS[vk] === 'string' ? virtualFS[vk] : null;
                                     break;
                                 }
                             }
-                            if (incContent) {
-                                var incTokens = Lexer(incContent, incPath).tokenize();
-                                // EOF トークンを除いて展開
-                                for (var iti = 0; iti < incTokens.length; iti++) {
-                                    if (incTokens[iti].kind !== TK.EOF) expanded.push(incTokens[iti]);
-                                }
-                            } else {
+                            if (!incContent) {
                                 diagnostics.warning('#INCLUDE file not found: ' + incPath);
+                                continue;
                             }
-                        } else {
-                            expanded.push(tokens[ti]);
+                            var incTokens = Lexer(incContent, incPath).tokenize();
+                            var nonEof = [];
+                            for (var iti = 0; iti < incTokens.length; iti++) {
+                                if (incTokens[iti].kind !== TK.EOF) nonEof.push(incTokens[iti]);
+                            }
+                            var subExpanded = expandTokens(nonEof);
+                            for (var ei = 0; ei < subExpanded.length; ei++) out.push(subExpanded[ei]);
                         }
+                        return out;
                     }
-                    tokens = expanded;
+                    tokens = expandTokens(tokens);
                 }
 
                 var envConfig = env || {};

--- a/html/x1pen_slang_compiler.js
+++ b/html/x1pen_slang_compiler.js
@@ -3035,6 +3035,9 @@
                     var result = exprToAsmString(sym.constAst, globalSymbols, diagnostics);
                     if (result) {
                         emit(IrOp.InlineAsm, IrOperand.Asm(node.name + ' EQU ' + result.expr));
+                        // 式中に含まれるランタイムラベルを依存として登録 (未登録だと本体が未出力になる)
+                        for (var d = 0; d < result.deps.length; d++)
+                            _module.addressSymbolDeps[result.deps[d]] = true;
                     } else {
                         diagnostics.error('CONST ASM ' + node.name + ' requires compile-time evaluable value', node.span);
                     }
@@ -6387,9 +6390,11 @@
                 var tokens = Lexer(source).tokenize();
 
                 // #INCLUDE 展開: PreprocInclude トークンをファイル内容のトークンに置換
-                // ネスト #INCLUDE (LIB 内の #INCLUDE) にも対応。同一ファイルは 1 度だけ展開 (循環防止)。
+                // ネスト #INCLUDE (LIB 内の #INCLUDE) にも対応。重複 include は展開する
+                // (同一ファイルが #IF で条件付き/無条件の両方から読まれるケースに対応)。
+                // 循環参照のみ「展開中スタック」で検出して止める。
                 if (virtualFS) {
-                    var includedFiles = {};
+                    var includeStack = {};
                     function expandTokens(inputTokens) {
                         var out = [];
                         for (var ti = 0; ti < inputTokens.length; ti++) {
@@ -6399,8 +6404,10 @@
                             }
                             var incPath = inputTokens[ti].value || inputTokens[ti].text;
                             var incPathUpper = incPath.toUpperCase();
-                            if (includedFiles[incPathUpper]) continue; // 重複/循環を抑止
-                            includedFiles[incPathUpper] = true;
+                            if (includeStack[incPathUpper]) {
+                                diagnostics.warning('Circular #INCLUDE skipped: ' + incPath);
+                                continue;
+                            }
                             // virtualFS からファイル内容を取得（大文字小文字非依存）
                             var incContent = null;
                             for (var vk in virtualFS) {
@@ -6418,7 +6425,9 @@
                             for (var iti = 0; iti < incTokens.length; iti++) {
                                 if (incTokens[iti].kind !== TK.EOF) nonEof.push(incTokens[iti]);
                             }
+                            includeStack[incPathUpper] = true;
                             var subExpanded = expandTokens(nonEof);
+                            includeStack[incPathUpper] = false;
                             for (var ei = 0; ei < subExpanded.length; ei++) out.push(subExpanded[ei]);
                         }
                         return out;

--- a/html/x1pen_slang_compiler.js
+++ b/html/x1pen_slang_compiler.js
@@ -809,6 +809,350 @@
     }
 
     // ================================================================
+    // Preprocessor expression evaluator (shared by runPreprocessor and Parser)
+    //
+    // #IF 式を評価する。defs は { NAME: intValue } 形式 (キーは大文字化済み)。
+    // 未定義の identifier は 0 として扱う (旧 SLANG 互換)。
+    // 評価失敗時は null を返す (呼び出し側は false としてフォールバック)。
+    // ================================================================
+    function evalPreprocExpr(expr, defs) {
+        defs = defs || {};
+        // Substitute defined constants and keywords
+        var s = expr.replace(/[A-Za-z_][A-Za-z0-9_]*/g, function(name) {
+            var up = name.toUpperCase();
+            if (up === 'TRUE') return '1';
+            if (up === 'FALSE') return '0';
+            if (up === 'AND') return '&';
+            if (up === 'OR') return '|';
+            if (up === 'NOT') return '!';
+            if (up in defs) return String(defs[up]);
+            return '0';
+        });
+        s = s.trim();
+        try {
+            var tokens = [];
+            var i = 0;
+            while (i < s.length) {
+                if (s[i] === ' ' || s[i] === '\t') { i++; continue; }
+                if (s[i] === '(') { tokens.push({ t: '(' }); i++; continue; }
+                if (s[i] === ')') { tokens.push({ t: ')' }); i++; continue; }
+                if (s[i] === '<' && s[i+1] === '=') { tokens.push({ t: '<=' }); i+=2; continue; }
+                if (s[i] === '>' && s[i+1] === '=') { tokens.push({ t: '>=' }); i+=2; continue; }
+                if (s[i] === '=' && s[i+1] === '=') { tokens.push({ t: '==' }); i+=2; continue; }
+                if (s[i] === '!' && s[i+1] === '=') { tokens.push({ t: '!=' }); i+=2; continue; }
+                if (s[i] === '<') { tokens.push({ t: '<' }); i++; continue; }
+                if (s[i] === '>') { tokens.push({ t: '>' }); i++; continue; }
+                if (s[i] === '=') { tokens.push({ t: '==' }); i++; continue; }
+                if (s[i] === '+') { tokens.push({ t: '+' }); i++; continue; }
+                if (s[i] === '-') { tokens.push({ t: '-' }); i++; continue; }
+                if (s[i] === '*') { tokens.push({ t: '*' }); i++; continue; }
+                if (s[i] === '/') { tokens.push({ t: '/' }); i++; continue; }
+                if (s[i] === '&') { tokens.push({ t: '&' }); i++; continue; }
+                if (s[i] === '|') { tokens.push({ t: '|' }); i++; continue; }
+                if (s[i] === '!') { tokens.push({ t: '!' }); i++; continue; }
+                if (s[i] === '$') {
+                    i++;
+                    var hs = '';
+                    while (i < s.length && /[0-9A-Fa-f]/.test(s[i])) hs += s[i++];
+                    tokens.push({ t: 'num', v: parseInt(hs, 16) || 0 });
+                    continue;
+                }
+                if (/[0-9]/.test(s[i])) {
+                    var ns = '';
+                    while (i < s.length && /[0-9]/.test(s[i])) ns += s[i++];
+                    tokens.push({ t: 'num', v: parseInt(ns, 10) });
+                    continue;
+                }
+                if (/[A-Za-z_]/.test(s[i])) {
+                    while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
+                    tokens.push({ t: 'num', v: 0 });
+                    continue;
+                }
+                return null;
+            }
+            var tp = 0;
+            function peek2() { return tp < tokens.length ? tokens[tp] : null; }
+            function next() { return tokens[tp++]; }
+            function parseOr() {
+                var v = parseAnd();
+                while (peek2() && peek2().t === '|') { next(); v = (v | parseAnd()); }
+                return v;
+            }
+            function parseAnd() {
+                var v = parseComp();
+                while (peek2() && peek2().t === '&') { next(); v = (v & parseComp()); }
+                return v;
+            }
+            function parseComp() {
+                var v = parseAdd();
+                while (peek2() && (peek2().t === '<=' || peek2().t === '>=' || peek2().t === '<' || peek2().t === '>' || peek2().t === '==' || peek2().t === '!=')) {
+                    var op = next().t;
+                    var r = parseAdd();
+                    if (op === '<=') v = (v <= r) ? 1 : 0;
+                    else if (op === '>=') v = (v >= r) ? 1 : 0;
+                    else if (op === '<') v = (v < r) ? 1 : 0;
+                    else if (op === '>') v = (v > r) ? 1 : 0;
+                    else if (op === '==') v = (v === r) ? 1 : 0;
+                    else if (op === '!=') v = (v !== r) ? 1 : 0;
+                }
+                return v;
+            }
+            function parseAdd() {
+                var v = parseMul();
+                while (peek2() && (peek2().t === '+' || peek2().t === '-')) {
+                    var op = next().t;
+                    v = op === '+' ? v + parseMul() : v - parseMul();
+                }
+                return v;
+            }
+            function parseMul() {
+                var v = parseUnary();
+                while (peek2() && (peek2().t === '*' || peek2().t === '/')) {
+                    var op = next().t;
+                    var r = parseUnary();
+                    v = op === '*' ? v * r : (r !== 0 ? Math.floor(v / r) : 0);
+                }
+                return v;
+            }
+            function parseUnary() {
+                if (peek2() && peek2().t === '!') { next(); return parseUnary() ? 0 : 1; }
+                if (peek2() && peek2().t === '-') { next(); return -parseUnary(); }
+                return parsePrimary();
+            }
+            function parsePrimary() {
+                var tok = peek2();
+                if (!tok) return 0;
+                if (tok.t === 'num') { next(); return tok.v; }
+                if (tok.t === '(') { next(); var v = parseOr(); if (peek2() && peek2().t === ')') next(); return v; }
+                return 0;
+            }
+            return parseOr();
+        } catch (e) { return null; }
+    }
+
+    // ================================================================
+    // runPreprocessor
+    //
+    // #IF / #ELSE / #ENDIF / #INCLUDE を 1 パスで評価して展開済みトークン列を返す。
+    // 返り値は { tokens, preprocDefs } 固定。
+    //
+    // 設計上の要点:
+    //  - #IF の collect 中は #MODULE / #END の opener stack も併走させる
+    //    (Lexer 上 #END と #ENDIF が同じ TK.PreprocEnd に畳まれるため、
+    //     MODULE 用 #END を outer #IF の終端と誤認しないようにする)。
+    //  - include キーは virtualFS 上で実際に解決できたキー (vk) を canonical として採用。
+    //    basename 衝突 (foo/X.LIB と bar/X.LIB) を避ける。
+    //  - 重複 include は silent skip。循環 include は warning + skip。
+    //  - CONST A=1, ASM B=2, C=3; のように宣言子ごとに ASM フラグが付くので、
+    //    block-depth を見ながら宣言子単位で preprocDefs を更新する。
+    // ================================================================
+    function runPreprocessor(initTokens, virtualFS, envDefines, diagnostics) {
+        var preprocDefs = {};
+        if (envDefines) {
+            for (var k in envDefines) {
+                if (Object.prototype.hasOwnProperty.call(envDefines, k)) {
+                    preprocDefs[k.toUpperCase()] = envDefines[k];
+                }
+            }
+        }
+
+        var includedSet = {};
+        var includeStack = {};
+
+        function isBlockOpenKind(k) {
+            return k === TK.LBracket || k === TK.LBrace || k === TK.LAngleBracket || k === TK.Begin;
+        }
+        function isBlockCloseKind(k) {
+            return k === TK.RBracket || k === TK.RBrace || k === TK.RAngleBracket || k === TK.End;
+        }
+
+        // Scan past a single CONST declarator (honoring block depth).
+        // `i` points to the first token after `=` (or wherever we ran into
+        // a non-integer value). Returns the index where the declarator ends:
+        // the position of Comma / Semicolon at depth 0, or the length.
+        function skipDeclarator(tokens, i) {
+            var depth = 0;
+            while (i < tokens.length) {
+                var kk = tokens[i].kind;
+                if (depth === 0 && (kk === TK.Comma || kk === TK.Semicolon)) return i;
+                if (isBlockOpenKind(kk)) depth++;
+                else if (isBlockCloseKind(kk)) depth = depth > 0 ? depth - 1 : 0;
+                i++;
+            }
+            return i;
+        }
+
+        // tokens[constIndex] is TK.Const. Walk declarators and update preprocDefs.
+        // Only `NAME = <IntegerLiteral>` pairs (without the per-declarator ASM
+        // modifier) are registered; everything else is skipped declarator-wise.
+        function extractConstValues(tokens, constIndex) {
+            var i = constIndex + 1;
+            while (i < tokens.length) {
+                var isAsm = false;
+                if (tokens[i] && tokens[i].kind === TK.Asm) { isAsm = true; i++; }
+                var nameTok = tokens[i];
+                var eqTok = tokens[i + 1];
+                var valTok = tokens[i + 2];
+                var afterTok = tokens[i + 3];
+                if (nameTok && nameTok.kind === TK.Identifier &&
+                    eqTok && eqTok.kind === TK.Eq &&
+                    valTok && valTok.kind === TK.IntegerLiteral &&
+                    afterTok && (afterTok.kind === TK.Comma || afterTok.kind === TK.Semicolon)) {
+                    if (!isAsm) {
+                        preprocDefs[nameTok.stringValue.toUpperCase()] = valTok.value;
+                    }
+                    i += 3;
+                } else {
+                    // Non-integer value (expr, code block, identifier ref, etc.) -
+                    // skip just this declarator.
+                    if (!nameTok || nameTok.kind === TK.Semicolon || nameTok.kind === TK.EOF) break;
+                    // Step over "NAME =" if present, then skipDeclarator
+                    if (nameTok.kind === TK.Identifier && eqTok && eqTok.kind === TK.Eq) i += 2;
+                    i = skipDeclarator(tokens, i);
+                }
+                if (i >= tokens.length) break;
+                if (tokens[i].kind === TK.Comma) { i++; continue; }
+                if (tokens[i].kind === TK.Semicolon) break;
+                break;
+            }
+        }
+
+        // Return the virtualFS key that resolves `specifier`, or null.
+        function resolveIncludeKey(specifier) {
+            if (!virtualFS) return null;
+            var up = specifier.toUpperCase();
+            // First pass: exact match (case-insensitive)
+            for (var vk in virtualFS) {
+                if (Object.prototype.hasOwnProperty.call(virtualFS, vk) &&
+                    vk.toUpperCase() === up) return vk;
+            }
+            // Second pass: basename match
+            for (var vk2 in virtualFS) {
+                if (Object.prototype.hasOwnProperty.call(virtualFS, vk2) &&
+                    vk2.toUpperCase().replace(/.*[\/\\]/, '') === up) return vk2;
+            }
+            return null;
+        }
+
+        function processInclude(token, out) {
+            var specifier = token.value || token.stringValue || token.text;
+            var resolved = resolveIncludeKey(specifier);
+            if (resolved === null) {
+                diagnostics.warning('#INCLUDE file not found: ' + specifier, token.span);
+                return;
+            }
+            var canonical = resolved.toUpperCase();
+            if (includeStack[canonical]) {
+                diagnostics.warning('Circular #INCLUDE skipped: ' + specifier, token.span);
+                return;
+            }
+            if (includedSet[canonical]) {
+                // silent skip (方針 B: guard 不要の安全な重複排除)
+                return;
+            }
+            var content = virtualFS[resolved];
+            if (typeof content !== 'string') {
+                diagnostics.warning('#INCLUDE file not found: ' + specifier, token.span);
+                return;
+            }
+            var incTokens = Lexer(content, specifier).tokenize();
+            var nonEof = [];
+            for (var ti = 0; ti < incTokens.length; ti++) {
+                if (incTokens[ti].kind !== TK.EOF) nonEof.push(incTokens[ti]);
+            }
+            includeStack[canonical] = true;
+            var expanded = process(nonEof);
+            includeStack[canonical] = false;
+            for (var ei = 0; ei < expanded.length; ei++) out.push(expanded[ei]);
+            includedSet[canonical] = true;
+        }
+
+        // Consume #IF ... #END and push the resulting tokens (after recursive
+        // preprocessing) to `out`. Returns the index just past the closing #END.
+        // Uses an opener stack so that `#MODULE ... #END` inside the branch
+        // doesn't prematurely close the outer #IF.
+        function processIf(tokens, start, out) {
+            var ifToken = tokens[start];
+            var condVal = evalPreprocExpr(ifToken.stringValue || '', preprocDefs);
+            var condTrue = (condVal === null) ? false : (condVal !== 0);
+
+            var collectTrue = [];
+            var collectFalse = [];
+            var target = collectTrue;
+            var stack = ['if'];
+            var i = start + 1;
+
+            while (i < tokens.length && stack.length > 0) {
+                var t = tokens[i];
+                var kind = t.kind;
+                if (kind === TK.PreprocIf) {
+                    stack.push('if');
+                    target.push(t);
+                    i++;
+                } else if (kind === TK.Module) {
+                    stack.push('module');
+                    target.push(t);
+                    i++;
+                } else if (kind === TK.PreprocEnd) {
+                    var top = stack.pop();
+                    if (stack.length === 0 && top === 'if') {
+                        i++;
+                        break;
+                    }
+                    target.push(t);
+                    i++;
+                } else if (kind === TK.PreprocElse && stack.length === 1 && stack[0] === 'if') {
+                    target = collectFalse;
+                    i++;
+                } else {
+                    target.push(t);
+                    i++;
+                }
+            }
+
+            if (stack.length > 0) {
+                diagnostics.error('Unterminated #IF', ifToken.span);
+            }
+
+            var collected = condTrue ? collectTrue : collectFalse;
+            var processed = process(collected);
+            for (var ei = 0; ei < processed.length; ei++) out.push(processed[ei]);
+            return i;
+        }
+
+        function process(tokens) {
+            var out = [];
+            var i = 0;
+            while (i < tokens.length) {
+                var t = tokens[i];
+                var kind = t.kind;
+                if (kind === TK.PreprocInclude) {
+                    processInclude(t, out);
+                    i++;
+                } else if (kind === TK.PreprocIf) {
+                    i = processIf(tokens, i, out);
+                } else if (kind === TK.PreprocElse || kind === TK.PreprocEnd) {
+                    // Stray #ELSE/#END (unpaired) — pass through to Parser.
+                    // #MODULE ... #END relies on #END reaching parseModuleBlock,
+                    // so we must not silently drop it here.
+                    out.push(t);
+                    i++;
+                } else if (kind === TK.Const) {
+                    extractConstValues(tokens, i);
+                    out.push(t);
+                    i++;
+                } else {
+                    out.push(t);
+                    i++;
+                }
+            }
+            return out;
+        }
+
+        return { tokens: process(initTokens), preprocDefs: preprocDefs };
+    }
+
+    // ================================================================
     // Parser
     // ================================================================
 
@@ -877,132 +1221,12 @@
             }
         }
 
-        // ---- Preprocessor (in-parser, simplified) ----
-        function evalPreprocExpr(expr) {
-            // Substitute defined constants and keywords
-            // Undefined identifiers become 0 (matching SLANG compiler behavior)
-            var s = expr.replace(/[A-Za-z_][A-Za-z0-9_]*/g, function(name) {
-                var up = name.toUpperCase();
-                if (up === 'TRUE') return '1';
-                if (up === 'FALSE') return '0';
-                if (up === 'AND') return '&';
-                if (up === 'OR') return '|';
-                if (up === 'NOT') return '!';
-                if (up in _preprocDefs) return String(_preprocDefs[up]);
-                return '0';
-            });
-            // Remove surrounding parens for simpler eval
-            s = s.trim();
-            // Simple expression evaluator for #IF conditions
-            try {
-                // Tokenize: numbers, identifiers, operators
-                var tokens = [];
-                var i = 0;
-                while (i < s.length) {
-                    if (s[i] === ' ' || s[i] === '\t') { i++; continue; }
-                    if (s[i] === '(') { tokens.push({ t: '(' }); i++; continue; }
-                    if (s[i] === ')') { tokens.push({ t: ')' }); i++; continue; }
-                    if (s[i] === '<' && s[i+1] === '=') { tokens.push({ t: '<=' }); i+=2; continue; }
-                    if (s[i] === '>' && s[i+1] === '=') { tokens.push({ t: '>=' }); i+=2; continue; }
-                    if (s[i] === '=' && s[i+1] === '=') { tokens.push({ t: '==' }); i+=2; continue; }
-                    if (s[i] === '!' && s[i+1] === '=') { tokens.push({ t: '!=' }); i+=2; continue; }
-                    if (s[i] === '<') { tokens.push({ t: '<' }); i++; continue; }
-                    if (s[i] === '>') { tokens.push({ t: '>' }); i++; continue; }
-                    if (s[i] === '=') { tokens.push({ t: '==' }); i++; continue; }
-                    if (s[i] === '+') { tokens.push({ t: '+' }); i++; continue; }
-                    if (s[i] === '-') { tokens.push({ t: '-' }); i++; continue; }
-                    if (s[i] === '*') { tokens.push({ t: '*' }); i++; continue; }
-                    if (s[i] === '/') { tokens.push({ t: '/' }); i++; continue; }
-                    if (s[i] === '&') { tokens.push({ t: '&' }); i++; continue; }
-                    if (s[i] === '|') { tokens.push({ t: '|' }); i++; continue; }
-                    if (s[i] === '!') { tokens.push({ t: '!' }); i++; continue; }
-                    if (s[i] === '$') {
-                        i++;
-                        var hs = '';
-                        while (i < s.length && /[0-9A-Fa-f]/.test(s[i])) hs += s[i++];
-                        tokens.push({ t: 'num', v: parseInt(hs, 16) || 0 });
-                        continue;
-                    }
-                    if (/[0-9]/.test(s[i])) {
-                        var ns = '';
-                        while (i < s.length && /[0-9]/.test(s[i])) ns += s[i++];
-                        tokens.push({ t: 'num', v: parseInt(ns, 10) });
-                        continue;
-                    }
-                    // Identifier (residual after substitution) — treat as 0
-                    if (/[A-Za-z_]/.test(s[i])) {
-                        while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
-                        tokens.push({ t: 'num', v: 0 });
-                        continue;
-                    }
-                    // Unknown char — bail
-                    return null;
-                }
-                // Recursive descent parser
-                var tp = 0;
-                function peek2() { return tp < tokens.length ? tokens[tp] : null; }
-                function next() { return tokens[tp++]; }
-                function parseOr() {
-                    var v = parseAnd();
-                    while (peek2() && peek2().t === '|') { next(); v = (v | parseAnd()); }
-                    return v;
-                }
-                function parseAnd() {
-                    var v = parseComp();
-                    while (peek2() && peek2().t === '&') { next(); v = (v & parseComp()); }
-                    return v;
-                }
-                function parseComp() {
-                    var v = parseAdd();
-                    while (peek2() && (peek2().t === '<=' || peek2().t === '>=' || peek2().t === '<' || peek2().t === '>' || peek2().t === '==' || peek2().t === '!=')) {
-                        var op = next().t;
-                        var r = parseAdd();
-                        if (op === '<=') v = (v <= r) ? 1 : 0;
-                        else if (op === '>=') v = (v >= r) ? 1 : 0;
-                        else if (op === '<') v = (v < r) ? 1 : 0;
-                        else if (op === '>') v = (v > r) ? 1 : 0;
-                        else if (op === '==') v = (v === r) ? 1 : 0;
-                        else if (op === '!=') v = (v !== r) ? 1 : 0;
-                    }
-                    return v;
-                }
-                function parseAdd() {
-                    var v = parseMul();
-                    while (peek2() && (peek2().t === '+' || peek2().t === '-')) {
-                        var op = next().t;
-                        v = op === '+' ? v + parseMul() : v - parseMul();
-                    }
-                    return v;
-                }
-                function parseMul() {
-                    var v = parseUnary();
-                    while (peek2() && (peek2().t === '*' || peek2().t === '/')) {
-                        var op = next().t;
-                        var r = parseUnary();
-                        v = op === '*' ? v * r : (r !== 0 ? Math.floor(v / r) : 0);
-                    }
-                    return v;
-                }
-                function parseUnary() {
-                    if (peek2() && peek2().t === '!') { next(); return parseUnary() ? 0 : 1; }
-                    if (peek2() && peek2().t === '-') { next(); return -parseUnary(); }
-                    return parsePrimary();
-                }
-                function parsePrimary() {
-                    var tok = peek2();
-                    if (!tok) return 0;
-                    if (tok.t === 'num') { next(); return tok.v; }
-                    if (tok.t === '(') { next(); var v = parseOr(); if (peek2() && peek2().t === ')') next(); return v; }
-                    return 0; // unknown — treat as 0
-                }
-                var result = parseOr();
-                return result;
-            } catch (e) { return null; }
-        }
+        // ---- Preprocessor (in-parser, 保険: Preprocessor が取りこぼした場合のみ発動) ----
+        // 式評価は IIFE 直下の共通 evalPreprocExpr(expr, defs) を使用。
         function parsePreprocIf() {
             var t = advance();
             var expr = t.stringValue;
-            var val = evalPreprocExpr(expr);
+            var val = evalPreprocExpr(expr, _preprocDefs);
             // If evaluation failed (parse error), default to false (exclude the block)
             var condTrue = (val === null) ? false : (val !== 0);
             if (!condTrue) {
@@ -1069,8 +1293,9 @@
                 else { value = parseNcExpr(); }
                 decls.push(AST.ConstDecl(name, value, isAsm, start));
                 // Register integer constants for #IF preprocessor evaluation
-                if (value && value.type === 'IntegerLiteral' && name) {
-                    _preprocDefs[name] = value.value;
+                // (Preprocessor 側も同じ規則で大文字化キーで登録するため、drift を避けるため揃える)
+                if (value && value.type === 'IntegerLiteral' && name && !isAsm) {
+                    _preprocDefs[name.toUpperCase()] = value.value;
                 }
             } while (match(TK.Comma));
             match(TK.Semicolon);
@@ -6388,55 +6613,13 @@
             var diagnostics = DiagnosticBag();
             try {
                 var tokens = Lexer(source).tokenize();
-
-                // #INCLUDE 展開: PreprocInclude トークンをファイル内容のトークンに置換
-                // ネスト #INCLUDE (LIB 内の #INCLUDE) にも対応。重複 include は展開する
-                // (同一ファイルが #IF で条件付き/無条件の両方から読まれるケースに対応)。
-                // 循環参照のみ「展開中スタック」で検出して止める。
-                if (virtualFS) {
-                    var includeStack = {};
-                    function expandTokens(inputTokens) {
-                        var out = [];
-                        for (var ti = 0; ti < inputTokens.length; ti++) {
-                            if (inputTokens[ti].kind !== TK.PreprocInclude) {
-                                out.push(inputTokens[ti]);
-                                continue;
-                            }
-                            var incPath = inputTokens[ti].value || inputTokens[ti].text;
-                            var incPathUpper = incPath.toUpperCase();
-                            if (includeStack[incPathUpper]) {
-                                diagnostics.warning('Circular #INCLUDE skipped: ' + incPath);
-                                continue;
-                            }
-                            // virtualFS からファイル内容を取得（大文字小文字非依存）
-                            var incContent = null;
-                            for (var vk in virtualFS) {
-                                if (vk.toUpperCase() === incPathUpper || vk.toUpperCase().replace(/.*[\/\\]/, '') === incPathUpper) {
-                                    incContent = typeof virtualFS[vk] === 'string' ? virtualFS[vk] : null;
-                                    break;
-                                }
-                            }
-                            if (!incContent) {
-                                diagnostics.warning('#INCLUDE file not found: ' + incPath);
-                                continue;
-                            }
-                            var incTokens = Lexer(incContent, incPath).tokenize();
-                            var nonEof = [];
-                            for (var iti = 0; iti < incTokens.length; iti++) {
-                                if (incTokens[iti].kind !== TK.EOF) nonEof.push(incTokens[iti]);
-                            }
-                            includeStack[incPathUpper] = true;
-                            var subExpanded = expandTokens(nonEof);
-                            includeStack[incPathUpper] = false;
-                            for (var ei = 0; ei < subExpanded.length; ei++) out.push(subExpanded[ei]);
-                        }
-                        return out;
-                    }
-                    tokens = expandTokens(tokens);
-                }
-
                 var envConfig = env || {};
-                var preprocDefs = envConfig.defines || {};
+
+                // プリプロセッサ: #IF / #ELSE / #ENDIF / #INCLUDE を 1 パスで評価・展開。
+                // 戻り値の preprocDefs は env.defines + active branch で通過した CONST から抽出。
+                var pp = runPreprocessor(tokens, virtualFS || null, envConfig.defines || {}, diagnostics);
+                tokens = pp.tokens;
+                var preprocDefs = pp.preprocDefs;
                 var parser = Parser(tokens, diagnostics, preprocDefs);
                 var ast = parser.parseCompilationUnit();
                 if (diagnostics.hasErrors) return { asm: '', errors: diagnostics.diagnostics };


### PR DESCRIPTION
## Summary

- SLANG-compiler 6147192 → c9e8f53 の同期
- X1 グラフィックライブラリ群 (TILELIB/SPRLIB/CHIPLIB/TILESPR/UILIB) を取り込み、ネスト `#INCLUDE` 対応
- `CONST ASM NAME = expr;` を EQU 出力に対応 (CHIPLIB が使用)
- ランタイム: `libx1_print.asm` の WIDTH 刷新 (LSX CRTCD 16-byte LDIR、_HEIGHT=25)、`libx1_pcg.asm` に `PCGDEFS` 追加

## 変更詳細

### runtime
- `libx1_print.asm`: WIDTH 関数を LSX-Dodgers の CRTCD 領域 (LSX_base+$B0, 16 byte) へ LDIR する方式に変更。個別 EQU (LSX_PAGE_MINUS / LSX_WIDTH / LSX_WIDTH_MINUS) は不要に。末尾で LSX `_HEIGHT` を 25 に書き換えて 25 行を使い切る。
- `libx1_pcg.asm`: `PCGDEFS` (STARTIDX, ADDR, COUNT) を追加。連続した PCG パターンを一括登録できる。

### include
- `CHIPLIB.LIB` / `SPRLIB.LIB` / `TILELIB.LIB` / `TILESPR.LIB` / `UILIB.LIB` を `assets/slang_include/` に配置
- `html/x1pen.js` の `includeFiles` に 5 本を追加
- UILIB は charset1 変換済みフォントデータを内蔵 (ひらがなは CLI 版の tools/png_to_asm.py で差し替え可能)

### compiler (html/x1pen_slang_compiler.js)
- `visitConstDecl` に `isAsmEqu` 分岐を追加 (C# IrGenerator.cs @ 5676d28 と同等)。`CONST ASM NAME = expr;` を `NAME EQU $xxxx` として InlineAsm emit。
- `#INCLUDE` 展開を再帰対応。LIB 内の `#INCLUDE` も再帰的に展開する (TILESPR → TILELIB + SPRLIB のような構造に対応)。同一ファイルの重複/循環は 1 回のみ展開に抑止。
- SHA コメント `6147192` → `c9e8f53`

## 影響なしと判断した upstream 変更

- `libsos_base.asm` / `libsosx1_base.asm` / `sosx1.env` (sos 環境機種非依存化): X1Pen は `ENV_TYPE=1` (LSX) 固定
- `liblsx_print.asm` の PCHR NUL 抑制: X1Pen のランタイムに当該ファイルは含まれていない
- `examples/*` / `tools/*` / `assets/ui/*`: CLI 版のサンプル/ツール/UILIB アセット (X1Pen は UILIB.LIB 単体で独立)

## Test plan

- [x] JS コンパイラ構文チェック通過
- [x] X1GRP.SL の差分はランタイム変更分 (WIDTH 刷新) のみ、コンパイラロジックは保持
- [x] 内蔵 Z80 アセンブラで X1GRP.ASM をアセンブル成功
- [x] CHIPTEST.SL / SPRTEST.SL / TILETEST.SL / TILSPRTEST.SL / UITEST.SL (+strings.sl) が全てコンパイル成功
- [x] `CONST ASM _CHIP_VVRAMW_MAX = 42` → `_CHIP_VVRAMW_MAX EQU $002A` を確認
- [x] TILESPR.LIB のネスト #INCLUDE が TILELIB/SPRLIB を正しく展開 (`CALL TileAnimTick` + 本体ラベル出力)
- [x] ブラウザ (dist) で TILELIB 使用プログラムの動作確認済み
- [x] 念のため実機/エミュで X1GRP / 既存 SLANG 例の回帰なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)