### PR TITLE
Package X1Pen MCP server for standalone use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ビルド成果物
 build/
 dist/
+x1pen-mcp-*.tgz
 
 # ROM・バイナリ (著作権物)
 *.X1

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -13,9 +13,44 @@ Node.js 20以降が必要です。通信はstdioと`127.0.0.1`だけを使用し
 
 ## セットアップ
 
+MCPサーバーはnpmパッケージとしてX1Pen本体から独立して配布します。MCPサーバーを動かすために、このリポジトリをcloneする必要はありません。予期しない自動更新を避けるため、設定ではバージョンを固定します。
+
+### Codex
+
+CodexのMCP設定に以下を追加します。
+
+```toml
+[mcp_servers.x1pen]
+command = "npx"
+args = ["-y", "x1pen-mcp@2.1.0"]
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+```
+
+Codexを再起動後、`codex mcp list`で登録を確認します。
+
+### Claude Code
+
+userスコープへ登録すると、任意のプロジェクトからX1Penを利用できます。
+
 ```bash
-npm ci
-./build.sh
+claude mcp add --transport stdio --scope user x1pen -- \
+  npx -y x1pen-mcp@2.1.0
+claude mcp list
+```
+
+プロジェクト単位で共有する場合は、対象プロジェクトの`.mcp.json`へ以下を追加します。初回起動時にプロジェクトMCPサーバーを承認してください。
+
+```json
+{
+  "mcpServers": {
+    "x1pen": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "x1pen-mcp@2.1.0"]
+    }
+  }
+}
 ```
 
 ### 拡張機能
@@ -25,25 +60,7 @@ npm ci
 3. Load unpackedを選択
 4. このリポジトリの`extension/`ディレクトリを指定
 
-PoC段階ではストア配布を行わないため、unpacked extensionとして読み込みます。
-
-### Codex
-
-リポジトリルートからCodexを起動すると`.codex/config.toml`がMCPサーバーを登録します。
-
-```bash
-codex mcp list
-codex
-```
-
-### Claude Code
-
-`.mcp.json`がプロジェクトMCPサーバーを登録します。初回起動時に承認してください。
-
-```bash
-claude mcp list
-claude
-```
+ストア公開前はunpacked extensionとして読み込みます。MCPサーバーのnpm配布とブラウザー拡張の配布は独立しており、拡張機能の更新にMCPパッケージの再公開は不要です。
 
 ## 接続
 
@@ -117,12 +134,22 @@ SLANG編集中のASMは生成物として読み取り・編集とも既定で保
 
 Share機能はユーザーが開いているX1Pen自身から実行するため、本番X1Pen上では既存のShare APIと公開URLをそのまま利用できます。
 
-## ローカル確認
+## 開発と公開
+
+このリポジトリでMCPサーバーを開発する場合は、ルートの`.codex/config.toml`と`.mcp.json`が`mcp/x1pen-server.mjs`を直接起動します。
+
+```bash
+npm ci
+./build.sh
+```
+
+### ローカル確認
 
 ```bash
 npm run test:automation
 npm run test:bridge
 npm run test:mcp
+npm run test:mcp-package
 ```
 
 MCPサーバー単体を起動すると、標準エラーにbridge portとpairing codeが表示されます。標準出力はMCP通信専用です。
@@ -130,6 +157,20 @@ MCPサーバー単体を起動すると、標準エラーにbridge portとpairin
 ```bash
 npm run mcp:x1pen
 ```
+
+`test:mcp-package`は`npm pack`で作ったtarballを一時ディレクトリへインストールし、リポジトリ外からMCPサーバーを起動してツール一覧を確認します。
+
+### npm公開
+
+パッケージ名は`x1pen-mcp`、公開単位は`mcp/`です。公開前に`mcp/package.json`のversionと変更内容を確認し、次を実行します。同じversionはnpmへ再公開できません。
+
+```bash
+npm whoami
+npm run test:mcp-package
+npm publish ./mcp
+```
+
+公開後は`npm view x1pen-mcp version`と`npx -y x1pen-mcp@<version> --version`で確認します。
 
 ## セキュリティ
 

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,29 @@
+X millennium Web Port License
+
+Portions Copyright (c) 2025-2026 Hiroshi OGINO (Web port)
+Portions Copyright (c) 1999-2000 Studio Milmake (Original X millennium)
+Portions Copyright (c) 2000 T_tune (T_tune variant)
+
+This software is provided as freeware for non-commercial use.
+
+To the extent permitted by applicable upstream licenses, permission is
+granted to use, copy, modify, and redistribute this software and its
+source code, subject to the following conditions:
+
+  1. This software may not be used for commercial purposes.
+  2. This copyright notice, the accompanying THIRD_PARTY_LICENSES.md,
+     and all per-file license and copyright notices shall be included
+     in all copies or substantial portions of the software.
+  3. The software is provided "as is", without warranty of any kind.
+
+This project includes code from third-party projects with their own
+license terms. See THIRD_PARTY_LICENSES.md for details.
+
+If this license conflicts with any third-party license, the third-party
+license terms shall prevail.
+
+This license applies to this package as a distribution notice and does
+not replace or override notices in individual third-party source files.
+
+SHARP and X1 are trademarks of Sharp Corporation. This project is not
+affiliated with or endorsed by Sharp Corporation.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,39 @@
+# x1pen-mcp
+
+`x1pen-mcp` is a local MCP server that lets Codex and Claude Code edit, validate, run, and inspect programs in the X1Pen tab already open in Chrome or Edge.
+
+The server communicates only through stdio and `127.0.0.1`. It requires Node.js 20 or later and the X1Pen Connector browser extension.
+
+## Codex
+
+Add the following server to your Codex MCP configuration. Pinning the version prevents an unexpected update during startup.
+
+```toml
+[mcp_servers.x1pen]
+command = "npx"
+args = ["-y", "x1pen-mcp@2.1.0"]
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+```
+
+## Claude Code
+
+Register the server at user scope to make it available from any project.
+
+```bash
+claude mcp add --transport stdio --scope user x1pen -- \
+  npx -y x1pen-mcp@2.1.0
+```
+
+Use `claude mcp list` or `/mcp` to check the connection.
+
+## Pairing
+
+1. Call `x1pen_connection_info` from the AI client.
+2. Open the X1Pen Connector extension in Chrome or Edge.
+3. Enter the reported bridge port and six-digit pairing code.
+4. Select **Connect this tab** on the X1Pen tab.
+
+The pairing code changes whenever the MCP server process restarts. One browser extension connection can be paired with one running MCP server at a time.
+
+See the [complete setup and tool documentation](https://github.com/ho-ogino/xmil-web/blob/main/docs/X1PEN_MCP.md) for details.

--- a/mcp/THIRD_PARTY_LICENSES.md
+++ b/mcp/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,11 @@
+# Third-Party Licenses
+
+The following runtime dependencies are installed separately by npm and retain their own license terms:
+
+| Package | License | Source |
+|---|---|---|
+| `@modelcontextprotocol/sdk` | MIT | https://github.com/modelcontextprotocol/typescript-sdk |
+| `ws` | MIT | https://github.com/websockets/ws |
+| `zod` | MIT | https://github.com/colinhacks/zod |
+
+The dependency packages installed by npm include their complete license notices. They are not bundled into the `x1pen-mcp` package tarball.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "x1pen-mcp",
+  "version": "2.1.0",
+  "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
+  "type": "module",
+  "bin": {
+    "x1pen-mcp": "x1pen-server.mjs"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "THIRD_PARTY_LICENSES.md",
+    "x1pen-bridge.mjs",
+    "x1pen-server.mjs"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "ws": "^8.21.2",
+    "zod": "^3.25.76"
+  },
+  "keywords": [
+    "mcp",
+    "x1",
+    "x1pen",
+    "emulator"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ho-ogino/xmil-web.git",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/ho-ogino/xmil-web",
+  "bugs": "https://github.com/ho-ogino/xmil-web/issues",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -2,11 +2,13 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { readFileSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as z from 'zod/v4';
 import { X1PenBridge } from './x1pen-bridge.mjs';
 
+const PACKAGE = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 const MAX_SOURCE_LENGTH = 512 * 1024;
 const DEFAULT_RANGE_CHARACTERS = 32 * 1024;
 const MAX_RANGE_CHARACTERS = 128 * 1024;
@@ -269,7 +271,7 @@ function assertEditableSection(snapshot, section) {
 
 export function createX1PenMcpServer(options = {}) {
   const bridge = options.bridge || new X1PenBridge(options.bridgeOptions);
-  const server = new McpServer({ name: 'x1pen', version: '2.1.0' });
+  const server = new McpServer({ name: 'x1pen', version: PACKAGE.version });
   const sessionInput = { sessionId: z.string().optional().describe('Connected X1Pen instance ID; omit when one tab is connected') };
 
   server.registerTool('x1pen_connection_info', {
@@ -462,6 +464,14 @@ export function createX1PenMcpServer(options = {}) {
 }
 
 async function main() {
+  if (process.argv.includes('--version') || process.argv.includes('-v')) {
+    console.log(PACKAGE.version);
+    return;
+  }
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    console.log(`x1pen-mcp ${PACKAGE.version}\n\nLocal stdio MCP server and browser bridge for X1Pen.\n\nOptions:\n  -h, --help     Show this help\n  -v, --version  Show the package version`);
+    return;
+  }
   const { server, bridge } = createX1PenMcpServer();
   await bridge.start();
   let closing = false;
@@ -477,7 +487,16 @@ async function main() {
   console.error('[x1pen-mcp] server ready on stdio');
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(process.argv[1]));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   main().catch((error) => {
     console.error('[x1pen-mcp] fatal:', error);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   "scripts": {
     "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify",
     "mcp:x1pen": "node mcp/x1pen-server.mjs",
+    "pack:mcp": "npm pack ./mcp",
     "test:automation": "node --test tests/x1pen_automation_test.mjs",
     "test:bridge": "node --test tests/x1pen_bridge_test.mjs",
-    "test:mcp": "node --test tests/x1pen_mcp_test.mjs"
+    "test:mcp": "node --test tests/x1pen_mcp_test.mjs",
+    "test:mcp-package": "node --test tests/x1pen_mcp_package_test.mjs"
   }
 }

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { test } from 'node:test';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+}
+
+function runNpm(args, options = {}) {
+  if (process.env.npm_execpath) {
+    return run(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+  return run(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, {
+    shell: process.platform === 'win32',
+    ...options,
+  });
+}
+
+test('packed x1pen-mcp installs and serves tools without the repository', { timeout: 120_000 }, async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'x1pen-mcp-package-'));
+  const npmCache = join(tempRoot, 'npm-cache');
+  let client;
+  try {
+    const packResult = JSON.parse(runNpm([
+      'pack', './mcp', '--json', '--pack-destination', tempRoot, '--cache', npmCache,
+    ], { cwd: repoRoot }))[0];
+    assert.deepEqual(packResult.files.map((file) => file.path).sort(), [
+      'LICENSE',
+      'README.md',
+      'THIRD_PARTY_LICENSES.md',
+      'package.json',
+      'x1pen-bridge.mjs',
+      'x1pen-server.mjs',
+    ]);
+
+    const installRoot = join(tempRoot, 'consumer');
+    await mkdir(installRoot);
+    await writeFile(join(installRoot, 'package.json'), '{"private":true}\n');
+    const tarball = join(tempRoot, packResult.filename);
+    runNpm([
+      'install', '--ignore-scripts', '--no-audit', '--no-fund', '--cache', npmCache, tarball,
+    ], { cwd: installRoot });
+
+    const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+    assert.equal(manifest.name, 'x1pen-mcp');
+    assert.equal(manifest.version, '2.1.0');
+    assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
+
+    const serverPath = join(packageRoot, 'x1pen-server.mjs');
+    assert.equal(run(process.execPath, [serverPath, '--version']).trim(), manifest.version);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [serverPath],
+      cwd: installRoot,
+      stderr: 'pipe',
+    });
+    client = new Client({ name: 'x1pen-package-test', version: '1.0.0' });
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    assert.equal(tools.tools.length, 13);
+    assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
+    const connection = await client.callTool({ name: 'x1pen_connection_info', arguments: {} });
+    const info = JSON.parse(connection.content[0].text);
+    assert.equal(info.host, '127.0.0.1');
+    assert.ok(Number.isInteger(info.port));
+    assert.match(info.pairingCode, /^\d{6}$/);
+  } finally {
+    if (client) await client.close();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a publishable `x1pen-mcp` package under `mcp/` with its own runtime dependencies, license notices, README, and CLI entry point
- load the MCP server version from package metadata and add `--help` / `--version`
- add a package test that packs, installs, and starts the server outside the repository
- document version-pinned Codex and Claude Code setup plus the npm release procedure

This lets users run the MCP server through `npx -y x1pen-mcp@2.1.0` without cloning xmil-web. The package is prepared for publication but this PR does not publish it to npm.

## Validation
- `npm run test:mcp-package` (packed tarball installed and 13 tools served)
- `npm publish ./mcp --dry-run` (6 files, 9.1 kB tarball)
- `npm run test:mcp` (9 passed)
- `npm run test:bridge` (4 passed)
- `npm run test:automation` (5 passed)
- `node --check mcp/x1pen-server.mjs`
- `node --check tests/x1pen_mcp_package_test.mjs`
- `git diff --check`