### PR TITLE
fix: suppress OS key auto-repeat, unify with X1 sub CPU repeat

### DIFF
--- a/platform/platform_input.cpp
+++ b/platform/platform_input.cpp
@@ -168,6 +168,9 @@ static EM_BOOL keyboard_callback(int eventType, const EmscriptenKeyboardEvent* e
     }
 
     if (eventType == EMSCRIPTEN_EVENT_KEYDOWN) {
+        // OS のキーオートリピートは捨てる。X1 サブ CPU 内蔵のリピート機能に
+        // 一本化することで、両者の二重リピートで keyque が飽和する問題を回避する。
+        if (e->repeat) return TRUE;
         winkeydown106((WPARAM)vk, 0);
     } else if (eventType == EMSCRIPTEN_EVENT_KEYUP) {
         winkeyup106((WPARAM)vk, 0);


### PR DESCRIPTION
## Summary

X1 エミュレータでキーを押したときに、ブラウザ/OS の auto-repeat で生成される複数の `keydown` イベントがそのまま `winkeydown106` に渡され、さらに X1 サブ CPU エミュレータが内蔵するキーリピート機能と二重に動くことで、`scpu.keyque` (7 エントリ) が飽和し、キーを離しても入力が続く症状が出ていた。特に SLANG の CHIPLIB/SPRLIB 等フレームレートが落ちやすいコードで顕在化。

修正は `platform/platform_input.cpp` の `keyboard_callback` で `e->repeat` フラグ付きの `keydown` を捨てるだけ。実機の挙動 (物理的に押し続けている間は X1 サブ CPU 側のリピートがキーコードを発行) に一本化される。

## 変更内容

- `platform/platform_input.cpp`: `EMSCRIPTEN_EVENT_KEYDOWN` で `e->repeat` の場合 `return TRUE` して `winkeydown106` を呼ばない。soft keyboard (`skKeyDown`) は元々 1 回ずつしか呼ばれないので影響なし。

## Test plan

- [x] 1 キー押下で通常の文字入力が動くこと
- [x] キー押しっぱなしで文字がリピート入力されること (X1 サブ CPU のリピート)
- [x] 重い SLANG プログラム (CHIPTEST 等) を動かしてキーを押しっぱなしにし、離したあとに入力が続かないこと
- [x] soft keyboard (画面キーボード) で連打/長押しの挙動が変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)