### PR TITLE
feat: connect MCP to the user's active X1Pen tab

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.x1pen]
+command = "node"
+args = ["mcp/x1pen-server.mjs"]
+cwd = "."
+startup_timeout_sec = 30
+tool_timeout_sec = 60

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "x1pen": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["mcp/x1pen-server.mjs"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SHARP X1 シリーズ（X1 / X1turbo / X1turboZ）のエミュレータ「X mill
 - フルスクリーン対応（ダブルクリック）
 - 4096 色モード（turboZ）
 - **[X1Pen](docs/X1PEN.md)** — ブラウザ上で FuzzyBASIC + Z80 アセンブリを書いて即実行できる Web IDE
+- **[X1Pen MCP Connector](docs/X1PEN_MCP.md)** — 開いているX1PenタブをCodex / Claude Codeから共同操作
 
 ## 必要な ROM
 

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -1,0 +1,97 @@
+# X1Pen MCP Connector
+
+X1Pen MCP Connectorは、ユーザーがChromeまたはEdgeで開いているX1PenタブをCodex / Claude Codeから操作するためのローカル連携機能です。AI専用ブラウザーを起動するのではなく、人間とAIが同じエディターとエミュレーターを使用します。
+
+## 対応環境
+
+- Windows / macOS: Chrome、Edge
+- Linux: Chromium系ブラウザー（ベストエフォート）
+- Brave、Vivaldiなど: ベストエフォート
+- Firefox、Safari: 現時点では対象外
+
+Node.js 20以降が必要です。通信はstdioと`127.0.0.1`だけを使用します。
+
+## セットアップ
+
+```bash
+npm ci
+./build.sh
+```
+
+### 拡張機能
+
+1. Chromeで`chrome://extensions`、Edgeで`edge://extensions`を開く
+2. Developer modeを有効化
+3. Load unpackedを選択
+4. このリポジトリの`extension/`ディレクトリを指定
+
+PoC段階ではストア配布を行わないため、unpacked extensionとして読み込みます。
+
+### Codex
+
+リポジトリルートからCodexを起動すると`.codex/config.toml`がMCPサーバーを登録します。
+
+```bash
+codex mcp list
+codex
+```
+
+### Claude Code
+
+`.mcp.json`がプロジェクトMCPサーバーを登録します。初回起動時に承認してください。
+
+```bash
+claude mcp list
+claude
+```
+
+## 接続
+
+1. AIに`x1pen_connection_info`を呼ばせ、bridge portと6桁のpairing codeを確認
+2. Automation API v2を含むX1PenをChrome / Edgeで開く
+3. X1Pen Connector拡張を開く
+4. bridge portとpairing codeを入力
+5. `Connect this tab`を押す
+
+接続されたX1Penには`MCP Connected`と表示されます。複数タブを接続した場合は`x1pen_list_sessions`と`x1pen_select_session`で操作対象を選びます。通常はX1Pen自身の複数タブ警告により1タブだけが接続されます。
+
+## ツール
+
+| Tool | 内容 |
+|---|---|
+| `x1pen_connection_info` | 拡張機能の接続情報を取得 |
+| `x1pen_list_sessions` | 接続済みX1Penタブを一覧表示 |
+| `x1pen_select_session` | 操作対象タブを選択 |
+| `x1pen_get_program` | ソース、instance ID、revisionを取得 |
+| `x1pen_set_program` | revision一致時だけプログラム全体を更新 |
+| `x1pen_validate` | 実行せずにコンパイル、アセンブル、トークナイズ |
+| `x1pen_run` | ユーザーが開いているX1Penで実行 |
+| `x1pen_stop` | ESCを送信して停止 |
+| `x1pen_get_status` | 接続、ロック、実行状態を取得 |
+| `x1pen_capture_screen` | 640x400のエミュレーター画面をPNG取得 |
+
+AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`は`x1pen_get_program`で取得した`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
+
+Share機能はユーザーが開いているX1Pen自身から実行するため、本番X1Pen上では既存のShare APIと公開URLをそのまま利用できます。
+
+## ローカル確認
+
+```bash
+npm run test:automation
+npm run test:bridge
+npm run test:mcp
+```
+
+MCPサーバー単体を起動すると、標準エラーにbridge portとpairing codeが表示されます。標準出力はMCP通信専用です。
+
+```bash
+npm run mcp:x1pen
+```
+
+## セキュリティ
+
+- ブリッジは`127.0.0.1`だけで待ち受ける
+- 6桁コードによる明示的なペアリングが必要
+- Chrome拡張の`activeTab`権限はユーザーが接続操作したタブだけに付与される
+- 任意JavaScriptやChrome DevTools Protocolは公開しない
+- X1Pen Automation APIの許可済みメソッドだけを中継する

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,5 @@
+# X1Pen Connector Extension
+
+Development-only Chromium extension for connecting the active X1Pen tab to the local MCP bridge.
+
+Load this directory as an unpacked extension from `chrome://extensions` or `edge://extensions`. See `docs/X1PEN_MCP.md` for the complete setup and pairing flow.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "X1Pen Connector",
+  "version": "0.1.0",
+  "description": "Connect the active X1Pen tab to a local Codex or Claude Code MCP server.",
+  "permissions": ["activeTab", "scripting", "storage"],
+  "background": {
+    "service_worker": "service-worker.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Connect X1Pen",
+    "default_popup": "popup.html"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; connect-src 'self' ws://127.0.0.1:* ws://localhost:*"
+  }
+}

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,64 @@
+* { box-sizing: border-box; }
+body {
+  width: 300px;
+  margin: 0;
+  padding: 14px;
+  background: #10141b;
+  color: #e6edf3;
+  font: 13px system-ui, sans-serif;
+}
+header {
+  margin-bottom: 14px;
+  color: #7dffb3;
+  font-size: 15px;
+  font-weight: 650;
+}
+label {
+  display: block;
+  margin: 9px 0 4px;
+  color: #9da7b3;
+}
+input {
+  width: 100%;
+  height: 32px;
+  padding: 5px 8px;
+  border: 1px solid #39414d;
+  border-radius: 4px;
+  background: #171d26;
+  color: #f0f3f6;
+}
+.actions {
+  display: flex;
+  gap: 7px;
+  margin-top: 13px;
+}
+button {
+  min-height: 32px;
+  padding: 5px 10px;
+  border: 1px solid #17804e;
+  border-radius: 4px;
+  background: #12633e;
+  color: #fff;
+  cursor: pointer;
+}
+button.secondary {
+  border-color: #4a5360;
+  background: #252c36;
+}
+button:disabled { opacity: 0.5; cursor: default; }
+#status {
+  min-height: 18px;
+  margin: 12px 0 4px;
+  color: #9da7b3;
+}
+#status.error { color: #ff8b8b; }
+ul {
+  margin: 7px 0 0;
+  padding: 0;
+  list-style: none;
+}
+li {
+  padding: 6px 0;
+  border-top: 1px solid #2a313b;
+  overflow-wrap: anywhere;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>X1Pen Connector</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <header>X1Pen Connector</header>
+  <label for="port">Bridge port</label>
+  <input id="port" type="number" min="1" max="65535" value="43110">
+  <label for="code">Pairing code</label>
+  <input id="code" type="text" inputmode="numeric" maxlength="6" autocomplete="one-time-code">
+  <div class="actions">
+    <button id="connect">Connect this tab</button>
+    <button id="disconnect" class="secondary">Disconnect</button>
+  </div>
+  <p id="status" role="status">Not connected</p>
+  <ul id="sessions"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,80 @@
+const portInput = document.getElementById('port');
+const codeInput = document.getElementById('code');
+const connectButton = document.getElementById('connect');
+const disconnectButton = document.getElementById('disconnect');
+const statusElement = document.getElementById('status');
+const sessionsElement = document.getElementById('sessions');
+
+loadState();
+
+connectButton.addEventListener('click', async () => {
+  setBusy(true);
+  try {
+    const response = await sendMessage({
+      type: 'connect-active-tab',
+      port: Number(portInput.value),
+      code: codeInput.value,
+    });
+    showStatus(`Connected: ${response.session.title}`);
+    await loadState();
+  } catch (error) {
+    showStatus(error.message, true);
+  } finally {
+    setBusy(false);
+  }
+});
+
+disconnectButton.addEventListener('click', async () => {
+  setBusy(true);
+  try {
+    await sendMessage({ type: 'disconnect-active-tab' });
+    showStatus('Disconnected');
+    await loadState();
+  } catch (error) {
+    showStatus(error.message, true);
+  } finally {
+    setBusy(false);
+  }
+});
+
+async function loadState() {
+  try {
+    const state = await sendMessage({ type: 'get-state' });
+    if (state.bridgeConfig) {
+      portInput.value = state.bridgeConfig.port;
+      codeInput.value = state.bridgeConfig.code;
+    }
+    sessionsElement.replaceChildren(...state.sessions.map((session) => {
+      const item = document.createElement('li');
+      item.textContent = `${session.active ? 'Active: ' : ''}${session.title}`;
+      return item;
+    }));
+    if (state.paired) showStatus(`${state.sessions.length} X1Pen tab(s) connected`);
+  } catch (error) {
+    showStatus(error.message, true);
+  }
+}
+
+function sendMessage(message) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(message, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+      } else if (!response?.ok) {
+        reject(new Error(response?.error || 'Extension request failed'));
+      } else {
+        resolve(response.result);
+      }
+    });
+  });
+}
+
+function showStatus(message, isError = false) {
+  statusElement.textContent = message;
+  statusElement.classList.toggle('error', isError);
+}
+
+function setBusy(busy) {
+  connectButton.disabled = busy;
+  disconnectButton.disabled = busy;
+}

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -1,0 +1,252 @@
+const connectedTabs = new Map();
+let bridgeConfig = null;
+let socket = null;
+let paired = false;
+let connectPromise = null;
+let reconnectTimer = null;
+
+initialize();
+
+async function initialize() {
+  const stored = await chrome.storage.local.get('bridgeConfig');
+  bridgeConfig = stored.bridgeConfig || null;
+  const session = await chrome.storage.session.get('connectedTabs');
+  for (const item of session.connectedTabs || []) connectedTabs.set(item.sessionId, item);
+  updateBadge();
+  if (bridgeConfig && connectedTabs.size > 0) connectBridge().catch(() => {});
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handlePopupMessage(message).then(
+    (result) => sendResponse({ ok: true, result }),
+    (error) => sendResponse({ ok: false, error: error.message || String(error) }),
+  );
+  return true;
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  for (const [sessionId, session] of connectedTabs) {
+    if (session.tabId === tabId) connectedTabs.delete(sessionId);
+  }
+  persistSessions().then(sendSessions).catch(() => {});
+});
+
+async function handlePopupMessage(message) {
+  if (message.type === 'get-state') {
+    await refreshSessions();
+    return { bridgeConfig, paired, sessions: Array.from(connectedTabs.values()) };
+  }
+  if (message.type === 'connect-active-tab') {
+    const port = Number(message.port);
+    const code = String(message.code || '').trim();
+    if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('Invalid bridge port');
+    if (!/^\d{6}$/.test(code)) throw new Error('Pairing code must be 6 digits');
+
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) throw new Error('No active browser tab');
+    const status = await invokeX1Pen(tab.id, 'probe', {});
+    bridgeConfig = { port, code };
+    await chrome.storage.local.set({ bridgeConfig });
+    connectedTabs.set(status.instanceId, {
+      sessionId: status.instanceId,
+      tabId: tab.id,
+      title: status.title,
+      url: status.url,
+      active: true,
+      revision: status.revision,
+    });
+    await persistSessions();
+    try {
+      await connectBridge();
+      await invokeX1Pen(tab.id, 'connection', { connected: true });
+      await refreshSessions();
+      sendSessions();
+      return { paired: true, session: connectedTabs.get(status.instanceId) };
+    } catch (error) {
+      connectedTabs.delete(status.instanceId);
+      await persistSessions();
+      throw error;
+    }
+  }
+  if (message.type === 'disconnect-active-tab') {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) return { disconnected: false };
+    for (const [sessionId, session] of connectedTabs) {
+      if (session.tabId !== tab.id) continue;
+      await invokeX1Pen(tab.id, 'connection', { connected: false }).catch(() => {});
+      connectedTabs.delete(sessionId);
+    }
+    await persistSessions();
+    sendSessions();
+    return { disconnected: true };
+  }
+  throw new Error('Unknown extension request');
+}
+
+async function connectBridge() {
+  if (!bridgeConfig) throw new Error('Bridge configuration is missing');
+  if (socket?.readyState === WebSocket.OPEN && paired) return;
+  if (connectPromise) return connectPromise;
+
+  connectPromise = new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${bridgeConfig.port}`);
+    let didPair = false;
+    socket = ws;
+    paired = false;
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('Timed out connecting to the local MCP bridge'));
+    }, 8_000);
+
+    ws.onopen = () => ws.send(JSON.stringify({
+      type: 'pair',
+      code: bridgeConfig.code,
+      extensionVersion: chrome.runtime.getManifest().version,
+    }));
+    ws.onmessage = (event) => {
+      let message;
+      try { message = JSON.parse(event.data); } catch { return; }
+      if (message.type === 'paired') {
+        clearTimeout(timeout);
+        didPair = true;
+        paired = true;
+        sendSessions();
+        resolve();
+      } else if (message.type === 'command') {
+        handleCommand(message);
+      } else if (message.type === 'ping') {
+        ws.send(JSON.stringify({ type: 'pong', timestamp: message.timestamp }));
+      }
+    };
+    ws.onerror = () => {
+      clearTimeout(timeout);
+      reject(new Error('Could not connect to the local MCP bridge'));
+    };
+    ws.onclose = (event) => {
+      clearTimeout(timeout);
+      if (!didPair) reject(new Error(event.reason || `Bridge closed the connection (${event.code})`));
+      if (socket === ws) {
+        socket = null;
+        paired = false;
+        for (const session of connectedTabs.values()) {
+          invokeX1Pen(session.tabId, 'connection', { connected: false }).catch(() => {});
+        }
+        scheduleReconnect();
+      }
+    };
+  }).finally(() => {
+    connectPromise = null;
+  });
+  return connectPromise;
+}
+
+function scheduleReconnect() {
+  if (!bridgeConfig || connectedTabs.size === 0 || reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectBridge().then(async () => {
+      for (const session of connectedTabs.values()) {
+        await invokeX1Pen(session.tabId, 'connection', { connected: true }).catch(() => {});
+      }
+      await refreshSessions();
+      sendSessions();
+    }).catch(scheduleReconnect);
+  }, 2_000);
+}
+
+async function handleCommand(message) {
+  const session = connectedTabs.get(message.sessionId);
+  if (!session) {
+    send({ type: 'result', id: message.id, ok: false, error: 'X1Pen tab is no longer connected' });
+    return;
+  }
+  try {
+    const result = await invokeX1Pen(session.tabId, message.method, message.params || {});
+    await refreshSessions();
+    send({ type: 'result', id: message.id, ok: true, result });
+    sendSessions();
+  } catch (error) {
+    send({ type: 'result', id: message.id, ok: false, error: error.message || String(error) });
+  }
+}
+
+async function invokeX1Pen(tabId, method, params) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: 'MAIN',
+    args: [method, params],
+    func: async (requestedMethod, requestedParams) => {
+      const api = window.X1PenAutomation;
+      if (!api || api.version < 2) throw new Error('This tab does not provide X1Pen Automation API v2');
+      if (requestedMethod === 'probe') return api.ready();
+      if (requestedMethod === 'connection') {
+        return api.setConnectionState(requestedParams.connected, requestedParams.connected ? 'MCP Connected' : '');
+      }
+
+      const lockLabels = {
+        setProgram: 'AI is updating the program...',
+        validate: 'AI is validating the program...',
+        run: 'AI is running the program...',
+        stop: 'AI is stopping the program...',
+      };
+      const shouldLock = Object.prototype.hasOwnProperty.call(lockLabels, requestedMethod);
+      if (shouldLock) api.setInteractionLocked(true, lockLabels[requestedMethod]);
+      try {
+        if (requestedMethod === 'getProgram') return api.getProgram();
+        if (requestedMethod === 'setProgram') return api.setProgram(requestedParams.program, requestedParams.expectedRevision);
+        if (requestedMethod === 'validate') return api.validate();
+        if (requestedMethod === 'run') {
+          const result = await api.run();
+          if (requestedParams.waitMs > 0) await new Promise((resolve) => setTimeout(resolve, requestedParams.waitMs));
+          return { ...result, state: api.getStatus() };
+        }
+        if (requestedMethod === 'stop') return api.stop();
+        if (requestedMethod === 'getStatus') return api.getStatus();
+        if (requestedMethod === 'captureScreen') return api.captureScreen();
+        throw new Error(`Unsupported X1Pen method: ${requestedMethod}`);
+      } finally {
+        if (shouldLock) api.setInteractionLocked(false);
+      }
+    },
+  });
+  if (!results.length) throw new Error('X1Pen tab did not return a result');
+  return results[0].result;
+}
+
+async function refreshSessions() {
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  for (const [sessionId, session] of Array.from(connectedTabs)) {
+    try {
+      const status = await invokeX1Pen(session.tabId, 'getStatus', {});
+      connectedTabs.set(sessionId, {
+        ...session,
+        title: status.title,
+        url: status.url,
+        revision: status.revision,
+        active: session.tabId === activeTab?.id,
+      });
+    } catch {
+      connectedTabs.delete(sessionId);
+    }
+  }
+  await persistSessions();
+}
+
+function sendSessions() {
+  send({ type: 'sessions', sessions: Array.from(connectedTabs.values()) });
+  updateBadge();
+}
+
+function send(message) {
+  if (socket?.readyState === WebSocket.OPEN && paired) socket.send(JSON.stringify(message));
+}
+
+async function persistSessions() {
+  await chrome.storage.session.set({ connectedTabs: Array.from(connectedTabs.values()) });
+  updateBadge();
+}
+
+function updateBadge() {
+  chrome.action.setBadgeBackgroundColor({ color: '#0d7a47' });
+  chrome.action.setBadgeText({ text: connectedTabs.size ? String(connectedTabs.size) : '' });
+}

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -110,6 +110,16 @@
             white-space: nowrap;
         }
 
+        #x1pen-mcp-status {
+            padding: 2px 6px;
+            border: 1px solid #26734d;
+            border-radius: 3px;
+            color: #7dffb3;
+            background: #0a3d28;
+            font-size: 0.7em;
+            white-space: nowrap;
+        }
+
         /* ── メインレイアウト ── */
         #x1pen-main {
             display: flex;
@@ -124,6 +134,20 @@
             flex-direction: column;
             border-right: 1px solid #0f3460;
             min-width: 0;
+            position: relative;
+        }
+
+        #x1pen-automation-lock {
+            position: absolute;
+            inset: 0;
+            z-index: 80;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(13, 17, 23, 0.82);
+            color: #7dffb3;
+            font-size: 0.9em;
+            cursor: wait;
         }
 
         #editor-tabs {
@@ -566,6 +590,7 @@
 <body>
     <div id="x1pen-toolbar">
         <span class="brand">X1Pen</span>
+        <span id="x1pen-mcp-status" class="hidden">MCP Connected</span>
         <button id="btn-run" disabled title="Ctrl+Enter">&#x25B6; RUN</button>
         <button id="btn-stop" title="Escape">&#x25A0; STOP</button>
         <button id="btn-dev-reload" class="hidden" title="Reload cached X1Pen assets">Reload Assets</button>
@@ -581,6 +606,7 @@
     </div>
     <div id="x1pen-main">
         <div id="editor-panel">
+            <div id="x1pen-automation-lock" class="hidden">AI is editing...</div>
             <div id="editor-tabs">
                 <button class="editor-tab active" data-tab="basic">BASIC</button>
                 <button class="editor-tab" data-tab="asm">ASM</button>

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -28,6 +28,25 @@ window.__X1PEN_MODE = true;
     automationReadyPromise.catch(function() {});
     var automationOperationQueue = Promise.resolve();
     var automationPendingOperations = 0;
+    var automationRevision = 0;
+    var automationConnected = false;
+    var automationInteractionLocked = false;
+    var automationInteractionLockDepth = 0;
+    var automationInstanceId = (function() {
+        try {
+            var saved = sessionStorage.getItem('x1pen_automation_instance_id');
+            if (saved) return saved;
+            var created = crypto.randomUUID();
+            sessionStorage.setItem('x1pen_automation_instance_id', created);
+            return created;
+        } catch(e) {
+            return 'x1pen-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        }
+    })();
+
+    function markProgramChanged() {
+        automationRevision++;
+    }
 
     // ── FuzzyBASIC addrmap ──
 
@@ -364,7 +383,7 @@ window.__X1PEN_MODE = true;
         { language: 'basic',
           showLineNumbers: false,
           placeholder: '10 PRINT "HELLO WORLD"\n20 GOTO 10',
-          onChange: function(text) { try { localStorage.setItem(LS_EDITOR_BASIC, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); try { localStorage.setItem(LS_EDITOR_BASIC, text); } catch(e) {} },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
@@ -374,7 +393,7 @@ window.__X1PEN_MODE = true;
         { language: 'asm',
           showLineNumbers: true,
           placeholder: '; Z80 Assembly\nORG 0E000h\n    LD A,042h\n    RET',
-          onChange: function(text) { lastAsmTabOrigin = 'user'; try { localStorage.setItem(LS_EDITOR_ASM, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); lastAsmTabOrigin = 'user'; try { localStorage.setItem(LS_EDITOR_ASM, text); } catch(e) {} },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
@@ -385,7 +404,7 @@ window.__X1PEN_MODE = true;
         { language: 'slang',
           showLineNumbers: true,
           placeholder: '// SLANG program\nVAR x = 42;\nmain() BEGIN\n  PRINT(x);\nEND;',
-          onChange: function(text) { try { localStorage.setItem(LS_EDITOR_SLANG, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); try { localStorage.setItem(LS_EDITOR_SLANG, text); } catch(e) {} },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
@@ -597,6 +616,62 @@ window.__X1PEN_MODE = true;
         return 'basic+asm';
     }
 
+    async function ensureSlangToolchain() {
+        if (!window.X1PenSlangCompiler) {
+            await new Promise(function(resolve, reject) {
+                var s = document.createElement('script');
+                s.src = 'x1pen_slang_compiler.js' + ((XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '');
+                s.onload = resolve;
+                s.onerror = function() { reject(new Error('Failed to load SLANG compiler')); };
+                document.head.appendChild(s);
+            });
+        }
+        if (window._slangRuntimeVFS) return;
+
+        var runtimeFiles = [
+            'runtime.asm', 'core.asm', 'opt.asm', 'libfloat.asm',
+            'liblsx_base.asm', 'libx1_base.asm', 'libx1_grp.asm',
+            'liblsx_input.asm', 'libx1_print.asm', 'liblsx_file.asm',
+            'libx1_pcg.asm', 'libmag.asm', 'libm8a.asm', 'libx1_psg.asm',
+            'libcompress.asm', 'libsoroban.asm', 'libx1_magic.asm', 'libx1_sgl_lsx.asm',
+        ];
+        var includeFiles = [
+            'GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB',
+            'CHIPLIB.LIB', 'SPRLIB.LIB', 'TILELIB.LIB', 'TILESPR.LIB', 'UILIB.LIB',
+        ];
+        var vfs = {};
+        var vBust = (XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '';
+        for (var ri = 0; ri < runtimeFiles.length; ri++) {
+            try {
+                var resp = await fetch('slang_runtime/' + runtimeFiles[ri] + vBust);
+                if (resp.ok) vfs[runtimeFiles[ri]] = await resp.text();
+            } catch(e) { /* optional file */ }
+        }
+        for (var ii = 0; ii < includeFiles.length; ii++) {
+            try {
+                var iresp = await fetch('slang_include/' + includeFiles[ii] + vBust);
+                if (iresp.ok) vfs[includeFiles[ii]] = await iresp.text();
+            } catch(e) { /* optional file */ }
+        }
+        window._slangRuntimeVFS = vfs;
+    }
+
+    async function getPredefinedSymbols(coldStateFile) {
+        var predefined = { OS_TYPE: 0, ENV_TYPE: 1 };
+        var versions = await loadAddrmapVersions();
+        var verName = COLD_STATE_VERSION[coldStateFile];
+        if (!versions || !verName || !versions[verName]) return predefined;
+
+        var ver = versions[verName];
+        var groups = [ver.user_hooks, ver.sound, ver.graphics];
+        for (var gi = 0; gi < groups.length; gi++) {
+            var group = groups[gi];
+            if (!group) continue;
+            for (var key in group) predefined[key] = parseInt(group[key], 16);
+        }
+        return predefined;
+    }
+
     // ── RUN ──
 
     async function onRunClick() {
@@ -623,51 +698,11 @@ window.__X1PEN_MODE = true;
         // SLANG → コンパイル → ASM に変換
         if (sourceMode === 'slang') {
             elStatus.textContent = 'Compiling SLANG...';
-            // 遅延ロード: SLANG コンパイラが未ロードなら動的ロード
-            if (!window.X1PenSlangCompiler) {
-                try {
-                    await new Promise(function(resolve, reject) {
-                        var s = document.createElement('script');
-                        s.src = 'x1pen_slang_compiler.js' + ((XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '');
-                        s.onload = resolve;
-                        s.onerror = function() { reject(new Error('Failed to load SLANG compiler')); };
-                        document.head.appendChild(s);
-                    });
-                } catch(e) {
-                    elStatus.textContent = e.message;
-                    return false;
-                }
-            }
-            // ランタイム .asm ファイルを virtualFS にロード (初回のみ fetch)
-            if (!window._slangRuntimeVFS) {
-                elStatus.textContent = 'Loading SLANG runtime...';
-                var runtimeFiles = [
-                    'runtime.asm', 'core.asm', 'opt.asm', 'libfloat.asm',
-                    'liblsx_base.asm', 'libx1_base.asm', 'libx1_grp.asm',
-                    'liblsx_input.asm', 'libx1_print.asm', 'liblsx_file.asm',
-                    'libx1_pcg.asm', 'libmag.asm', 'libm8a.asm', 'libx1_psg.asm',
-                    'libcompress.asm', 'libsoroban.asm', 'libx1_magic.asm', 'libx1_sgl_lsx.asm',
-                ];
-                var vfs = {};
-                var vBust = (XMIL_BUILD_HASH && XMIL_BUILD_HASH.indexOf('@@') < 0) ? '?v=' + XMIL_BUILD_HASH : '';
-                for (var ri = 0; ri < runtimeFiles.length; ri++) {
-                    try {
-                        var resp = await fetch('slang_runtime/' + runtimeFiles[ri] + vBust);
-                        if (resp.ok) vfs[runtimeFiles[ri]] = await resp.text();
-                    } catch(e) { /* optional file */ }
-                }
-                // インクルードファイルも読み込み
-                var includeFiles = [
-                    'GRAPH.LIB', 'GRAPHF.LIB', 'SOROBAN.LIB',
-                    'CHIPLIB.LIB', 'SPRLIB.LIB', 'TILELIB.LIB', 'TILESPR.LIB', 'UILIB.LIB',
-                ];
-                for (var ii = 0; ii < includeFiles.length; ii++) {
-                    try {
-                        var iresp = await fetch('slang_include/' + includeFiles[ii] + vBust);
-                        if (iresp.ok) vfs[includeFiles[ii]] = await iresp.text();
-                    } catch(e) { /* optional file */ }
-                }
-                window._slangRuntimeVFS = vfs;
+            try {
+                await ensureSlangToolchain();
+            } catch(e) {
+                elStatus.textContent = e.message;
+                return false;
             }
 
             // X1 環境固定 (ENV_TYPE: 0=CP/M, 1=LSX-Dodgers, 2=MSX-DOS)
@@ -691,6 +726,7 @@ window.__X1PEN_MODE = true;
             if (asmEditor) {
                 asmEditor.setValue(asmSrc, { silent: true });
                 lastAsmTabOrigin = 'slang-generated';
+                markProgramChanged();
             }
             elStatus.textContent = 'SLANG compiled (' + asmSrc.split('\n').length + ' lines)';
         }
@@ -765,24 +801,7 @@ window.__X1PEN_MODE = true;
 
         // 4. ASM アセンブル (タブに内容がある場合)
         //    addrmap から predefined symbols を構築
-        var predefined = {
-            OS_TYPE: 0,   // 0=LSX-Dodgers, 1=S-OS
-            ENV_TYPE: 1,  // 0=CP/M, 1=LSX-Dodgers(X1), 2=MSX-DOS
-        };
-        var versions = await loadAddrmapVersions();
-        var verName = COLD_STATE_VERSION[actualColdState];
-        if (versions && verName && versions[verName]) {
-            var ver = versions[verName];
-            if (ver.user_hooks) {
-                for (var k in ver.user_hooks) predefined[k] = parseInt(ver.user_hooks[k], 16);
-            }
-            if (ver.sound) {
-                for (var k in ver.sound) predefined[k] = parseInt(ver.sound[k], 16);
-            }
-            if (ver.graphics) {
-                for (var k in ver.graphics) predefined[k] = parseInt(ver.graphics[k], 16);
-            }
-        }
+        var predefined = await getPredefinedSymbols(actualColdState);
 
         var asmResult = null;
         if (asmSrc) {
@@ -1058,7 +1077,9 @@ window.__X1PEN_MODE = true;
             basic: basic,
             asm: asm,
             slang: slang,
-            sourceMode: inferSourceMode(basic.trim(), asm.trim(), slang.trim())
+            sourceMode: inferSourceMode(basic.trim(), asm.trim(), slang.trim()),
+            revision: automationRevision,
+            instanceId: automationInstanceId
         };
     }
 
@@ -1102,7 +1123,10 @@ window.__X1PEN_MODE = true;
         return { basic: basic, asm: asm, slang: slang, sourceMode: sourceMode };
     }
 
-    function setAutomationProgram(program) {
+    function setAutomationProgram(program, expectedRevision) {
+        if (expectedRevision !== undefined && expectedRevision !== automationRevision) {
+            throw new Error('Revision conflict: expected ' + expectedRevision + ', current ' + automationRevision);
+        }
         var normalized = normalizeAutomationProgram(program);
         basicEditor.setValue(normalized.basic, { silent: true });
         if (asmEditor) asmEditor.setValue(normalized.asm, { silent: true });
@@ -1110,19 +1134,150 @@ window.__X1PEN_MODE = true;
         lastAsmTabOrigin = normalized.asm ? 'user' : null;
         pendingShareRuntime = null;
         lastRunWasShared = false;
+        markProgramChanged();
         clearSymbols();
         forceResyncEditorTab(normalized.sourceMode === 'basic+asm' ? 'basic' : normalized.sourceMode);
         elStatus.textContent = 'Program loaded';
         return getAutomationProgram();
     }
 
+    function makeAutomationDiagnostic(kind, message, details) {
+        var diagnostic = {
+            kind: kind,
+            severity: (details && details.severity) || 'error',
+            message: String(message || 'Unknown error')
+        };
+        if (details && details.file) diagnostic.file = details.file;
+        if (details && Number.isFinite(details.line)) diagnostic.line = details.line;
+        if (details && Number.isFinite(details.column)) diagnostic.column = details.column;
+        return diagnostic;
+    }
+
+    async function validateAutomationProgram() {
+        var program = getAutomationProgram();
+        var diagnostics = [];
+        var asmSource = program.asm;
+        var generatedAsmLines = 0;
+        var asmBytes = 0;
+        var basicBytes = 0;
+
+        if (!program.basic.trim() && !program.asm.trim() && !program.slang.trim()) {
+            diagnostics.push(makeAutomationDiagnostic('program', 'Nothing to validate'));
+        }
+        if (program.sourceMode === 'slang' && diagnostics.length === 0) {
+            try {
+                await ensureSlangToolchain();
+                var slangEnv = { defaultOrg: 0x100, codeReadonly: false, defines: { ENV_TYPE: 1 } };
+                var slangResult = window.X1PenSlangCompiler.compile(program.slang.trim(), window._slangRuntimeVFS, slangEnv);
+                var slangErrors = slangResult.errors || [];
+                for (var si = 0; si < slangErrors.length; si++) {
+                    var slangError = slangErrors[si];
+                    var start = slangError.span && slangError.span.start;
+                    diagnostics.push(makeAutomationDiagnostic('slang', slangError.message || slangError, {
+                        severity: String(slangError.severity || 'error').toLowerCase(),
+                        file: start && start.fileName,
+                        line: start && start.line,
+                        column: start && start.column
+                    }));
+                }
+                asmSource = slangResult.asm || '';
+                generatedAsmLines = asmSource ? asmSource.split('\n').length : 0;
+            } catch(e) {
+                diagnostics.push(makeAutomationDiagnostic('slang', e.message));
+            }
+        }
+        if (asmSource.trim() && diagnostics.length === 0) {
+            var coldState = program.sourceMode === 'basic+asm' ? COLD_STATE_FILE : LSX_COLD_STATE;
+            var predefined = await getPredefinedSymbols(coldState);
+            var asmResult = window.X1PenZ80Asm.assemble(asmSource.trim(), predefined);
+            asmBytes = asmResult.bytes.length;
+            for (var ai = 0; ai < asmResult.errors.length; ai++) {
+                var asmError = asmResult.errors[ai];
+                diagnostics.push(makeAutomationDiagnostic('asm', asmError.msg, { line: asmError.line }));
+            }
+        }
+        if (program.sourceMode === 'basic+asm' && program.basic.trim() && diagnostics.length === 0) {
+            try {
+                basicBytes = window.X1PenTokenizer.tokenizeProgram(program.basic.trim()).length;
+            } catch(e) {
+                diagnostics.push(makeAutomationDiagnostic('basic', e.message));
+            }
+        }
+
+        return {
+            ok: diagnostics.length === 0,
+            sourceMode: program.sourceMode,
+            revision: automationRevision,
+            diagnostics: diagnostics,
+            output: {
+                basicBytes: basicBytes,
+                asmBytes: asmBytes,
+                generatedAsmLines: generatedAsmLines
+            }
+        };
+    }
+
     function getAutomationStatus() {
         return {
+            instanceId: automationInstanceId,
+            revision: automationRevision,
             ready: automationReadyState === 'ready',
             state: automationReadyState,
             busy: automationPendingOperations > 0,
+            connected: automationConnected,
+            interactionLocked: automationInteractionLocked,
+            title: document.title,
+            url: location.href,
             status: elStatus ? elStatus.textContent : ''
         };
+    }
+
+    function setAutomationConnectionState(connected, label) {
+        automationConnected = !!connected;
+        var badge = document.getElementById('x1pen-mcp-status');
+        if (badge) {
+            badge.textContent = label || 'MCP Connected';
+            badge.classList.toggle('hidden', !automationConnected);
+        }
+        return getAutomationStatus();
+    }
+
+    function setAutomationInteractionLocked(locked, label) {
+        var wasLocked = automationInteractionLocked;
+        if (locked) {
+            automationInteractionLockDepth++;
+        } else {
+            automationInteractionLockDepth = Math.max(0, automationInteractionLockDepth - 1);
+        }
+        automationInteractionLocked = automationInteractionLockDepth > 0;
+        var panel = document.getElementById('editor-panel');
+        var overlay = document.getElementById('x1pen-automation-lock');
+        if (!wasLocked && automationInteractionLocked && document.activeElement && document.activeElement.blur) {
+            document.activeElement.blur();
+        }
+        if (panel) panel.inert = automationInteractionLocked;
+        if (overlay) {
+            if (automationInteractionLocked && label) overlay.textContent = label;
+            if (!automationInteractionLocked) overlay.textContent = 'AI is editing...';
+            overlay.classList.toggle('hidden', !automationInteractionLocked);
+        }
+        var buttons = document.querySelectorAll('#x1pen-toolbar button');
+        buttons.forEach(function(button) {
+            if (!wasLocked && automationInteractionLocked) {
+                button.dataset.mcpWasDisabled = button.disabled ? '1' : '0';
+                button.disabled = true;
+            } else if (wasLocked && !automationInteractionLocked && button.dataset.mcpWasDisabled !== undefined) {
+                button.disabled = button.dataset.mcpWasDisabled === '1';
+                delete button.dataset.mcpWasDisabled;
+            }
+        });
+        return getAutomationStatus();
+    }
+
+    function captureAutomationScreen() {
+        var canvas = document.getElementById('canvas');
+        if (!canvas) throw new Error('X1Pen canvas not found');
+        return canvas.toDataURL('image/png');
     }
 
     function queueAutomationOperation(operation) {
@@ -1141,15 +1296,18 @@ window.__X1PEN_MODE = true;
     }
 
     window.X1PenAutomation = Object.freeze({
-        version: 1,
+        version: 2,
         ready: function() {
             return automationReadyPromise.then(getAutomationStatus);
         },
         getProgram: getAutomationProgram,
-        setProgram: function(program) {
+        setProgram: function(program, expectedRevision) {
             return queueAutomationOperation(function() {
-                return setAutomationProgram(program);
+                return setAutomationProgram(program, expectedRevision);
             });
+        },
+        validate: function() {
+            return queueAutomationOperation(validateAutomationProgram);
         },
         run: function() {
             return queueAutomationOperation(async function() {
@@ -1157,7 +1315,8 @@ window.__X1PEN_MODE = true;
                 return {
                     ok: ok,
                     status: elStatus ? elStatus.textContent : '',
-                    sourceMode: getAutomationProgram().sourceMode
+                    sourceMode: getAutomationProgram().sourceMode,
+                    revision: automationRevision
                 };
             });
         },
@@ -1167,7 +1326,10 @@ window.__X1PEN_MODE = true;
                 return getAutomationStatus();
             });
         },
-        getStatus: getAutomationStatus
+        getStatus: getAutomationStatus,
+        captureScreen: captureAutomationScreen,
+        setConnectionState: setAutomationConnectionState,
+        setInteractionLocked: setAutomationInteractionLocked
     });
 
     function showShareDialog(url) {
@@ -1552,6 +1714,7 @@ window.__X1PEN_MODE = true;
                     if (slangEditor) {
                         slangEditor.setValue(shared.slang || '', { silent: true });
                     }
+                    markProgramChanged();
                     // Share meta → pendingShareRuntime
                     if (shared.meta) {
                         var shareRelocAddrs = null;

--- a/mcp/x1pen-bridge.mjs
+++ b/mcp/x1pen-bridge.mjs
@@ -1,0 +1,234 @@
+import { randomInt, randomUUID } from 'node:crypto';
+import { WebSocket, WebSocketServer } from 'ws';
+
+const DEFAULT_START_PORT = 43110;
+const DEFAULT_END_PORT = 43119;
+const MAX_MESSAGE_BYTES = 2 * 1024 * 1024;
+
+function createPairingCode() {
+  return String(randomInt(100000, 1000000));
+}
+
+function isExtensionOrigin(origin) {
+  return typeof origin === 'string' && origin.startsWith('chrome-extension://');
+}
+
+export class X1PenBridge {
+  constructor(options = {}) {
+    this.host = '127.0.0.1';
+    const configuredPort = process.env.X1PEN_BRIDGE_PORT ? Number(process.env.X1PEN_BRIDGE_PORT) : DEFAULT_START_PORT;
+    this.startPort = options.startPort ?? configuredPort;
+    this.endPort = options.endPort ?? (this.startPort === DEFAULT_START_PORT ? DEFAULT_END_PORT : this.startPort);
+    this.pairingCode = options.pairingCode || createPairingCode();
+    this.commandTimeoutMs = options.commandTimeoutMs || 60_000;
+    this.allowOrigin = options.allowOrigin || isExtensionOrigin;
+    this.logger = options.logger || ((message) => console.error(`[x1pen-mcp] ${message}`));
+    this.server = null;
+    this.socket = null;
+    this.port = null;
+    this.sessions = new Map();
+    this.selectedSessionId = null;
+    this.pendingCommands = new Map();
+    this.keepAliveTimer = null;
+  }
+
+  async start() {
+    if (this.server) return this.connectionInfo();
+    let lastError;
+    for (let port = this.startPort; port <= this.endPort; port++) {
+      try {
+        await this.listen(port);
+        this.port = this.server.address().port;
+        this.keepAliveTimer = setInterval(() => {
+          if (this.socket?.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
+          }
+        }, 20_000);
+        this.logger(`browser bridge listening on ws://${this.host}:${this.port}`);
+        this.logger(`pairing code: ${this.pairingCode}`);
+        return this.connectionInfo();
+      } catch (error) {
+        lastError = error;
+        if (error.code !== 'EADDRINUSE') throw error;
+      }
+    }
+    throw new Error(`No X1Pen bridge port available (${this.startPort}-${this.endPort}): ${lastError?.message || 'unknown error'}`);
+  }
+
+  listen(port) {
+    return new Promise((resolve, reject) => {
+      const server = new WebSocketServer({
+        host: this.host,
+        port,
+        maxPayload: MAX_MESSAGE_BYTES,
+        verifyClient: ({ origin }) => this.allowOrigin(origin),
+      });
+      const onError = (error) => {
+        server.close();
+        reject(error);
+      };
+      server.once('error', onError);
+      server.once('listening', () => {
+        server.off('error', onError);
+        server.on('error', (error) => this.logger(`bridge error: ${error.message}`));
+        server.on('connection', (socket) => this.handleConnection(socket));
+        this.server = server;
+        resolve();
+      });
+    });
+  }
+
+  handleConnection(socket) {
+    let authenticated = false;
+    const authTimeout = setTimeout(() => socket.close(1008, 'Pairing timeout'), 10_000);
+
+    socket.on('message', (data) => {
+      let message;
+      try {
+        message = JSON.parse(data.toString());
+      } catch {
+        socket.close(1007, 'Invalid JSON');
+        return;
+      }
+
+      if (!authenticated) {
+        if (message.type !== 'pair' || message.code !== this.pairingCode) {
+          socket.close(1008, 'Invalid pairing code');
+          return;
+        }
+        clearTimeout(authTimeout);
+        authenticated = true;
+        if (this.socket && this.socket !== socket) {
+          this.rejectPending(new Error('X1Pen browser extension connection was replaced'));
+          this.socket.close(1012, 'Replaced by a new extension connection');
+        }
+        this.socket = socket;
+        this.sessions.clear();
+        this.selectedSessionId = null;
+        socket.send(JSON.stringify({ type: 'paired', protocolVersion: 1 }));
+        this.logger('browser extension paired');
+        return;
+      }
+
+      if (this.socket === socket) this.handleMessage(message);
+    });
+
+    socket.on('close', () => {
+      clearTimeout(authTimeout);
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.sessions.clear();
+      this.selectedSessionId = null;
+      this.rejectPending(new Error('X1Pen browser extension disconnected'));
+      this.logger('browser extension disconnected');
+    });
+  }
+
+  handleMessage(message) {
+    if (message.type === 'sessions' && Array.isArray(message.sessions)) {
+      this.sessions.clear();
+      for (const session of message.sessions.slice(0, 16)) {
+        if (!session || typeof session.sessionId !== 'string') continue;
+        this.sessions.set(session.sessionId, {
+          sessionId: session.sessionId,
+          title: String(session.title || 'X1Pen'),
+          url: String(session.url || ''),
+          active: !!session.active,
+          revision: Number.isInteger(session.revision) ? session.revision : 0,
+        });
+      }
+      if (this.selectedSessionId && !this.sessions.has(this.selectedSessionId)) this.selectedSessionId = null;
+      if (!this.selectedSessionId && this.sessions.size === 1) this.selectedSessionId = this.sessions.keys().next().value;
+      return;
+    }
+    if (message.type === 'result' && typeof message.id === 'string') {
+      const pending = this.pendingCommands.get(message.id);
+      if (!pending) return;
+      this.pendingCommands.delete(message.id);
+      clearTimeout(pending.timeout);
+      if (message.ok) pending.resolve(message.result);
+      else pending.reject(new Error(message.error || 'X1Pen command failed'));
+    }
+  }
+
+  connectionInfo() {
+    return {
+      host: this.host,
+      port: this.port,
+      pairingCode: this.pairingCode,
+      extensionConnected: !!this.socket,
+      sessionCount: this.sessions.size,
+      selectedSessionId: this.selectedSessionId,
+    };
+  }
+
+  listSessions() {
+    return Array.from(this.sessions.values()).map((session) => ({
+      ...session,
+      selected: session.sessionId === this.selectedSessionId,
+    }));
+  }
+
+  selectSession(sessionId) {
+    if (!this.sessions.has(sessionId)) throw new Error(`X1Pen session not found: ${sessionId}`);
+    this.selectedSessionId = sessionId;
+    return this.sessions.get(sessionId);
+  }
+
+  resolveSession(sessionId) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('X1Pen browser extension is not connected. Call x1pen_connection_info and pair the extension first.');
+    }
+    const resolved = sessionId || this.selectedSessionId;
+    if (resolved && this.sessions.has(resolved)) return resolved;
+    if (this.sessions.size === 1) return this.sessions.keys().next().value;
+    if (this.sessions.size === 0) throw new Error('No X1Pen tab is connected. Use the extension popup on an X1Pen tab.');
+    throw new Error('Multiple X1Pen tabs are connected. Call x1pen_list_sessions and x1pen_select_session first.');
+  }
+
+  sendCommand(method, params = {}, sessionId) {
+    const resolvedSessionId = this.resolveSession(sessionId);
+    const id = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingCommands.delete(id);
+        reject(new Error(`X1Pen command timed out: ${method}`));
+      }, this.commandTimeoutMs);
+      this.pendingCommands.set(id, { resolve, reject, timeout });
+      this.socket.send(JSON.stringify({
+        type: 'command',
+        id,
+        sessionId: resolvedSessionId,
+        method,
+        params,
+      }), (error) => {
+        if (!error) return;
+        clearTimeout(timeout);
+        this.pendingCommands.delete(id);
+        reject(error);
+      });
+    });
+  }
+
+  rejectPending(error) {
+    for (const pending of this.pendingCommands.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pendingCommands.clear();
+  }
+
+  async close() {
+    clearInterval(this.keepAliveTimer);
+    this.keepAliveTimer = null;
+    this.rejectPending(new Error('X1Pen bridge closed'));
+    if (this.socket) this.socket.close(1001, 'Server shutting down');
+    this.socket = null;
+    if (this.server) {
+      const server = this.server;
+      this.server = null;
+      await new Promise((resolve) => server.close(resolve));
+    }
+    this.port = null;
+  }
+}

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as z from 'zod/v4';
+import { X1PenBridge } from './x1pen-bridge.mjs';
+
+const MAX_SOURCE_LENGTH = 512 * 1024;
+
+function textResult(value) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+function toolError(error) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+  };
+}
+
+function handleTool(handler) {
+  return async (args) => {
+    try {
+      return await handler(args || {});
+    } catch (error) {
+      return toolError(error);
+    }
+  };
+}
+
+export function createX1PenMcpServer(options = {}) {
+  const bridge = options.bridge || new X1PenBridge(options.bridgeOptions);
+  const server = new McpServer({ name: 'x1pen', version: '2.0.0' });
+  const sessionInput = { sessionId: z.string().optional().describe('Connected X1Pen instance ID; omit when one tab is connected') };
+
+  server.registerTool('x1pen_connection_info', {
+    description: 'Get the local bridge port and pairing code used by the X1Pen Connector extension.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult(bridge.connectionInfo())));
+
+  server.registerTool('x1pen_list_sessions', {
+    description: 'List X1Pen browser tabs explicitly connected through the extension.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async () => textResult({ sessions: bridge.listSessions() })));
+
+  server.registerTool('x1pen_select_session', {
+    description: 'Select the X1Pen browser tab used by later tool calls.',
+    inputSchema: { sessionId: z.string().min(1) },
+    annotations: { openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(bridge.selectSession(sessionId))));
+
+  server.registerTool('x1pen_get_program', {
+    description: 'Get source and revision from the connected X1Pen tab.',
+    inputSchema: sessionInput,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('getProgram', {}, sessionId))));
+
+  server.registerTool('x1pen_set_program', {
+    description: 'Replace the complete program when expectedRevision still matches the connected X1Pen tab.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      expectedRevision: z.number().int().min(0),
+      sourceMode: z.enum(['basic+asm', 'asm', 'slang']),
+      basic: z.string().max(MAX_SOURCE_LENGTH).optional(),
+      asm: z.string().max(MAX_SOURCE_LENGTH).optional(),
+      slang: z.string().max(MAX_SOURCE_LENGTH).optional(),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, expectedRevision, ...program }) => textResult(await bridge.sendCommand(
+    'setProgram', { program, expectedRevision }, sessionId,
+  ))));
+
+  server.registerTool('x1pen_validate', {
+    description: 'Compile or tokenize the current program without running it.',
+    inputSchema: sessionInput,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('validate', {}, sessionId))));
+
+  server.registerTool('x1pen_run', {
+    description: 'Build and run the current program in the connected user-visible X1Pen tab.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      waitMs: z.number().int().min(0).max(10_000).default(500),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, waitMs }) => textResult(await bridge.sendCommand('run', { waitMs }, sessionId))));
+
+  server.registerTool('x1pen_stop', {
+    description: 'Send ESC to stop the program in the connected X1Pen tab.',
+    inputSchema: sessionInput,
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('stop', {}, sessionId))));
+
+  server.registerTool('x1pen_get_status', {
+    description: 'Get readiness, revision, lock and status state from the connected X1Pen tab.',
+    inputSchema: sessionInput,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('getStatus', {}, sessionId))));
+
+  server.registerTool('x1pen_capture_screen', {
+    description: 'Capture the connected X1Pen emulator canvas as a 640x400 PNG.',
+    inputSchema: sessionInput,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => {
+    const dataUrl = await bridge.sendCommand('captureScreen', {}, sessionId);
+    const comma = dataUrl.indexOf(',');
+    if (!dataUrl.startsWith('data:image/png;base64,') || comma < 0) throw new Error('Invalid PNG data returned by X1Pen');
+    return {
+      content: [
+        { type: 'text', text: 'Current user-visible X1Pen screen (640x400 PNG).' },
+        { type: 'image', data: dataUrl.slice(comma + 1), mimeType: 'image/png' },
+      ],
+    };
+  }));
+
+  return { server, bridge };
+}
+
+async function main() {
+  const { server, bridge } = createX1PenMcpServer();
+  await bridge.start();
+  let closing = false;
+  const close = async () => {
+    if (closing) return;
+    closing = true;
+    await bridge.close();
+    await server.close();
+  };
+  process.once('SIGINT', () => close().finally(() => process.exit(0)));
+  process.once('SIGTERM', () => close().finally(() => process.exit(0)));
+  await server.connect(new StdioServerTransport());
+  console.error('[x1pen-mcp] server ready on stdio');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error('[x1pen-mcp] fatal:', error);
+    process.exit(1);
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,17 @@
         "@codemirror/language": "^6.0.0",
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
+        "@codemirror/view": "^6.0.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "ws": "^8.21.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "esbuild": "^0.21.0",
         "playwright": "^1.62.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@codemirror/commands": {
@@ -466,6 +472,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
@@ -496,11 +514,328 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -541,6 +876,165 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -554,6 +1048,343 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -588,17 +1419,376 @@
         "node": ">=20"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "private": true,
   "name": "xmil-web",
   "description": "X millennium Web - SHARP X1 Emulator",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "esbuild": "^0.21.0",
     "playwright": "^1.62.1"
@@ -11,10 +14,16 @@
     "@codemirror/language": "^6.0.0",
     "@codemirror/search": "^6.0.0",
     "@codemirror/state": "^6.0.0",
-    "@codemirror/view": "^6.0.0"
+    "@codemirror/view": "^6.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "ws": "^8.21.2",
+    "zod": "^3.25.76"
   },
   "scripts": {
     "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify",
-    "test:automation": "node --test tests/x1pen_automation_test.mjs"
+    "mcp:x1pen": "node mcp/x1pen-server.mjs",
+    "test:automation": "node --test tests/x1pen_automation_test.mjs",
+    "test:bridge": "node --test tests/x1pen_bridge_test.mjs",
+    "test:mcp": "node --test tests/x1pen_mcp_test.mjs"
   }
 }

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -71,7 +71,7 @@ after(async () => {
 test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async () => {
   const ready = await page.evaluate(() => window.X1PenAutomation.ready());
   assert.equal(ready.ready, true);
-  assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 1);
+  assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
 
   const program = {
     sourceMode: 'basic+asm',
@@ -79,8 +79,18 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
     asm: '',
     slang: '',
   };
-  const loaded = await page.evaluate((value) => window.X1PenAutomation.setProgram(value), program);
-  assert.deepEqual(loaded, program);
+  const loaded = await page.evaluate((value) => {
+    const current = window.X1PenAutomation.getProgram();
+    return window.X1PenAutomation.setProgram(value, current.revision);
+  }, program);
+  assert.equal(loaded.basic, program.basic);
+  assert.equal(loaded.sourceMode, program.sourceMode);
+  assert.equal(loaded.revision, 1);
+  assert.equal(typeof loaded.instanceId, 'string');
+
+  const validation = await page.evaluate(() => window.X1PenAutomation.validate());
+  assert.equal(validation.ok, true);
+  assert.ok(validation.output.basicBytes > 0);
 
   await page.evaluate(() => window.XmilControls.setKeyMode(1));
   const result = await page.evaluate(() => window.X1PenAutomation.run());
@@ -104,10 +114,80 @@ test('automation operations are serialized and stale source modes are cleared', 
 
   assert.equal(programs.results[0].sourceMode, 'asm');
   assert.equal(programs.results[1].sourceMode, 'slang');
-  assert.deepEqual(programs.final, {
-    basic: '',
-    asm: '',
-    slang: 'main() BEGIN\nEND;',
-    sourceMode: 'slang',
+  assert.equal(programs.final.basic, '');
+  assert.equal(programs.final.asm, '');
+  assert.equal(programs.final.slang, 'main() BEGIN\nEND;');
+  assert.equal(programs.final.sourceMode, 'slang');
+  assert.ok(programs.final.revision > programs.results[0].revision);
+});
+
+test('revision conflicts prevent stale AI updates', async () => {
+  const result = await page.evaluate(async () => {
+    const stale = window.X1PenAutomation.getProgram().revision;
+    await window.X1PenAutomation.setProgram({ sourceMode: 'basic+asm', basic: '10 PRINT "HUMAN"' });
+    try {
+      await window.X1PenAutomation.setProgram({ sourceMode: 'basic+asm', basic: '10 PRINT "AI"' }, stale);
+      return null;
+    } catch (error) {
+      return error.message;
+    }
   });
+  assert.match(result, /Revision conflict/);
+});
+
+test('connection state and AI interaction lock are visible', async () => {
+  const locked = await page.evaluate(() => {
+    window.X1PenAutomation.setConnectionState(true);
+    const status = window.X1PenAutomation.setInteractionLocked(true, 'AI test');
+    return {
+      status,
+      panelInert: document.getElementById('editor-panel').inert,
+      overlay: document.getElementById('x1pen-automation-lock').textContent,
+      badgeHidden: document.getElementById('x1pen-mcp-status').classList.contains('hidden'),
+    };
+  });
+  assert.equal(locked.status.connected, true);
+  assert.equal(locked.status.interactionLocked, true);
+  assert.equal(locked.panelInert, true);
+  assert.equal(locked.overlay, 'AI test');
+  assert.equal(locked.badgeHidden, false);
+
+  const nested = await page.evaluate(() => {
+    window.X1PenAutomation.setInteractionLocked(true, 'Second AI operation');
+    window.X1PenAutomation.setInteractionLocked(false);
+    return {
+      status: window.X1PenAutomation.getStatus(),
+      panelInert: document.getElementById('editor-panel').inert,
+      runDisabled: document.getElementById('btn-run').disabled,
+    };
+  });
+  assert.equal(nested.status.interactionLocked, true, 'one completed operation must not release another operation lock');
+  assert.equal(nested.panelInert, true);
+  assert.equal(nested.runDisabled, true);
+
+  const unlocked = await page.evaluate(() => {
+    window.X1PenAutomation.setInteractionLocked(false);
+    window.X1PenAutomation.setConnectionState(false);
+    return {
+      status: window.X1PenAutomation.getStatus(),
+      panelInert: document.getElementById('editor-panel').inert,
+      hasSavedButtonState: document.getElementById('btn-run').dataset.mcpWasDisabled !== undefined,
+    };
+  });
+  assert.equal(unlocked.status.interactionLocked, false);
+  assert.equal(unlocked.panelInert, false);
+  assert.equal(unlocked.hasSavedButtonState, false);
+});
+
+test('automation validation and capture return structured results', async () => {
+  await page.evaluate(() => window.X1PenAutomation.setProgram({ sourceMode: 'asm', asm: 'ORG $100\nBOGUS A' }));
+  const validation = await page.evaluate(() => window.X1PenAutomation.validate());
+  assert.equal(validation.ok, false);
+  assert.equal(validation.diagnostics[0].kind, 'asm');
+  assert.equal(validation.diagnostics[0].line, 2);
+
+  const dataUrl = await page.evaluate(() => window.X1PenAutomation.captureScreen());
+  const png = Buffer.from(dataUrl.split(',')[1], 'base64');
+  assert.equal(png.readUInt32BE(16), 640);
+  assert.equal(png.readUInt32BE(20), 400);
 });

--- a/tests/x1pen_bridge_test.mjs
+++ b/tests/x1pen_bridge_test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { WebSocket } from 'ws';
+import { X1PenBridge } from '../mcp/x1pen-bridge.mjs';
+
+const openBridges = new Set();
+const openSockets = new Set();
+
+afterEach(async () => {
+  for (const socket of openSockets) socket.close();
+  openSockets.clear();
+  for (const bridge of openBridges) await bridge.close();
+  openBridges.clear();
+});
+
+async function connectExtension(bridge) {
+  const socket = new WebSocket(`ws://127.0.0.1:${bridge.port}`, {
+    origin: 'chrome-extension://x1pen-test',
+  });
+  openSockets.add(socket);
+  await new Promise((resolve, reject) => {
+    socket.once('open', resolve);
+    socket.once('error', reject);
+  });
+  const paired = waitForMessage(socket, (message) => message.type === 'paired');
+  socket.send(JSON.stringify({ type: 'pair', code: bridge.pairingCode }));
+  await paired;
+  return socket;
+}
+
+function waitForMessage(socket, predicate) {
+  return new Promise((resolve) => {
+    const listener = (data) => {
+      const message = JSON.parse(data.toString());
+      if (!predicate(message)) return;
+      socket.off('message', listener);
+      resolve(message);
+    };
+    socket.on('message', listener);
+  });
+}
+
+test('bridge rejects WebSocket connections from ordinary web pages', async () => {
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = new WebSocket(`ws://127.0.0.1:${bridge.port}`, {
+    origin: 'https://example.test',
+  });
+  openSockets.add(socket);
+  await assert.rejects(new Promise((resolve, reject) => {
+    socket.once('open', resolve);
+    socket.once('error', reject);
+  }));
+});
+
+test('bridge pairs an extension and routes commands to one X1Pen tab', async () => {
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = await connectExtension(bridge);
+  socket.send(JSON.stringify({
+    type: 'sessions',
+    sessions: [{ sessionId: 'tab-a', title: 'X1Pen A', url: 'https://example.test/x1pen', active: true, revision: 4 }],
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const commandMessage = waitForMessage(socket, (message) => message.type === 'command');
+  const commandPromise = bridge.sendCommand('getProgram');
+  const command = await commandMessage;
+  assert.equal(command.sessionId, 'tab-a');
+  assert.equal(command.method, 'getProgram');
+  socket.send(JSON.stringify({ type: 'result', id: command.id, ok: true, result: { revision: 4 } }));
+  assert.deepEqual(await commandPromise, { revision: 4 });
+});
+
+test('bridge requires explicit selection when multiple tabs are connected', async () => {
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = await connectExtension(bridge);
+  socket.send(JSON.stringify({
+    type: 'sessions',
+    sessions: [
+      { sessionId: 'tab-a', title: 'A' },
+      { sessionId: 'tab-b', title: 'B' },
+    ],
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.throws(() => bridge.sendCommand('getStatus'), /Multiple X1Pen tabs/);
+  bridge.selectSession('tab-b');
+  const commandMessage = waitForMessage(socket, (message) => message.type === 'command');
+  const commandPromise = bridge.sendCommand('getStatus');
+  const command = await commandMessage;
+  assert.equal(command.sessionId, 'tab-b');
+  socket.send(JSON.stringify({ type: 'result', id: command.id, ok: true, result: { ready: true } }));
+  await commandPromise;
+});
+
+test('a replacement extension rejects commands waiting on the old connection', async () => {
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const firstSocket = await connectExtension(bridge);
+  firstSocket.send(JSON.stringify({
+    type: 'sessions',
+    sessions: [{ sessionId: 'tab-a', title: 'A' }],
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const waitingCommand = bridge.sendCommand('getStatus');
+  const rejectedCommand = assert.rejects(waitingCommand, /connection was replaced/);
+  await connectExtension(bridge);
+  await rejectedCommand;
+});

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { after, before, test } from 'node:test';
+import { createX1PenMcpServer } from '../mcp/x1pen-server.mjs';
+
+const program = {
+  sourceMode: 'basic+asm',
+  basic: '10 PRINT "MCP"',
+  asm: '',
+  slang: '',
+  revision: 3,
+  instanceId: 'tab-a',
+};
+const calls = [];
+const fakeBridge = {
+  connectionInfo() { return { port: 43110, pairingCode: '123456', extensionConnected: true }; },
+  listSessions() { return [{ sessionId: 'tab-a', title: 'X1Pen', selected: true }]; },
+  selectSession(sessionId) { return { sessionId }; },
+  async sendCommand(method, params, sessionId) {
+    calls.push({ method, params, sessionId });
+    if (method === 'getProgram' || method === 'setProgram') return program;
+    if (method === 'validate') return { ok: true, diagnostics: [] };
+    if (method === 'captureScreen') return `data:image/png;base64,${Buffer.from('png').toString('base64')}`;
+    return { ok: true };
+  },
+  async close() {},
+};
+
+let server;
+let client;
+
+before(async () => {
+  ({ server } = createX1PenMcpServer({ bridge: fakeBridge }));
+  client = new Client({ name: 'x1pen-mcp-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+after(async () => {
+  if (client) await client.close();
+  if (server) await server.close();
+});
+
+test('server exposes browser connection and X1Pen tools', async () => {
+  const tools = await client.listTools();
+  assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), [
+    'x1pen_capture_screen',
+    'x1pen_connection_info',
+    'x1pen_get_program',
+    'x1pen_get_status',
+    'x1pen_list_sessions',
+    'x1pen_run',
+    'x1pen_select_session',
+    'x1pen_set_program',
+    'x1pen_stop',
+    'x1pen_validate',
+  ]);
+});
+
+test('set_program forwards expected revision and source to the selected tab', async () => {
+  const result = await client.callTool({
+    name: 'x1pen_set_program',
+    arguments: { sourceMode: 'basic+asm', basic: program.basic, expectedRevision: 3 },
+  });
+  assert.equal(result.isError, undefined);
+  assert.equal(calls.at(-1).method, 'setProgram');
+  assert.equal(calls.at(-1).params.expectedRevision, 3);
+  assert.equal(calls.at(-1).params.program.basic, program.basic);
+});
+
+test('capture_screen returns an MCP PNG image', async () => {
+  const result = await client.callTool({ name: 'x1pen_capture_screen', arguments: {} });
+  const image = result.content.find((item) => item.type === 'image');
+  assert.equal(image.mimeType, 'image/png');
+  assert.equal(Buffer.from(image.data, 'base64').toString(), 'png');
+});


### PR DESCRIPTION
## Summary

- add a Chromium MV3 connector that explicitly attaches the active X1Pen tab
- add a loopback-only WebSocket bridge and stdio MCP server for Codex / Claude Code
- extend the Automation API with revisions, structured validation, screenshots, connection state, and re-entrant interaction locking
- preserve multiple-tab safety with explicit session listing/selection
- document local setup, pairing, security boundaries, and supported browsers

#51 has been merged and this PR now targets main. It replaces the headless, agent-owned browser approach from closed #52.

## Security

- binds only to 127.0.0.1
- requires a six-digit pairing code
- accepts WebSocket connections only from chrome-extension:// origins
- uses activeTab instead of broad host or debugger permissions
- exposes an allowlist of X1Pen Automation API operations, not arbitrary JavaScript
- rejects stale source updates by revision

## Validation

- ./build.sh
- npm run test:automation (5 passed)
- npm run test:bridge (4 passed)
- npm run test:mcp (3 passed)
- node tests/z80asm_test.js (322 passed)
- npm audit --omit=dev (0 vulnerabilities)
- node --check for page, MCP, and extension JavaScript
- Codex MCP config: enabled
- Claude Code MCP config: detected, pending first-use approval

The unpacked extension installation remains a manual browser step because current branded Chrome builds do not permit reliable command-line sideloading for automated smoke tests.

Closes #50