### PR TITLE
feat: add X1Pen MCP server

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.x1pen]
+command = "node"
+args = ["mcp/x1pen-server.mjs"]
+cwd = "."
+startup_timeout_sec = 30
+tool_timeout_sec = 60

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "x1pen": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["mcp/x1pen-server.mjs"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SHARP X1 シリーズ（X1 / X1turbo / X1turboZ）のエミュレータ「X mill
 - フルスクリーン対応（ダブルクリック）
 - 4096 色モード（turboZ）
 - **[X1Pen](docs/X1PEN.md)** — ブラウザ上で FuzzyBASIC + Z80 アセンブリを書いて即実行できる Web IDE
+- **[X1Pen MCP Server](docs/X1PEN_MCP.md)** — Codex / Claude Code からX1Penをローカル操作
 
 ## 必要な ROM
 

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -1,0 +1,63 @@
+# X1Pen MCP Server
+
+X1Penをローカルのstdio MCPサーバーとして起動し、CodexやClaude Codeからプログラムの編集、検証、実行、画面取得を行えます。ソース、ディスクイメージ、エミュレーション処理はローカル環境内に留まります。
+
+## セットアップ
+
+Node.js 20以降とEmscripten SDKが必要です。
+
+```bash
+npm ci
+./build.sh
+npm run mcp:install-browser
+```
+
+ChromeまたはEdgeが既にインストールされている場合、Playwright同梱Chromiumがなくても自動的にフォールバックします。使用するブラウザーを固定する場合は`X1PEN_BROWSER_EXECUTABLE`に実行ファイルの絶対パスを設定してください。
+
+## Codex
+
+プロジェクトを信頼してCodexをこのリポジトリのルートから起動すると、`.codex/config.toml`の`x1pen`サーバーが利用可能になります。
+
+```bash
+codex mcp list
+```
+
+## Claude Code
+
+リポジトリに含まれる`.mcp.json`がプロジェクトスコープの`x1pen`サーバーを登録します。初回はClaude Code上でプロジェクトMCPサーバーの承認が必要です。
+
+```bash
+claude mcp list
+```
+
+## ツール
+
+| Tool | 内容 |
+|---|---|
+| `x1pen_get_program` | 現在のBASIC、ASM、SLANGソースを取得 |
+| `x1pen_set_program` | プログラム全体を一括設定 |
+| `x1pen_validate` | 実行せずにトークナイズ、コンパイル、アセンブル |
+| `x1pen_run` | 現在のプログラムをビルドして実行 |
+| `x1pen_stop` | ESCを送信して停止 |
+| `x1pen_get_status` | 初期化・処理中・ステータス文字列を取得 |
+| `x1pen_capture_screen` | エミュレーター画面を640x400 PNGで取得 |
+
+`x1pen_set_program`は完全置換です。`sourceMode`で使用しないエディターの内容は消去され、過去のソースが実行モードへ影響することを防ぎます。ブラウザーコンテキストはMCPプロセスごとに分離されるため、通常利用しているX1PenのlocalStorage設定は変更しません。
+
+## 手動起動と診断
+
+stdioサーバーを直接起動する場合は次を実行します。標準出力はMCP通信専用で、診断ログは標準エラーへ出力されます。
+
+```bash
+npm run mcp:x1pen
+```
+
+Automation APIの実ブラウザテストとMCPプロトコルテストは次のとおりです。Automationテストの前に`./build.sh`で`dist/`を更新してください。
+
+```bash
+npm run test:automation
+npm run test:mcp
+npm run test:mcp:e2e
+```
+
+GUI付きブラウザーで調査する場合は`X1PEN_HEADLESS=0`を設定できます。

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -597,6 +597,65 @@ window.__X1PEN_MODE = true;
         return 'basic+asm';
     }
 
+    async function ensureSlangToolchain() {
+        if (!window.X1PenSlangCompiler) {
+            await new Promise(function(resolve, reject) {
+                var s = document.createElement('script');
+                s.src = 'x1pen_slang_compiler.js' + ((XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '');
+                s.onload = resolve;
+                s.onerror = function() { reject(new Error('Failed to load SLANG compiler')); };
+                document.head.appendChild(s);
+            });
+        }
+        if (window._slangRuntimeVFS) return;
+
+        var runtimeFiles = [
+            'runtime.asm', 'core.asm', 'opt.asm', 'libfloat.asm',
+            'liblsx_base.asm', 'libx1_base.asm', 'libx1_grp.asm',
+            'liblsx_input.asm', 'libx1_print.asm', 'liblsx_file.asm',
+            'libx1_pcg.asm', 'libmag.asm', 'libm8a.asm', 'libx1_psg.asm',
+            'libcompress.asm', 'libsoroban.asm', 'libx1_magic.asm', 'libx1_sgl_lsx.asm',
+        ];
+        var includeFiles = [
+            'GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB',
+            'CHIPLIB.LIB', 'SPRLIB.LIB', 'TILELIB.LIB', 'TILESPR.LIB', 'UILIB.LIB',
+        ];
+        var vfs = {};
+        var vBust = (XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '';
+        for (var ri = 0; ri < runtimeFiles.length; ri++) {
+            try {
+                var resp = await fetch('slang_runtime/' + runtimeFiles[ri] + vBust);
+                if (resp.ok) vfs[runtimeFiles[ri]] = await resp.text();
+            } catch(e) { /* optional file */ }
+        }
+        for (var ii = 0; ii < includeFiles.length; ii++) {
+            try {
+                var iresp = await fetch('slang_include/' + includeFiles[ii] + vBust);
+                if (iresp.ok) vfs[includeFiles[ii]] = await iresp.text();
+            } catch(e) { /* optional file */ }
+        }
+        window._slangRuntimeVFS = vfs;
+    }
+
+    async function getPredefinedSymbols(coldStateFile) {
+        var predefined = {
+            OS_TYPE: 0,   // 0=LSX-Dodgers, 1=S-OS
+            ENV_TYPE: 1,  // 0=CP/M, 1=LSX-Dodgers(X1), 2=MSX-DOS
+        };
+        var versions = await loadAddrmapVersions();
+        var verName = COLD_STATE_VERSION[coldStateFile];
+        if (!versions || !verName || !versions[verName]) return predefined;
+
+        var ver = versions[verName];
+        var groups = [ver.user_hooks, ver.sound, ver.graphics];
+        for (var gi = 0; gi < groups.length; gi++) {
+            var group = groups[gi];
+            if (!group) continue;
+            for (var key in group) predefined[key] = parseInt(group[key], 16);
+        }
+        return predefined;
+    }
+
     // ── RUN ──
 
     async function onRunClick() {
@@ -623,51 +682,11 @@ window.__X1PEN_MODE = true;
         // SLANG → コンパイル → ASM に変換
         if (sourceMode === 'slang') {
             elStatus.textContent = 'Compiling SLANG...';
-            // 遅延ロード: SLANG コンパイラが未ロードなら動的ロード
-            if (!window.X1PenSlangCompiler) {
-                try {
-                    await new Promise(function(resolve, reject) {
-                        var s = document.createElement('script');
-                        s.src = 'x1pen_slang_compiler.js' + ((XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '');
-                        s.onload = resolve;
-                        s.onerror = function() { reject(new Error('Failed to load SLANG compiler')); };
-                        document.head.appendChild(s);
-                    });
-                } catch(e) {
-                    elStatus.textContent = e.message;
-                    return false;
-                }
-            }
-            // ランタイム .asm ファイルを virtualFS にロード (初回のみ fetch)
-            if (!window._slangRuntimeVFS) {
-                elStatus.textContent = 'Loading SLANG runtime...';
-                var runtimeFiles = [
-                    'runtime.asm', 'core.asm', 'opt.asm', 'libfloat.asm',
-                    'liblsx_base.asm', 'libx1_base.asm', 'libx1_grp.asm',
-                    'liblsx_input.asm', 'libx1_print.asm', 'liblsx_file.asm',
-                    'libx1_pcg.asm', 'libmag.asm', 'libm8a.asm', 'libx1_psg.asm',
-                    'libcompress.asm', 'libsoroban.asm', 'libx1_magic.asm', 'libx1_sgl_lsx.asm',
-                ];
-                var vfs = {};
-                var vBust = (XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '';
-                for (var ri = 0; ri < runtimeFiles.length; ri++) {
-                    try {
-                        var resp = await fetch('slang_runtime/' + runtimeFiles[ri] + vBust);
-                        if (resp.ok) vfs[runtimeFiles[ri]] = await resp.text();
-                    } catch(e) { /* optional file */ }
-                }
-                // インクルードファイルも読み込み
-                var includeFiles = [
-                    'GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB',
-                    'CHIPLIB.LIB', 'SPRLIB.LIB', 'TILELIB.LIB', 'TILESPR.LIB', 'UILIB.LIB',
-                ];
-                for (var ii = 0; ii < includeFiles.length; ii++) {
-                    try {
-                        var iresp = await fetch('slang_include/' + includeFiles[ii] + vBust);
-                        if (iresp.ok) vfs[includeFiles[ii]] = await iresp.text();
-                    } catch(e) { /* optional file */ }
-                }
-                window._slangRuntimeVFS = vfs;
+            try {
+                await ensureSlangToolchain();
+            } catch(e) {
+                elStatus.textContent = e.message;
+                return false;
             }
 
             // X1 環境固定 (ENV_TYPE: 0=CP/M, 1=LSX-Dodgers, 2=MSX-DOS)
@@ -765,24 +784,7 @@ window.__X1PEN_MODE = true;
 
         // 4. ASM アセンブル (タブに内容がある場合)
         //    addrmap から predefined symbols を構築
-        var predefined = {
-            OS_TYPE: 0,   // 0=LSX-Dodgers, 1=S-OS
-            ENV_TYPE: 1,  // 0=CP/M, 1=LSX-Dodgers(X1), 2=MSX-DOS
-        };
-        var versions = await loadAddrmapVersions();
-        var verName = COLD_STATE_VERSION[actualColdState];
-        if (versions && verName && versions[verName]) {
-            var ver = versions[verName];
-            if (ver.user_hooks) {
-                for (var k in ver.user_hooks) predefined[k] = parseInt(ver.user_hooks[k], 16);
-            }
-            if (ver.sound) {
-                for (var k in ver.sound) predefined[k] = parseInt(ver.sound[k], 16);
-            }
-            if (ver.graphics) {
-                for (var k in ver.graphics) predefined[k] = parseInt(ver.graphics[k], 16);
-            }
-        }
+        var predefined = await getPredefinedSymbols(actualColdState);
 
         var asmResult = null;
         if (asmSrc) {
@@ -1116,6 +1118,84 @@ window.__X1PEN_MODE = true;
         return getAutomationProgram();
     }
 
+    function makeAutomationDiagnostic(kind, message, details) {
+        var diagnostic = {
+            kind: kind,
+            severity: (details && details.severity) || 'error',
+            message: String(message || 'Unknown error')
+        };
+        if (details && details.file) diagnostic.file = details.file;
+        if (details && Number.isFinite(details.line)) diagnostic.line = details.line;
+        if (details && Number.isFinite(details.column)) diagnostic.column = details.column;
+        return diagnostic;
+    }
+
+    async function validateAutomationProgram() {
+        var program = getAutomationProgram();
+        var diagnostics = [];
+        var asmSource = program.asm;
+        var generatedAsmLines = 0;
+        var asmBytes = 0;
+        var basicBytes = 0;
+
+        if (!program.basic.trim() && !program.asm.trim() && !program.slang.trim()) {
+            diagnostics.push(makeAutomationDiagnostic('program', 'Nothing to validate'));
+        }
+
+        if (program.sourceMode === 'slang' && diagnostics.length === 0) {
+            try {
+                await ensureSlangToolchain();
+                var slangEnv = { defaultOrg: 0x100, codeReadonly: false, defines: { ENV_TYPE: 1 } };
+                var slangResult = window.X1PenSlangCompiler.compile(program.slang.trim(), window._slangRuntimeVFS, slangEnv);
+                var slangErrors = slangResult.errors || [];
+                for (var si = 0; si < slangErrors.length; si++) {
+                    var slangError = slangErrors[si];
+                    var start = slangError.span && slangError.span.start;
+                    diagnostics.push(makeAutomationDiagnostic('slang', slangError.message || slangError, {
+                        severity: String(slangError.severity || 'error').toLowerCase(),
+                        file: start && start.fileName,
+                        line: start && start.line,
+                        column: start && start.column
+                    }));
+                }
+                asmSource = slangResult.asm || '';
+                generatedAsmLines = asmSource ? asmSource.split('\n').length : 0;
+            } catch(e) {
+                diagnostics.push(makeAutomationDiagnostic('slang', e.message));
+            }
+        }
+
+        if (asmSource.trim() && diagnostics.length === 0) {
+            var coldState = program.sourceMode === 'basic+asm' ? COLD_STATE_FILE : LSX_COLD_STATE;
+            var predefined = await getPredefinedSymbols(coldState);
+            var asmResult = window.X1PenZ80Asm.assemble(asmSource.trim(), predefined);
+            asmBytes = asmResult.bytes.length;
+            for (var ai = 0; ai < asmResult.errors.length; ai++) {
+                var asmError = asmResult.errors[ai];
+                diagnostics.push(makeAutomationDiagnostic('asm', asmError.msg, { line: asmError.line }));
+            }
+        }
+
+        if (program.sourceMode === 'basic+asm' && program.basic.trim() && diagnostics.length === 0) {
+            try {
+                basicBytes = window.X1PenTokenizer.tokenizeProgram(program.basic.trim()).length;
+            } catch(e) {
+                diagnostics.push(makeAutomationDiagnostic('basic', e.message));
+            }
+        }
+
+        return {
+            ok: diagnostics.length === 0,
+            sourceMode: program.sourceMode,
+            diagnostics: diagnostics,
+            output: {
+                basicBytes: basicBytes,
+                asmBytes: asmBytes,
+                generatedAsmLines: generatedAsmLines
+            }
+        };
+    }
+
     function getAutomationStatus() {
         return {
             ready: automationReadyState === 'ready',
@@ -1150,6 +1230,9 @@ window.__X1PEN_MODE = true;
             return queueAutomationOperation(function() {
                 return setAutomationProgram(program);
             });
+        },
+        validate: function() {
+            return queueAutomationOperation(validateAutomationProgram);
         },
         run: function() {
             return queueAutomationOperation(async function() {

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as z from 'zod/v4';
+import { X1PenSession } from './x1pen-session.mjs';
+
+const MAX_SOURCE_LENGTH = 512 * 1024;
+
+function textResult(value) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+function toolError(error) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+  };
+}
+
+function handleTool(handler) {
+  return async (args) => {
+    try {
+      return await handler(args);
+    } catch (error) {
+      return toolError(error);
+    }
+  };
+}
+
+export function createX1PenMcpServer(options = {}) {
+  const session = options.session || new X1PenSession(options.sessionOptions);
+  const server = new McpServer({ name: 'x1pen', version: '1.0.0' });
+
+  server.registerTool('x1pen_get_program', {
+    description: 'Get the BASIC, Z80 assembly, and SLANG source currently loaded in X1Pen.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult(await session.getProgram())));
+
+  server.registerTool('x1pen_set_program', {
+    description: 'Replace the complete X1Pen program. Sources not used by sourceMode are cleared.',
+    inputSchema: {
+      sourceMode: z.enum(['basic+asm', 'asm', 'slang']),
+      basic: z.string().max(MAX_SOURCE_LENGTH).optional(),
+      asm: z.string().max(MAX_SOURCE_LENGTH).optional(),
+      slang: z.string().max(MAX_SOURCE_LENGTH).optional(),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async (program) => textResult(await session.setProgram(program))));
+
+  server.registerTool('x1pen_validate', {
+    description: 'Compile or tokenize the current program without resetting or running the emulator.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult(await session.validate())));
+
+  server.registerTool('x1pen_run', {
+    description: 'Build and run the current X1Pen program, then wait briefly before returning status.',
+    inputSchema: {
+      waitMs: z.number().int().min(0).max(10_000).default(500),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ waitMs }) => textResult(await session.run(waitMs))));
+
+  server.registerTool('x1pen_stop', {
+    description: 'Send ESC to stop the current X1Pen program.',
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult(await session.stop())));
+
+  server.registerTool('x1pen_get_status', {
+    description: 'Get X1Pen initialization, busy, and status-message state.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult(await session.getStatus())));
+
+  server.registerTool('x1pen_capture_screen', {
+    description: 'Capture the current 640x400 X1 emulator canvas as a PNG image.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => {
+    const png = await session.captureScreen();
+    return {
+      content: [
+        { type: 'text', text: 'Current X1Pen emulator screen (640x400 PNG).' },
+        { type: 'image', data: png.toString('base64'), mimeType: 'image/png' },
+      ],
+    };
+  }));
+
+  return { server, session };
+}
+
+async function main() {
+  const { server, session } = createX1PenMcpServer();
+  let closing = false;
+  const close = async () => {
+    if (closing) return;
+    closing = true;
+    await session.close();
+    await server.close();
+  };
+  process.once('SIGINT', () => close().finally(() => process.exit(0)));
+  process.once('SIGTERM', () => close().finally(() => process.exit(0)));
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('[x1pen-mcp] server ready on stdio');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error('[x1pen-mcp] fatal:', error);
+    process.exit(1);
+  });
+}

--- a/mcp/x1pen-session.mjs
+++ b/mcp/x1pen-session.mjs
@@ -1,0 +1,201 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.d88': 'application/octet-stream',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.xmst': 'application/octet-stream',
+};
+
+export class X1PenSession {
+  constructor(options = {}) {
+    this.distDir = resolve(options.distDir || process.env.X1PEN_DIST_DIR || join(projectRoot, 'dist'));
+    this.browserExecutable = options.browserExecutable || process.env.X1PEN_BROWSER_EXECUTABLE;
+    this.headless = options.headless ?? process.env.X1PEN_HEADLESS !== '0';
+    this.logger = options.logger || ((message) => console.error(`[x1pen-mcp] ${message}`));
+    this.startPromise = null;
+    this.operationQueue = Promise.resolve();
+    this.httpServer = null;
+    this.browser = null;
+    this.context = null;
+    this.page = null;
+    this.baseUrl = null;
+  }
+
+  async ensureStarted() {
+    if (!this.startPromise) {
+      this.startPromise = this.start().catch(async (error) => {
+        await this.close();
+        this.startPromise = null;
+        throw error;
+      });
+    }
+    return this.startPromise;
+  }
+
+  async start() {
+    const entryPoint = join(this.distDir, 'x1pen.html');
+    if (!existsSync(entryPoint)) {
+      throw new Error(`X1Pen build not found at ${entryPoint}. Run ./build.sh first.`);
+    }
+
+    await this.startStaticServer();
+    this.browser = await this.launchBrowser();
+    this.context = await this.browser.newContext({
+      viewport: { width: 1280, height: 900 },
+      serviceWorkers: 'block',
+    });
+    this.page = await this.context.newPage();
+    this.page.on('pageerror', (error) => this.logger(`page error: ${error.message}`));
+    await this.page.goto(`${this.baseUrl}/x1pen.html`, { waitUntil: 'domcontentloaded' });
+    await this.page.waitForFunction(() => window.X1PenAutomation?.version >= 1, null, { timeout: 15_000 });
+    let readyTimeout;
+    let status;
+    try {
+      status = await Promise.race([
+        this.page.evaluate(() => window.X1PenAutomation.ready()),
+        new Promise((_, reject) => {
+          readyTimeout = setTimeout(() => reject(new Error('X1Pen initialization timed out after 30 seconds')), 30_000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(readyTimeout);
+    }
+    if (!status.ready) throw new Error(`X1Pen initialization failed: ${status.status || status.state}`);
+    this.logger(`session ready at ${this.baseUrl}`);
+  }
+
+  async startStaticServer() {
+    await new Promise((resolvePromise, reject) => {
+      this.httpServer = createServer((request, response) => this.serveFile(request, response));
+      this.httpServer.once('error', reject);
+      this.httpServer.listen(0, '127.0.0.1', () => {
+        const address = this.httpServer.address();
+        this.baseUrl = `http://127.0.0.1:${address.port}`;
+        resolvePromise();
+      });
+    });
+  }
+
+  serveFile(request, response) {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      response.writeHead(405, { Allow: 'GET, HEAD' }).end();
+      return;
+    }
+
+    let pathname;
+    try {
+      pathname = decodeURIComponent(new URL(request.url, 'http://127.0.0.1').pathname);
+    } catch {
+      response.writeHead(400).end('Bad request');
+      return;
+    }
+    const filePath = resolve(this.distDir, `.${pathname === '/' ? '/index.html' : pathname}`);
+    const relativePath = relative(this.distDir, filePath);
+    if (relativePath.startsWith('..') || isAbsolute(relativePath) || !existsSync(filePath) || !statSync(filePath).isFile()) {
+      response.writeHead(404).end('Not found');
+      return;
+    }
+
+    response.setHeader('Content-Type', mimeTypes[extname(filePath).toLowerCase()] || 'application/octet-stream');
+    response.setHeader('Cache-Control', 'no-store');
+    if (request.method === 'HEAD') {
+      response.writeHead(200).end();
+      return;
+    }
+    const stream = createReadStream(filePath);
+    stream.on('error', () => {
+      if (!response.headersSent) response.writeHead(500);
+      response.end();
+    });
+    stream.pipe(response);
+  }
+
+  async launchBrowser() {
+    if (this.browserExecutable) {
+      return chromium.launch({ executablePath: this.browserExecutable, headless: this.headless });
+    }
+    try {
+      return await chromium.launch({ headless: this.headless });
+    } catch (bundledError) {
+      for (const channel of ['chrome', 'msedge']) {
+        try {
+          return await chromium.launch({ channel, headless: this.headless });
+        } catch { /* try next installed browser */ }
+      }
+      throw new Error(`Chromium could not be launched. Run "npx playwright install chromium" or set X1PEN_BROWSER_EXECUTABLE. ${bundledError.message}`);
+    }
+  }
+
+  enqueue(operation) {
+    const result = this.operationQueue.then(async () => {
+      await this.ensureStarted();
+      return operation(this.page);
+    });
+    this.operationQueue = result.catch(() => {});
+    return result;
+  }
+
+  getProgram() {
+    return this.enqueue((page) => page.evaluate(() => window.X1PenAutomation.getProgram()));
+  }
+
+  setProgram(program) {
+    return this.enqueue((page) => page.evaluate((value) => window.X1PenAutomation.setProgram(value), program));
+  }
+
+  validate() {
+    return this.enqueue((page) => page.evaluate(() => window.X1PenAutomation.validate()));
+  }
+
+  run(waitMs = 500) {
+    return this.enqueue(async (page) => {
+      const result = await page.evaluate(() => window.X1PenAutomation.run());
+      if (waitMs > 0) await page.waitForTimeout(waitMs);
+      return { ...result, state: await page.evaluate(() => window.X1PenAutomation.getStatus()) };
+    });
+  }
+
+  stop() {
+    return this.enqueue((page) => page.evaluate(() => window.X1PenAutomation.stop()));
+  }
+
+  getStatus() {
+    return this.enqueue((page) => page.evaluate(() => window.X1PenAutomation.getStatus()));
+  }
+
+  captureScreen() {
+    return this.enqueue(async (page) => {
+      const dataUrl = await page.evaluate(() => {
+        const canvas = document.getElementById('canvas');
+        if (!canvas) throw new Error('X1Pen canvas not found');
+        return canvas.toDataURL('image/png');
+      });
+      return Buffer.from(dataUrl.slice(dataUrl.indexOf(',') + 1), 'base64');
+    });
+  }
+
+  async close() {
+    const resources = [this.context, this.browser];
+    this.page = null;
+    this.context = null;
+    this.browser = null;
+    for (const resource of resources) {
+      if (resource) await resource.close().catch(() => {});
+    }
+    if (this.httpServer) {
+      const server = this.httpServer;
+      this.httpServer = null;
+      await new Promise((resolvePromise) => server.close(resolvePromise));
+    }
+    this.baseUrl = null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,16 @@
         "@codemirror/language": "^6.0.0",
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
+        "@codemirror/view": "^6.0.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "playwright": "^1.62.1",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
-        "esbuild": "^0.21.0",
-        "playwright": "^1.62.1"
+        "esbuild": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@codemirror/commands": {
@@ -466,6 +471,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
@@ -496,11 +513,328 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -541,11 +875,169 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -556,11 +1048,347 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.1"
@@ -579,7 +1407,6 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -588,17 +1415,355 @@
         "node": ">=20"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,28 @@
   "private": true,
   "name": "xmil-web",
   "description": "X millennium Web - SHARP X1 Emulator",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
-    "esbuild": "^0.21.0",
-    "playwright": "^1.62.1"
+    "esbuild": "^0.21.0"
   },
   "dependencies": {
     "@codemirror/commands": "^6.0.0",
     "@codemirror/language": "^6.0.0",
     "@codemirror/search": "^6.0.0",
     "@codemirror/state": "^6.0.0",
-    "@codemirror/view": "^6.0.0"
+    "@codemirror/view": "^6.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "playwright": "^1.62.1",
+    "zod": "^3.25.76"
   },
   "scripts": {
     "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify",
-    "test:automation": "node --test tests/x1pen_automation_test.mjs"
+    "mcp:x1pen": "node mcp/x1pen-server.mjs",
+    "mcp:install-browser": "playwright install chromium",
+    "test:automation": "node --test tests/x1pen_automation_test.mjs",
+    "test:mcp": "node --test tests/x1pen_mcp_test.mjs",
+    "test:mcp:e2e": "node --test tests/x1pen_mcp_e2e_test.mjs"
   }
 }

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -82,6 +82,10 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   const loaded = await page.evaluate((value) => window.X1PenAutomation.setProgram(value), program);
   assert.deepEqual(loaded, program);
 
+  const validation = await page.evaluate(() => window.X1PenAutomation.validate());
+  assert.equal(validation.ok, true);
+  assert.ok(validation.output.basicBytes > 0);
+
   await page.evaluate(() => window.XmilControls.setKeyMode(1));
   const result = await page.evaluate(() => window.X1PenAutomation.run());
   assert.equal(result.ok, true);
@@ -110,4 +114,13 @@ test('automation operations are serialized and stale source modes are cleared', 
     slang: 'main() BEGIN\nEND;',
     sourceMode: 'slang',
   });
+});
+
+test('automation validation returns structured assembler diagnostics', async () => {
+  await page.evaluate(() => window.X1PenAutomation.setProgram({ sourceMode: 'asm', asm: 'ORG $100\nBOGUS A' }));
+  const validation = await page.evaluate(() => window.X1PenAutomation.validate());
+  assert.equal(validation.ok, false);
+  assert.equal(validation.sourceMode, 'asm');
+  assert.equal(validation.diagnostics[0].kind, 'asm');
+  assert.equal(validation.diagnostics[0].line, 2);
 });

--- a/tests/x1pen_mcp_e2e_test.mjs
+++ b/tests/x1pen_mcp_e2e_test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { after, before, test } from 'node:test';
+
+let client;
+
+before(async () => {
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['mcp/x1pen-server.mjs'],
+    cwd: process.cwd(),
+    stderr: 'inherit',
+  });
+  client = new Client({ name: 'x1pen-mcp-e2e-test', version: '1.0.0' });
+  await client.connect(transport);
+});
+
+after(async () => {
+  if (client) await client.close();
+});
+
+test('stdio MCP server controls the real X1Pen browser session', { timeout: 60_000 }, async () => {
+  const source = {
+    sourceMode: 'basic+asm',
+    basic: '10 PRINT "MCP E2E"',
+    asm: '',
+    slang: '',
+  };
+  const setResult = await client.callTool({ name: 'x1pen_set_program', arguments: source });
+  assert.equal(setResult.isError, undefined);
+
+  const validation = await client.callTool({ name: 'x1pen_validate', arguments: {} });
+  assert.equal(validation.structuredContent.ok, true);
+
+  const run = await client.callTool({ name: 'x1pen_run', arguments: { waitMs: 200 } });
+  assert.equal(run.structuredContent.ok, true);
+
+  const screen = await client.callTool({ name: 'x1pen_capture_screen', arguments: {} });
+  const image = screen.content.find((item) => item.type === 'image');
+  assert.equal(image.mimeType, 'image/png');
+  const png = Buffer.from(image.data, 'base64');
+  assert.ok(png.length > 1_000);
+  assert.equal(png.readUInt32BE(16), 640);
+  assert.equal(png.readUInt32BE(20), 400);
+});

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { after, before, test } from 'node:test';
+import { createX1PenMcpServer } from '../mcp/x1pen-server.mjs';
+
+const program = { sourceMode: 'basic+asm', basic: '10 PRINT "MCP"', asm: '', slang: '' };
+const fakeSession = {
+  async getProgram() { return program; },
+  async setProgram(value) { return value; },
+  async validate() { return { ok: true, sourceMode: 'basic+asm', diagnostics: [], output: {} }; },
+  async run(waitMs) { return { ok: true, waitMs }; },
+  async stop() { return { ready: true, status: 'Stopped' }; },
+  async getStatus() { return { ready: true, state: 'ready', busy: false, status: 'Ready' }; },
+  async captureScreen() { return Buffer.from('png'); },
+  async close() {},
+};
+
+let server;
+let client;
+
+before(async () => {
+  ({ server } = createX1PenMcpServer({ session: fakeSession }));
+  client = new Client({ name: 'x1pen-mcp-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+after(async () => {
+  if (client) await client.close();
+  if (server) await server.close();
+});
+
+test('server exposes the expected X1Pen tool surface', async () => {
+  const tools = await client.listTools();
+  assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), [
+    'x1pen_capture_screen',
+    'x1pen_get_program',
+    'x1pen_get_status',
+    'x1pen_run',
+    'x1pen_set_program',
+    'x1pen_stop',
+    'x1pen_validate',
+  ]);
+});
+
+test('program and image results cross the MCP protocol', async () => {
+  const setResult = await client.callTool({ name: 'x1pen_set_program', arguments: program });
+  assert.equal(setResult.isError, undefined);
+  assert.deepEqual(setResult.structuredContent, program);
+
+  const imageResult = await client.callTool({ name: 'x1pen_capture_screen', arguments: {} });
+  assert.equal(imageResult.content[1].type, 'image');
+  assert.equal(imageResult.content[1].mimeType, 'image/png');
+  assert.equal(Buffer.from(imageResult.content[1].data, 'base64').toString(), 'png');
+});


### PR DESCRIPTION
## Summary

- add a local-only stdio MCP server backed by an isolated Playwright/X1Pen session
- expose seven tools for source editing, validation, execution, stop/status, and 640x400 PNG capture
- add structured BASIC/ASM/SLANG validation to the browser automation API
- add project configuration for Codex and Claude Code plus setup documentation
- add in-memory MCP protocol tests and a full stdio-to-WASM end-to-end test

## Security and isolation

- the static asset server binds only to `127.0.0.1` on an ephemeral port
- requested asset paths are constrained to `dist/`
- each MCP process uses an isolated browser context
- source inputs are capped at 512 KiB per field

## Test plan

- `./build.sh`
- `npm run test:automation`
- `npm run test:mcp`
- `npm run test:mcp:e2e`
- `node tests/z80asm_test.js`
- `npm audit --omit=dev`
- `codex mcp list`
- `claude mcp list`

Depends on #51. Advances #50.
