### PR TITLE
Reduce X1Pen MCP source context usage

### DIFF
--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -62,15 +62,58 @@ claude
 | `x1pen_connection_info` | 拡張機能の接続情報を取得 |
 | `x1pen_list_sessions` | 接続済みX1Penタブを一覧表示 |
 | `x1pen_select_session` | 操作対象タブを選択 |
-| `x1pen_get_program` | ソース、instance ID、revisionを取得 |
-| `x1pen_set_program` | revision一致時だけプログラム全体を更新 |
+| `x1pen_get_program` | メタデータと明示指定した完全ソースを取得 |
+| `x1pen_get_source` | 1セクションを行範囲・文字数上限付きで取得 |
+| `x1pen_search_source` | 1セクションをリテラル検索し、限定した前後行を取得 |
+| `x1pen_apply_edits` | revision一致時だけ構造化された行編集を適用 |
+| `x1pen_set_program` | revision一致時だけプログラム全体を更新（新規作成・全置換用） |
 | `x1pen_validate` | 実行せずにコンパイル、アセンブル、トークナイズ |
 | `x1pen_run` | ユーザーが開いているX1Penで実行 |
 | `x1pen_stop` | ESCを送信して停止 |
 | `x1pen_get_status` | 接続、ロック、実行状態を取得 |
 | `x1pen_capture_screen` | 640x400のエミュレーター画面をPNG取得 |
 
-AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`は`x1pen_get_program`で取得した`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
+AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
+
+### 大きなプログラムの扱い
+
+`x1pen_get_program`は引数なしの場合、`sourceMode`、`revision`、各セクションの行数・文字数だけを返します。完全ソースが必要な場合だけ`fields`を明示します。SLANGから生成されたASMは`includeGeneratedAsm: true`を明示しない限り返しません。完全取得には既定で128 KiBの上限があり、超えるソースは`x1pen_get_source`で分割取得します。
+
+```json
+{
+  "fields": ["slang"],
+  "includeGeneratedAsm": false
+}
+```
+
+大きなソースは、まず`x1pen_search_source`で位置を探し、`x1pen_get_source`で必要な範囲だけを取得します。
+
+```json
+{
+  "section": "slang",
+  "startLine": 100,
+  "lineCount": 200,
+  "maxCharacters": 32768
+}
+```
+
+既存プログラムの変更には、全置換ではなく`x1pen_apply_edits`を使用します。行番号は1始まりで、同一リクエスト内の編集範囲は重複できません。応答には新しいrevisionと変更行数だけが含まれ、完全ソースは返りません。
+
+```json
+{
+  "section": "slang",
+  "expectedRevision": 3,
+  "edits": [
+    {
+      "startLine": 120,
+      "deleteLineCount": 4,
+      "text": "replacement source"
+    }
+  ]
+}
+```
+
+SLANG編集中のASMは生成物として読み取り・編集とも既定で保護されます。SLANGへ編集を適用すると古い生成ASMは破棄され、次回の検証・実行時に再生成されます。
 
 Share機能はユーザーが開いているX1Pen自身から実行するため、本番X1Pen上では既存のShare APIと公開URLをそのまま利用できます。
 

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -8,11 +8,13 @@ import * as z from 'zod/v4';
 import { X1PenBridge } from './x1pen-bridge.mjs';
 
 const MAX_SOURCE_LENGTH = 512 * 1024;
+const DEFAULT_RANGE_CHARACTERS = 32 * 1024;
+const MAX_RANGE_CHARACTERS = 128 * 1024;
+const SOURCE_SECTIONS = ['basic', 'asm', 'slang'];
 
 function textResult(value) {
   return {
-    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
-    structuredContent: value,
+    content: [{ type: 'text', text: JSON.stringify(value) }],
   };
 }
 
@@ -33,9 +35,241 @@ function handleTool(handler) {
   };
 }
 
+function normalizeProgramSnapshot(value) {
+  if (!value || typeof value !== 'object') throw new Error('X1Pen returned an invalid program snapshot');
+  const sourceMode = value.sourceMode;
+  if (!['basic+asm', 'asm', 'slang'].includes(sourceMode)) {
+    throw new Error(`X1Pen returned an invalid source mode: ${sourceMode}`);
+  }
+  if (!Number.isInteger(value.revision) || value.revision < 0) {
+    throw new Error('X1Pen returned an invalid program revision');
+  }
+  const snapshot = {
+    sourceMode,
+    revision: value.revision,
+    instanceId: typeof value.instanceId === 'string' ? value.instanceId : undefined,
+  };
+  for (const section of SOURCE_SECTIONS) {
+    if (typeof value[section] !== 'string') throw new Error(`X1Pen returned invalid ${section} source`);
+    snapshot[section] = value[section];
+  }
+  return snapshot;
+}
+
+function sourceLineCount(source) {
+  return source.length === 0 ? 0 : source.split('\n').length;
+}
+
+function summarizeProgram(snapshot) {
+  const sections = {};
+  for (const section of SOURCE_SECTIONS) {
+    sections[section] = {
+      lineCount: sourceLineCount(snapshot[section]),
+      characterCount: snapshot[section].length,
+    };
+  }
+  sections.asm.generated = snapshot.sourceMode === 'slang' && snapshot.asm.length > 0;
+  return {
+    sourceMode: snapshot.sourceMode,
+    revision: snapshot.revision,
+    ...(snapshot.instanceId ? { instanceId: snapshot.instanceId } : {}),
+    sections,
+  };
+}
+
+function selectProgramFields(snapshot, fields, includeGeneratedAsm, maxCharacters) {
+  const requested = [...new Set(fields || [])];
+  const result = {
+    ...summarizeProgram(snapshot),
+    includedFields: [],
+    omittedFields: [],
+  };
+  let selectedCharacters = 0;
+  for (const section of requested) {
+    const generatedAsm = section === 'asm' && snapshot.sourceMode === 'slang' && snapshot.asm.length > 0;
+    if (generatedAsm && !includeGeneratedAsm) {
+      result.omittedFields.push({ field: section, reason: 'generated ASM is excluded by default' });
+      continue;
+    }
+    selectedCharacters += snapshot[section].length;
+    if (selectedCharacters > maxCharacters) {
+      throw new Error(`Selected sources contain ${selectedCharacters} characters, exceeding maxCharacters ${maxCharacters}. Use x1pen_get_source or raise maxCharacters explicitly.`);
+    }
+    result[section] = snapshot[section];
+    result.includedFields.push(section);
+  }
+  return result;
+}
+
+function getReadableSection(snapshot, section, includeGeneratedAsm) {
+  if (section === 'asm' && snapshot.sourceMode === 'slang' && snapshot.asm.length > 0 && !includeGeneratedAsm) {
+    throw new Error('ASM is generated from SLANG. Set includeGeneratedAsm to true to read it.');
+  }
+  return snapshot[section];
+}
+
+function getSourceRange(snapshot, section, options) {
+  const source = getReadableSection(snapshot, section, options.includeGeneratedAsm);
+  const lines = source.length === 0 ? [] : source.split('\n');
+  if (lines.length === 0) {
+    return {
+      section,
+      revision: snapshot.revision,
+      startLine: 1,
+      endLine: 0,
+      totalLines: 0,
+      text: '',
+      truncated: false,
+    };
+  }
+  if (options.startLine > lines.length) {
+    throw new Error(`startLine ${options.startLine} exceeds ${section} line count ${lines.length}`);
+  }
+
+  const requested = lines.slice(options.startLine - 1, options.startLine - 1 + options.lineCount);
+  const selected = [];
+  let characterCount = 0;
+  let lineTruncated = false;
+  for (const line of requested) {
+    const separatorLength = selected.length > 0 ? 1 : 0;
+    if (characterCount + separatorLength + line.length <= options.maxCharacters) {
+      selected.push(line);
+      characterCount += separatorLength + line.length;
+      continue;
+    }
+    if (selected.length === 0) {
+      selected.push(line.slice(0, options.maxCharacters));
+      lineTruncated = true;
+    }
+    break;
+  }
+  const endLine = options.startLine + selected.length - 1;
+  return {
+    section,
+    revision: snapshot.revision,
+    startLine: options.startLine,
+    endLine,
+    totalLines: lines.length,
+    text: selected.join('\n'),
+    truncated: lineTruncated || endLine < lines.length,
+    lineTruncated,
+    nextStartLine: lineTruncated || endLine >= lines.length ? null : endLine + 1,
+  };
+}
+
+function clipSearchLine(line, matchIndex, maxLength = 500) {
+  if (line.length <= maxLength) return { text: line, columnOffset: 0, truncated: false };
+  const start = Math.max(0, Math.min(matchIndex - Math.floor(maxLength / 3), line.length - maxLength));
+  return {
+    text: `${start > 0 ? '...' : ''}${line.slice(start, start + maxLength)}${start + maxLength < line.length ? '...' : ''}`,
+    columnOffset: start,
+    truncated: true,
+  };
+}
+
+function searchSource(snapshot, section, options) {
+  const source = getReadableSection(snapshot, section, options.includeGeneratedAsm);
+  const lines = source.length === 0 ? [] : source.split('\n');
+  const needle = options.caseSensitive ? options.query : options.query.toLowerCase();
+  const matches = [];
+  let totalMatches = 0;
+  for (let index = 0; index < lines.length; index++) {
+    const haystack = options.caseSensitive ? lines[index] : lines[index].toLowerCase();
+    let searchFrom = 0;
+    while (searchFrom <= haystack.length) {
+      const columnIndex = haystack.indexOf(needle, searchFrom);
+      if (columnIndex < 0) break;
+      totalMatches++;
+      if (matches.length < options.maxResults) {
+        const contextStart = Math.max(0, index - options.contextLines);
+        const contextEnd = Math.min(lines.length - 1, index + options.contextLines);
+        const context = [];
+        for (let contextIndex = contextStart; contextIndex <= contextEnd; contextIndex++) {
+          const clipped = clipSearchLine(lines[contextIndex], contextIndex === index ? columnIndex : 0);
+          context.push({ line: contextIndex + 1, text: clipped.text, truncated: clipped.truncated });
+        }
+        const matchLine = clipSearchLine(lines[index], columnIndex);
+        matches.push({
+          line: index + 1,
+          column: columnIndex + 1,
+          displayedColumn: columnIndex - matchLine.columnOffset + 1 + (matchLine.columnOffset > 0 ? 3 : 0),
+          context,
+        });
+      }
+      searchFrom = columnIndex + needle.length;
+    }
+  }
+  return {
+    section,
+    revision: snapshot.revision,
+    query: options.query,
+    totalMatches,
+    matches,
+    truncated: totalMatches > matches.length,
+  };
+}
+
+function applyLineEdits(source, edits) {
+  const lines = source.length === 0 ? [] : source.split('\n');
+  const normalized = edits.map((edit, index) => {
+    const startIndex = edit.startLine - 1;
+    if (startIndex > lines.length || (edit.deleteLineCount > 0 && startIndex === lines.length)) {
+      throw new Error(`edit ${index + 1} starts beyond the source at line ${edit.startLine}`);
+    }
+    if (startIndex + edit.deleteLineCount > lines.length) {
+      throw new Error(`edit ${index + 1} deletes beyond the end of the source`);
+    }
+    return {
+      index,
+      startIndex,
+      endIndex: startIndex + edit.deleteLineCount,
+      replacementLines: edit.text.length === 0 ? [] : edit.text.split('\n'),
+      startLine: edit.startLine,
+      deleteLineCount: edit.deleteLineCount,
+    };
+  });
+
+  const ascending = [...normalized].sort((left, right) => left.startIndex - right.startIndex);
+  for (let index = 1; index < ascending.length; index++) {
+    const previous = ascending[index - 1];
+    const current = ascending[index];
+    if (current.startIndex === previous.startIndex || current.startIndex < previous.endIndex) {
+      throw new Error(`edits ${previous.index + 1} and ${current.index + 1} overlap`);
+    }
+  }
+
+  let outputLines = [];
+  let cursor = 0;
+  for (const edit of ascending) {
+    outputLines = outputLines.concat(lines.slice(cursor, edit.startIndex), edit.replacementLines);
+    cursor = edit.endIndex;
+  }
+  outputLines = outputLines.concat(lines.slice(cursor));
+  return {
+    source: outputLines.join('\n'),
+    changes: normalized.map((edit) => ({
+      startLine: edit.startLine,
+      oldLineCount: edit.deleteLineCount,
+      newLineCount: edit.replacementLines.length,
+    })),
+  };
+}
+
+function assertEditableSection(snapshot, section) {
+  if (snapshot.sourceMode === 'slang' && section !== 'slang') {
+    throw new Error('SLANG mode only allows edits to the SLANG source; generated ASM is read-only');
+  }
+  if (snapshot.sourceMode === 'asm' && section !== 'asm') {
+    throw new Error('ASM mode only allows edits to the ASM source');
+  }
+  if (snapshot.sourceMode === 'basic+asm' && section === 'slang') {
+    throw new Error('BASIC+ASM mode does not allow edits to the SLANG source');
+  }
+}
+
 export function createX1PenMcpServer(options = {}) {
   const bridge = options.bridge || new X1PenBridge(options.bridgeOptions);
-  const server = new McpServer({ name: 'x1pen', version: '2.0.0' });
+  const server = new McpServer({ name: 'x1pen', version: '2.1.0' });
   const sessionInput = { sessionId: z.string().optional().describe('Connected X1Pen instance ID; omit when one tab is connected') };
 
   server.registerTool('x1pen_connection_info', {
@@ -55,10 +289,21 @@ export function createX1PenMcpServer(options = {}) {
   }, handleTool(async ({ sessionId }) => textResult(bridge.selectSession(sessionId))));
 
   server.registerTool('x1pen_get_program', {
-    description: 'Get source and revision from the connected X1Pen tab.',
-    inputSchema: sessionInput,
+    description: 'Get a compact program summary and explicitly selected complete sources. Defaults to metadata only; prefer get_source/search_source for large sources.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      fields: z.array(z.enum(SOURCE_SECTIONS)).max(3).optional()
+        .describe('Complete sources to include; omit or pass [] for metadata only'),
+      includeGeneratedAsm: z.boolean().default(false)
+        .describe('Allow generated ASM to be returned when the program is in SLANG mode'),
+      maxCharacters: z.number().int().min(1).max(MAX_SOURCE_LENGTH).default(MAX_RANGE_CHARACTERS)
+        .describe('Maximum combined size of explicitly selected complete sources'),
+    },
     annotations: { readOnlyHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('getProgram', {}, sessionId))));
+  }, handleTool(async ({ sessionId, fields, includeGeneratedAsm, maxCharacters }) => {
+    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    return textResult(selectProgramFields(snapshot, fields, includeGeneratedAsm, maxCharacters));
+  }));
 
   server.registerTool('x1pen_set_program', {
     description: 'Replace the complete program when expectedRevision still matches the connected X1Pen tab.',
@@ -71,9 +316,104 @@ export function createX1PenMcpServer(options = {}) {
       slang: z.string().max(MAX_SOURCE_LENGTH).optional(),
     },
     annotations: { destructiveHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId, expectedRevision, ...program }) => textResult(await bridge.sendCommand(
-    'setProgram', { program, expectedRevision }, sessionId,
-  ))));
+  }, handleTool(async ({ sessionId, expectedRevision, ...program }) => {
+    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand(
+      'setProgram', { program, expectedRevision }, sessionId,
+    ));
+    return textResult({ ok: true, ...summarizeProgram(snapshot) });
+  }));
+
+  server.registerTool('x1pen_get_source', {
+    description: 'Read a bounded line range from one X1Pen source section without returning the complete program.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      section: z.enum(SOURCE_SECTIONS),
+      startLine: z.number().int().min(1).default(1),
+      lineCount: z.number().int().min(1).max(1_000).default(200),
+      maxCharacters: z.number().int().min(1).max(MAX_RANGE_CHARACTERS).default(DEFAULT_RANGE_CHARACTERS),
+      includeGeneratedAsm: z.boolean().default(false),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, section, ...options }) => {
+    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    return textResult(getSourceRange(snapshot, section, options));
+  }));
+
+  server.registerTool('x1pen_search_source', {
+    description: 'Find literal text in one X1Pen source section and return bounded line context around matches.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      section: z.enum(SOURCE_SECTIONS),
+      query: z.string().min(1).max(1_024),
+      caseSensitive: z.boolean().default(false),
+      contextLines: z.number().int().min(0).max(5).default(2),
+      maxResults: z.number().int().min(1).max(20).default(20),
+      includeGeneratedAsm: z.boolean().default(false),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, section, ...options }) => {
+    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    return textResult(searchSource(snapshot, section, options));
+  }));
+
+  server.registerTool('x1pen_apply_edits', {
+    description: 'Apply non-overlapping line edits to one authoring source when expectedRevision still matches. Line numbers are 1-based.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      section: z.enum(SOURCE_SECTIONS),
+      expectedRevision: z.number().int().min(0),
+      edits: z.array(z.object({
+        startLine: z.number().int().min(1),
+        deleteLineCount: z.number().int().min(0),
+        text: z.string().max(MAX_SOURCE_LENGTH),
+      })).min(1).max(100),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, section, expectedRevision, edits }) => {
+    const replacementSize = edits.reduce((total, edit) => total + edit.text.length, 0);
+    if (replacementSize > MAX_SOURCE_LENGTH) {
+      throw new Error(`Combined replacement text exceeds ${MAX_SOURCE_LENGTH} characters`);
+    }
+
+    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    if (snapshot.revision !== expectedRevision) {
+      throw new Error(`Revision conflict: expected ${expectedRevision}, current ${snapshot.revision}`);
+    }
+    assertEditableSection(snapshot, section);
+    const applied = applyLineEdits(snapshot[section], edits);
+    if (applied.source.length > MAX_SOURCE_LENGTH) {
+      throw new Error(`Edited ${section} source exceeds ${MAX_SOURCE_LENGTH} characters`);
+    }
+    if (applied.source === snapshot[section]) {
+      return textResult({
+        ok: true,
+        changed: false,
+        section,
+        changes: applied.changes,
+        ...summarizeProgram(snapshot),
+      });
+    }
+
+    const program = {
+      sourceMode: snapshot.sourceMode,
+      basic: snapshot.basic,
+      asm: snapshot.asm,
+      slang: snapshot.slang,
+      [section]: applied.source,
+    };
+    const generatedAsmCleared = section === 'slang' && snapshot.asm.length > 0;
+    const updated = normalizeProgramSnapshot(await bridge.sendCommand(
+      'setProgram', { program, expectedRevision }, sessionId,
+    ));
+    return textResult({
+      ok: true,
+      changed: true,
+      section,
+      changes: applied.changes,
+      generatedAsmCleared,
+      ...summarizeProgram(updated),
+    });
+  }));
 
   server.registerTool('x1pen_validate', {
     description: 'Compile or tokenize the current program without running it.',

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -1,31 +1,72 @@
 import assert from 'node:assert/strict';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { after, before, test } from 'node:test';
+import { after, before, beforeEach, test } from 'node:test';
 import { createX1PenMcpServer } from '../mcp/x1pen-server.mjs';
 
-const program = {
+const initialProgram = {
   sourceMode: 'basic+asm',
-  basic: '10 PRINT "MCP"',
+  basic: '10 PRINT "MCP"\n20 END',
   asm: '',
   slang: '',
   revision: 3,
   instanceId: 'tab-a',
 };
 const calls = [];
+let currentProgram;
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function normalizeProgram(program) {
+  const normalized = {
+    sourceMode: program.sourceMode,
+    basic: program.basic || '',
+    asm: program.asm || '',
+    slang: program.slang || '',
+  };
+  if (normalized.sourceMode === 'slang') {
+    normalized.basic = '';
+    normalized.asm = '';
+  } else if (normalized.sourceMode === 'asm') {
+    normalized.basic = '';
+    normalized.slang = '';
+  } else {
+    normalized.slang = '';
+  }
+  return normalized;
+}
+
 const fakeBridge = {
   connectionInfo() { return { port: 43110, pairingCode: '123456', extensionConnected: true }; },
   listSessions() { return [{ sessionId: 'tab-a', title: 'X1Pen', selected: true }]; },
   selectSession(sessionId) { return { sessionId }; },
   async sendCommand(method, params, sessionId) {
-    calls.push({ method, params, sessionId });
-    if (method === 'getProgram' || method === 'setProgram') return program;
+    calls.push({ method, params: clone(params), sessionId });
+    if (method === 'getProgram') return clone(currentProgram);
+    if (method === 'setProgram') {
+      if (params.expectedRevision !== currentProgram.revision) {
+        throw new Error(`Revision conflict: expected ${params.expectedRevision}, current ${currentProgram.revision}`);
+      }
+      currentProgram = {
+        ...normalizeProgram(params.program),
+        revision: currentProgram.revision + 1,
+        instanceId: currentProgram.instanceId,
+      };
+      return clone(currentProgram);
+    }
     if (method === 'validate') return { ok: true, diagnostics: [] };
     if (method === 'captureScreen') return `data:image/png;base64,${Buffer.from('png').toString('base64')}`;
     return { ok: true };
   },
   async close() {},
 };
+
+function jsonContent(result) {
+  const item = result.content.find((entry) => entry.type === 'text');
+  return JSON.parse(item.text);
+}
 
 let server;
 let client;
@@ -38,20 +79,28 @@ before(async () => {
   await client.connect(clientTransport);
 });
 
+beforeEach(() => {
+  calls.length = 0;
+  currentProgram = clone(initialProgram);
+});
+
 after(async () => {
   if (client) await client.close();
   if (server) await server.close();
 });
 
-test('server exposes browser connection and X1Pen tools', async () => {
+test('server exposes context-efficient source tools', async () => {
   const tools = await client.listTools();
   assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), [
+    'x1pen_apply_edits',
     'x1pen_capture_screen',
     'x1pen_connection_info',
     'x1pen_get_program',
+    'x1pen_get_source',
     'x1pen_get_status',
     'x1pen_list_sessions',
     'x1pen_run',
+    'x1pen_search_source',
     'x1pen_select_session',
     'x1pen_set_program',
     'x1pen_stop',
@@ -59,15 +108,186 @@ test('server exposes browser connection and X1Pen tools', async () => {
   ]);
 });
 
-test('set_program forwards expected revision and source to the selected tab', async () => {
+test('get_program defaults to metadata only and excludes generated ASM', async () => {
+  const generatedAsm = Array.from({ length: 20_000 }, (_, index) => `L${index}: NOP`).join('\n');
+  currentProgram = {
+    sourceMode: 'slang',
+    basic: '',
+    asm: generatedAsm,
+    slang: 'main() BEGIN\n  PRINT("MCP");\nEND;',
+    revision: 8,
+    instanceId: 'tab-a',
+  };
+
+  const defaultResult = await client.callTool({ name: 'x1pen_get_program', arguments: {} });
+  const selected = jsonContent(defaultResult);
+  assert.equal(selected.slang, undefined);
+  assert.equal(selected.asm, undefined);
+  assert.deepEqual(selected.includedFields, []);
+  assert.equal(selected.sections.asm.generated, true);
+  assert.equal(selected.sections.asm.lineCount, 20_000);
+  assert.ok(defaultResult.content[0].text.length < 500, 'metadata-only response must stay small even with huge generated ASM');
+  assert.equal(defaultResult.structuredContent, undefined);
+
+  const slangResult = await client.callTool({
+    name: 'x1pen_get_program',
+    arguments: { fields: ['slang'] },
+  });
+  assert.equal(jsonContent(slangResult).slang, currentProgram.slang);
+
+  const omittedResult = await client.callTool({
+    name: 'x1pen_get_program',
+    arguments: { fields: ['asm'] },
+  });
+  const omitted = jsonContent(omittedResult);
+  assert.equal(omitted.asm, undefined);
+  assert.equal(omitted.omittedFields[0].field, 'asm');
+
+  const generatedResult = await client.callTool({
+    name: 'x1pen_get_program',
+    arguments: { fields: ['asm'], includeGeneratedAsm: true },
+  });
+  assert.equal(generatedResult.isError, true);
+  assert.match(generatedResult.content[0].text, /exceeding maxCharacters/);
+
+  const deliberateResult = await client.callTool({
+    name: 'x1pen_get_program',
+    arguments: { fields: ['asm'], includeGeneratedAsm: true, maxCharacters: 512 * 1024 },
+  });
+  assert.equal(jsonContent(deliberateResult).asm, generatedAsm);
+});
+
+test('get_source returns a bounded line range and protects generated ASM', async () => {
+  currentProgram.basic = Array.from({ length: 20 }, (_, index) => `${(index + 1) * 10} PRINT ${index + 1}`).join('\n');
+  const result = await client.callTool({
+    name: 'x1pen_get_source',
+    arguments: { section: 'basic', startLine: 5, lineCount: 3 },
+  });
+  const range = jsonContent(result);
+  assert.equal(range.startLine, 5);
+  assert.equal(range.endLine, 7);
+  assert.equal(range.totalLines, 20);
+  assert.equal(range.text, '50 PRINT 5\n60 PRINT 6\n70 PRINT 7');
+  assert.equal(range.nextStartLine, 8);
+  assert.equal(range.truncated, true);
+
+  currentProgram = {
+    sourceMode: 'slang', basic: '', asm: 'generated', slang: 'main() BEGIN\nEND;', revision: 4, instanceId: 'tab-a',
+  };
+  const protectedResult = await client.callTool({
+    name: 'x1pen_get_source',
+    arguments: { section: 'asm' },
+  });
+  assert.equal(protectedResult.isError, true);
+  assert.match(protectedResult.content[0].text, /generated from SLANG/);
+});
+
+test('search_source finds literal text with bounded context', async () => {
+  currentProgram.slang = [
+    'main() BEGIN',
+    '  drawPlayer(); drawPlayer();',
+    'END;',
+    '',
+    'drawPlayer() BEGIN',
+    '  PRINT("PLAYER");',
+    'END;',
+  ].join('\n');
+  currentProgram.sourceMode = 'slang';
+  currentProgram.basic = '';
+
+  const result = await client.callTool({
+    name: 'x1pen_search_source',
+    arguments: { section: 'slang', query: 'drawplayer', contextLines: 1, maxResults: 1 },
+  });
+  const search = jsonContent(result);
+  assert.equal(search.totalMatches, 3);
+  assert.equal(search.matches.length, 1);
+  assert.equal(search.matches[0].line, 2);
+  assert.equal(search.truncated, true);
+  assert.deepEqual(search.matches[0].context.map((line) => line.line), [1, 2, 3]);
+});
+
+test('set_program forwards expected revision but returns only a compact summary', async () => {
   const result = await client.callTool({
     name: 'x1pen_set_program',
-    arguments: { sourceMode: 'basic+asm', basic: program.basic, expectedRevision: 3 },
+    arguments: { sourceMode: 'basic+asm', basic: '10 PRINT "UPDATED"', expectedRevision: 3 },
   });
+  const response = jsonContent(result);
   assert.equal(result.isError, undefined);
   assert.equal(calls.at(-1).method, 'setProgram');
   assert.equal(calls.at(-1).params.expectedRevision, 3);
-  assert.equal(calls.at(-1).params.program.basic, program.basic);
+  assert.equal(calls.at(-1).params.program.basic, '10 PRINT "UPDATED"');
+  assert.equal(response.revision, 4);
+  assert.equal(response.basic, undefined);
+  assert.equal(response.sections.basic.lineCount, 1);
+});
+
+test('apply_edits updates one section and preserves the other authoring source', async () => {
+  currentProgram.asm = 'ORG $100\nRET';
+  const result = await client.callTool({
+    name: 'x1pen_apply_edits',
+    arguments: {
+      section: 'basic',
+      expectedRevision: 3,
+      edits: [
+        { startLine: 1, deleteLineCount: 1, text: '10 PRINT "START"' },
+        { startLine: 2, deleteLineCount: 1, text: '20 PRINT "EDITED"\n30 END' },
+      ],
+    },
+  });
+  const response = jsonContent(result);
+  assert.equal(response.changed, true);
+  assert.equal(response.revision, 4);
+  assert.equal(response.basic, undefined);
+  assert.equal(currentProgram.basic, '10 PRINT "START"\n20 PRINT "EDITED"\n30 END');
+  assert.equal(currentProgram.asm, 'ORG $100\nRET');
+  assert.equal(calls.at(-1).params.program.asm, 'ORG $100\nRET');
+  assert.deepEqual(response.changes, [
+    { startLine: 1, oldLineCount: 1, newLineCount: 1 },
+    { startLine: 2, oldLineCount: 1, newLineCount: 2 },
+  ]);
+});
+
+test('apply_edits rejects stale revisions and overlapping edits', async () => {
+  const stale = await client.callTool({
+    name: 'x1pen_apply_edits',
+    arguments: {
+      section: 'basic', expectedRevision: 2, edits: [{ startLine: 1, deleteLineCount: 1, text: '10 END' }],
+    },
+  });
+  assert.equal(stale.isError, true);
+  assert.match(stale.content[0].text, /Revision conflict/);
+
+  const overlapping = await client.callTool({
+    name: 'x1pen_apply_edits',
+    arguments: {
+      section: 'basic',
+      expectedRevision: 3,
+      edits: [
+        { startLine: 1, deleteLineCount: 2, text: '10 END' },
+        { startLine: 2, deleteLineCount: 1, text: '20 END' },
+      ],
+    },
+  });
+  assert.equal(overlapping.isError, true);
+  assert.match(overlapping.content[0].text, /overlap/);
+});
+
+test('apply_edits clears generated ASM when editing SLANG', async () => {
+  currentProgram = {
+    sourceMode: 'slang', basic: '', asm: 'generated asm', slang: 'main() BEGIN\nEND;', revision: 9, instanceId: 'tab-a',
+  };
+  const result = await client.callTool({
+    name: 'x1pen_apply_edits',
+    arguments: {
+      section: 'slang', expectedRevision: 9, edits: [{ startLine: 2, deleteLineCount: 0, text: '  PRINT("MCP");' }],
+    },
+  });
+  const response = jsonContent(result);
+  assert.equal(response.generatedAsmCleared, true);
+  assert.equal(response.sections.asm.characterCount, 0);
+  assert.equal(currentProgram.asm, '');
+  assert.equal(currentProgram.slang, 'main() BEGIN\n  PRINT("MCP");\nEND;');
 });
 
 test('capture_screen returns an MCP PNG image', async () => {


### PR DESCRIPTION
## Summary
- make `x1pen_get_program` metadata-only by default and require explicit source fields
- add bounded source range reads, literal search, and revision-checked structured line edits
- exclude generated SLANG ASM by default and return compact mutation responses without duplicate structured content
- document the large-program workflow and preserve full replacement for creation/import

The optimization is contained in the local MCP server, so the published X1Pen page and Chrome extension do not need an update for these tools.

## Validation
- `npm run test:mcp` (9 passed)
- `npm run test:bridge` (4 passed)
- `npm run test:automation` (5 passed)
- `node tests/z80asm_test.js` (322 passed)
- `node --check mcp/x1pen-server.mjs`
- `git diff --check`