### PR TITLE
feat: add X1Pen browser automation API

### DIFF
--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -16,6 +16,19 @@ window.__X1PEN_MODE = true;
     var lastAsmSymbols = null;  // { symbols: {}, predefined: {}, sourceMode: string }
     var lastAsmTabOrigin = null; // null | 'user' | 'slang-generated'
 
+    var automationReadyState = 'loading';
+    var automationReadyResolve;
+    var automationReadyReject;
+    var automationReadyPromise = new Promise(function(resolve, reject) {
+        automationReadyResolve = resolve;
+        automationReadyReject = reject;
+    });
+    // The API exposes the rejection to clients; this handler prevents an unhandled rejection
+    // when the page is used normally without an automation client.
+    automationReadyPromise.catch(function() {});
+    var automationOperationQueue = Promise.resolve();
+    var automationPendingOperations = 0;
+
     // ── FuzzyBASIC addrmap ──
 
     var COLD_STATE_VERSION = {
@@ -578,6 +591,12 @@ window.__X1PEN_MODE = true;
         return simulateKeys([0x50, 0x52, 0x4F, 0x47, 0x0D], 50);  // P, R, O, G, Enter
     }
 
+    function inferSourceMode(basicSrc, asmSrc, slangSrc) {
+        if (slangSrc) return 'slang';
+        if (!basicSrc && asmSrc) return 'asm';
+        return 'basic+asm';
+    }
+
     // ── RUN ──
 
     async function onRunClick() {
@@ -592,12 +611,8 @@ window.__X1PEN_MODE = true;
         var sourceMode;
         if (pendingShareRuntime && pendingShareRuntime.sourceMode) {
             sourceMode = pendingShareRuntime.sourceMode;
-        } else if (slangSrc) {
-            sourceMode = 'slang';
-        } else if (!basicSrc && asmSrc) {
-            sourceMode = 'asm';
         } else {
-            sourceMode = 'basic+asm';
+            sourceMode = inferSourceMode(basicSrc, asmSrc, slangSrc);
         }
 
         if (!basicSrc && !asmSrc && !slangSrc) {
@@ -866,7 +881,7 @@ window.__X1PEN_MODE = true;
             var canvas = document.getElementById('canvas');
             if (canvas) canvas.focus();
             await new Promise(function(r) { setTimeout(r, 500); });
-            simulateProgCommand();
+            await simulateProgCommand();
             elStatus.textContent = 'LSX-Dodgers mode';
         } else {
             // FuzzyBASIC モード: BASIC 注入 + RUN キー注入
@@ -883,7 +898,7 @@ window.__X1PEN_MODE = true;
             var canvas = document.getElementById('canvas');
             if (canvas) canvas.focus();
             await new Promise(function(r) { setTimeout(r, 500); });
-            simulateRunCommand();
+            await simulateRunCommand();
         }
         return true;
     }
@@ -1032,6 +1047,128 @@ window.__X1PEN_MODE = true;
             return b.toString(16).padStart(2, '0');
         }).join('');
     }
+
+    // ── Automation API (Playwright / MCP bridge) ──
+
+    function getAutomationProgram() {
+        var basic = basicEditor ? basicEditor.getValue() : '';
+        var asm = asmEditor ? asmEditor.getValue() : '';
+        var slang = slangEditor ? slangEditor.getValue() : '';
+        return {
+            basic: basic,
+            asm: asm,
+            slang: slang,
+            sourceMode: inferSourceMode(basic.trim(), asm.trim(), slang.trim())
+        };
+    }
+
+    function normalizeAutomationProgram(program) {
+        if (!program || typeof program !== 'object' || Array.isArray(program)) {
+            throw new TypeError('program must be an object');
+        }
+
+        var basic = program.basic === undefined ? '' : program.basic;
+        var asm = program.asm === undefined ? '' : program.asm;
+        var slang = program.slang === undefined ? '' : program.slang;
+        if (typeof basic !== 'string' || typeof asm !== 'string' || typeof slang !== 'string') {
+            throw new TypeError('basic, asm and slang must be strings');
+        }
+
+        var sourceMode = program.sourceMode || inferSourceMode(basic.trim(), asm.trim(), slang.trim());
+        if (sourceMode !== 'basic+asm' && sourceMode !== 'asm' && sourceMode !== 'slang') {
+            throw new TypeError('sourceMode must be basic+asm, asm or slang');
+        }
+        if (sourceMode === 'slang' && !slang.trim()) {
+            throw new TypeError('slang source is required for sourceMode slang');
+        }
+        if (sourceMode === 'asm' && !asm.trim()) {
+            throw new TypeError('asm source is required for sourceMode asm');
+        }
+        if (sourceMode === 'basic+asm' && !basic.trim()) {
+            throw new TypeError('basic source is required for sourceMode basic+asm');
+        }
+
+        // A complete program replaces all editor state so stale sources cannot change run mode.
+        if (sourceMode === 'slang') {
+            basic = '';
+            asm = '';
+        } else if (sourceMode === 'asm') {
+            basic = '';
+            slang = '';
+        } else {
+            slang = '';
+        }
+
+        return { basic: basic, asm: asm, slang: slang, sourceMode: sourceMode };
+    }
+
+    function setAutomationProgram(program) {
+        var normalized = normalizeAutomationProgram(program);
+        basicEditor.setValue(normalized.basic, { silent: true });
+        if (asmEditor) asmEditor.setValue(normalized.asm, { silent: true });
+        if (slangEditor) slangEditor.setValue(normalized.slang, { silent: true });
+        lastAsmTabOrigin = normalized.asm ? 'user' : null;
+        pendingShareRuntime = null;
+        lastRunWasShared = false;
+        clearSymbols();
+        forceResyncEditorTab(normalized.sourceMode === 'basic+asm' ? 'basic' : normalized.sourceMode);
+        elStatus.textContent = 'Program loaded';
+        return getAutomationProgram();
+    }
+
+    function getAutomationStatus() {
+        return {
+            ready: automationReadyState === 'ready',
+            state: automationReadyState,
+            busy: automationPendingOperations > 0,
+            status: elStatus ? elStatus.textContent : ''
+        };
+    }
+
+    function queueAutomationOperation(operation) {
+        automationPendingOperations++;
+        var result = automationOperationQueue.then(function() {
+            return automationReadyPromise.then(operation);
+        });
+        automationOperationQueue = result.catch(function() {});
+        return result.then(function(value) {
+            automationPendingOperations--;
+            return value;
+        }, function(error) {
+            automationPendingOperations--;
+            throw error;
+        });
+    }
+
+    window.X1PenAutomation = Object.freeze({
+        version: 1,
+        ready: function() {
+            return automationReadyPromise.then(getAutomationStatus);
+        },
+        getProgram: getAutomationProgram,
+        setProgram: function(program) {
+            return queueAutomationOperation(function() {
+                return setAutomationProgram(program);
+            });
+        },
+        run: function() {
+            return queueAutomationOperation(async function() {
+                var ok = await onRunClick();
+                return {
+                    ok: ok,
+                    status: elStatus ? elStatus.textContent : '',
+                    sourceMode: getAutomationProgram().sourceMode
+                };
+            });
+        },
+        stop: function() {
+            return queueAutomationOperation(function() {
+                onStopClick();
+                return getAutomationStatus();
+            });
+        },
+        getStatus: getAutomationStatus
+    });
 
     function showShareDialog(url) {
         var dialog = document.getElementById('share-dialog');
@@ -1316,6 +1453,8 @@ window.__X1PEN_MODE = true;
                         window.__tabChannel = null;
                     }
                     elStatus.textContent = 'Close other tabs and reload.';
+                    automationReadyState = 'error';
+                    automationReadyReject(new Error(elStatus.textContent));
                     return;
                 }
             }
@@ -1325,6 +1464,8 @@ window.__X1PEN_MODE = true;
         var coldState = await loadRuntimeAsset(COLD_STATE_FILE);
         if (!coldState) {
             elStatus.textContent = 'Failed to load FuzzyBASIC state';
+            automationReadyState = 'error';
+            automationReadyReject(new Error(elStatus.textContent));
             return;
         }
         await loadRuntimeAsset(BOOT_DISK_FILE); // 失敗しても起動は継続
@@ -1351,6 +1492,8 @@ window.__X1PEN_MODE = true;
         // 3. コールドステート復元
         if (!restoreColdState(assetCache[COLD_STATE_FILE])) {
             elStatus.textContent = 'State restore failed';
+            automationReadyState = 'error';
+            automationReadyReject(new Error(elStatus.textContent));
             return;
         }
         // 4. フォントを現セッションに反映
@@ -1364,6 +1507,8 @@ window.__X1PEN_MODE = true;
 
         elBtnRun.disabled = false;
         elStatus.textContent = 'Ready';
+        automationReadyState = 'ready';
+        automationReadyResolve();
 
         // 共有コード読み込み (?id=xxx)
         var urlId = new URLSearchParams(location.search).get('id');

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@codemirror/view": "^6.0.0"
       },
       "devDependencies": {
-        "esbuild": "^0.21.0"
+        "esbuild": "^0.21.0",
+        "playwright": "^1.62.1"
       }
     },
     "node_modules/@codemirror/commands": {
@@ -538,6 +539,53 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/style-mod": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "name": "xmil-web",
   "description": "X millennium Web - SHARP X1 Emulator",
   "devDependencies": {
-    "esbuild": "^0.21.0"
+    "esbuild": "^0.21.0",
+    "playwright": "^1.62.1"
   },
   "dependencies": {
-    "@codemirror/state": "^6.0.0",
-    "@codemirror/view": "^6.0.0",
     "@codemirror/commands": "^6.0.0",
     "@codemirror/language": "^6.0.0",
-    "@codemirror/search": "^6.0.0"
+    "@codemirror/search": "^6.0.0",
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0"
   },
   "scripts": {
-    "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify"
+    "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify",
+    "test:automation": "node --test tests/x1pen_automation_test.mjs"
   }
 }

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+import { after, before, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+const distDir = join(projectRoot, 'dist');
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+};
+
+let server;
+let browser;
+let page;
+let baseUrl;
+
+function startStaticServer() {
+  return new Promise((resolve, reject) => {
+    server = createServer((request, response) => {
+      const pathname = decodeURIComponent(new URL(request.url, 'http://127.0.0.1').pathname);
+      const relativePath = normalize(pathname).replace(/^[/\\]+/, '');
+      const filePath = join(distDir, relativePath || 'index.html');
+      if (!filePath.startsWith(distDir) || !existsSync(filePath) || !statSync(filePath).isFile()) {
+        response.writeHead(404).end('Not found');
+        return;
+      }
+      response.setHeader('Content-Type', mimeTypes[extname(filePath)] || 'application/octet-stream');
+      createReadStream(filePath).pipe(response);
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+}
+
+async function launchChromium() {
+  const executablePath = process.env.X1PEN_BROWSER_EXECUTABLE;
+  if (executablePath) return chromium.launch({ executablePath, headless: true });
+  try {
+    return await chromium.launch({ headless: true });
+  } catch (error) {
+    if (process.platform !== 'darwin') throw error;
+    return chromium.launch({ channel: 'chrome', headless: true });
+  }
+}
+
+before(async () => {
+  assert.ok(existsSync(join(distDir, 'x1pen.html')), 'dist/x1pen.html is missing; run ./build.sh first');
+  await startStaticServer();
+  browser = await launchChromium();
+  const context = await browser.newContext();
+  page = await context.newPage();
+  await page.goto(`${baseUrl}/x1pen.html`);
+}, { timeout: 60_000 });
+
+after(async () => {
+  if (browser) await browser.close();
+  if (server) await new Promise((resolve) => server.close(resolve));
+});
+
+test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async () => {
+  const ready = await page.evaluate(() => window.X1PenAutomation.ready());
+  assert.equal(ready.ready, true);
+  assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 1);
+
+  const program = {
+    sourceMode: 'basic+asm',
+    basic: '10 PRINT "MCP READY"',
+    asm: '',
+    slang: '',
+  };
+  const loaded = await page.evaluate((value) => window.X1PenAutomation.setProgram(value), program);
+  assert.deepEqual(loaded, program);
+
+  await page.evaluate(() => window.XmilControls.setKeyMode(1));
+  const result = await page.evaluate(() => window.X1PenAutomation.run());
+  assert.equal(result.ok, true);
+  assert.equal(result.sourceMode, 'basic+asm');
+
+  await page.waitForTimeout(500);
+  const screenshot = await page.locator('#canvas').screenshot({ type: 'png' });
+  assert.ok(screenshot.length > 1_000, 'canvas screenshot should contain rendered output');
+
+  const settings = await page.evaluate(() => window.XmilControls.getSettings());
+  assert.equal(settings.keyMode, 1, 'automation run must preserve the JoyKey setting');
+});
+
+test('automation operations are serialized and stale source modes are cleared', async () => {
+  const programs = await page.evaluate(async () => {
+    const first = window.X1PenAutomation.setProgram({ sourceMode: 'asm', asm: 'ORG $100\nRET' });
+    const second = window.X1PenAutomation.setProgram({ sourceMode: 'slang', slang: 'main() BEGIN\nEND;' });
+    return { results: await Promise.all([first, second]), final: window.X1PenAutomation.getProgram() };
+  });
+
+  assert.equal(programs.results[0].sourceMode, 'asm');
+  assert.equal(programs.results[1].sourceMode, 'slang');
+  assert.deepEqual(programs.final, {
+    basic: '',
+    asm: '',
+    slang: 'main() BEGIN\nEND;',
+    sourceMode: 'slang',
+  });
+});


### PR DESCRIPTION
## Summary

- expose a versioned `window.X1PenAutomation` API for browser automation
- serialize automated set/run/stop operations and add an explicit WASM readiness promise
- make `run()` wait until synthetic RUN/PROG key injection completes
- add a Playwright integration test covering BASIC execution, JoyKey preservation, canvas capture, and operation serialization

## Test plan

- `./build.sh`
- `npm run test:automation`
- `node tests/z80asm_test.js`
- `node --check html/x1pen.js`

Closes part of #50.
