### PR TITLE
fix: JoyKeyモード時に自動実行の改行(Enter)が届かない問題を修正

### DIFF
--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -502,23 +502,80 @@ window.__X1PEN_MODE = true;
     }
 
     // ── キー注入 ──
+    // JoyKey では Enter が keyboard_inkey で落ちるため、合成キー送信中だけ実機 KEY_MODE を KB にする。
+    // 永続設定(localStorage)は触らない。重なった送信は参照カウントで全完了まで KB を維持する。
+
+    var syntheticKeyDepth = 0;
+    var syntheticKeyRestoreMode = null;
+
+    function enterSyntheticKeyboardMode(prevMode) {
+        if (!module || !module._js_set_key_mode || prevMode === 0) return false;
+        if (syntheticKeyDepth === 0) {
+            try {
+                module._js_set_key_mode(0);
+            } catch (e) {
+                return false;  // 切替失敗時は depth を増やさない
+            }
+            syntheticKeyRestoreMode = prevMode;
+        }
+        syntheticKeyDepth++;
+        return true;
+    }
+
+    function leaveSyntheticKeyboardMode(switched) {
+        if (!switched) return;
+        syntheticKeyDepth = Math.max(0, syntheticKeyDepth - 1);
+        if (syntheticKeyDepth === 0) {
+            var restoreMode = syntheticKeyRestoreMode;
+            syntheticKeyRestoreMode = null;
+            if (module && module._js_set_key_mode && restoreMode !== null) {
+                module._js_set_key_mode(restoreMode);
+            }
+        }
+    }
 
     function simulateKeys(keys, interval) {
-        var ms = interval || 100;
-        keys.forEach(function(vk, i) {
-            setTimeout(function() {
-                module._js_key_down(vk);
-                setTimeout(function() { module._js_key_up(vk); }, 80);
-            }, i * ms);
+        var ms = (interval === undefined) ? 100 : interval;
+        if (!keys || keys.length === 0) return Promise.resolve();
+
+        var prevMode = 0;
+        try {
+            if (window.XmilControls && window.XmilControls.getSettings) {
+                prevMode = window.XmilControls.getSettings().keyMode || 0;
+            }
+        } catch (e) {}
+
+        var switched = enterSyntheticKeyboardMode(prevMode);
+
+        return new Promise(function(resolve) {
+            keys.forEach(function(vk, i) {
+                var last = (i === keys.length - 1);
+                setTimeout(function() {
+                    try { module._js_key_down(vk); } catch (e) {}
+                    setTimeout(function() {
+                        try {
+                            module._js_key_up(vk);
+                        } finally {
+                            if (last) {
+                                try {
+                                    leaveSyntheticKeyboardMode(switched);
+                                } finally {
+                                    resolve();
+                                }
+                            }
+                        }
+                    }, 80);
+                }, i * ms);
+            });
         });
     }
 
     function simulateRunCommand() {
-        simulateKeys([0x52, 0x55, 0x4E, 0x0D], 100);  // R, U, N, Enter
+        return simulateKeys([0x52, 0x55, 0x4E, 0x0D], 100);  // R, U, N, Enter
     }
 
     function simulateProgCommand() {
-        simulateKeys([0x50, 0x52, 0x4F, 0x47, 0x0D], 50);  // P, R, O, G, Enter
+        return simulateKeys([0x50, 0x52, 0x4F, 0x47, 0x0D], 50);  // P, R, O, G, Enter
     }
 
     // ── RUN ──


### PR DESCRIPTION
## 背景・問題

X1Pen の Share リンク（`?id=xxx`）自動実行や通常の Run ボタンは、最後にキー注入で改行（Enter）を送って RUN/PROG コマンドを確定させている。しかし `KEY_MODE` が **JoyKeyモード(Joy1/Joy2)** のままだと、Enter（VK 0x0D → スキャンコード 0x1C）が `keyboard_inkey()`（`src/Input.cpp:411-413`）の `joykeyhook` フィルタで捨てられ、**コマンドが確定せずプログラムが走らない**。

`KEY_MODE` は localStorage に永続化され起動時に復元されるため、過去に Joy1/Joy2 を選んでいると Share リンクを開いても Joy モードのまま自動実行が走り不発になる。R/U/N/P/O/G の英字キーはフック対象外なので通るが、確定の Enter だけが落ちるのが原因。

## 修正内容

`html/x1pen.js` の `simulateKeys` に、**合成キー送信中だけ実機 `KEY_MODE` を一時的に KB(0) へ切替え、送信完了後に元のモードへ復帰**する処理を追加。

- **localStorage は非変更**：`module._js_set_key_mode()` の直叩きのみ。ユーザーの永続モード設定は保持。
- **参照カウント方式**（`syntheticKeyDepth`）：Run 連打や自動実行中の手動 Run で送信が重なっても、全送信完了まで KB を維持し、最後の完了でのみ復帰。後発が先に完了して先発の Enter が落ちる事故を防止。
- **例外安全**：enter の切替失敗時は depth を増やさず、leave/resolve は try/finally で必ず到達。
- **エッジケース**：空配列ガード、`interval === undefined ? 100 : interval`（0 許容）。
- 適用範囲は `simulateKeys` 共通のため、Share リンク自動実行と通常 Run ボタンの両方を解消。

C++/WASM の変更は不要（再ビルド不要）。

## 動作確認

`npx wrangler pages dev html` で起動し、Key Mode を Joy1 にした状態で簡単な BASIC（例 `10 PRINT "HELLO":GOTO 10`）を Run／Share リンク経由で実行 → RUN が確定して HELLO が表示され、実行後も Key Mode が Joy1 のままであることを確認。Key Mode = KB(0) では従来どおり動作（切替自体が発生しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)