### PR TITLE
feat: add X1Pen language reference tools

### DIFF
--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -22,7 +22,7 @@ CodexのMCP設定に以下を追加します。
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.1.0"]
+args = ["-y", "x1pen-mcp@2.2.0"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -35,7 +35,7 @@ userスコープへ登録すると、任意のプロジェクトからX1Penを�
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.1.0
+  npx -y x1pen-mcp@2.2.0
 claude mcp list
 ```
 
@@ -47,7 +47,7 @@ claude mcp list
     "x1pen": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "x1pen-mcp@2.1.0"]
+      "args": ["-y", "x1pen-mcp@2.2.0"]
     }
   }
 }
@@ -79,6 +79,9 @@ claude mcp list
 | `x1pen_connection_info` | 拡張機能の接続情報を取得 |
 | `x1pen_list_sessions` | 接続済みX1Penタブを一覧表示 |
 | `x1pen_select_session` | 操作対象タブを選択 |
+| `x1pen_get_language_profile` | 同梱リファレンスと接続中X1Penの言語profileを確認 |
+| `x1pen_search_reference` | FuzzyBASIC / SLANGリファレンスを要約検索 |
+| `x1pen_get_reference` | 検索結果のIDを指定して詳細を上限付きで取得 |
 | `x1pen_get_program` | メタデータと明示指定した完全ソースを取得 |
 | `x1pen_get_source` | 1セクションを行範囲・文字数上限付きで取得 |
 | `x1pen_search_source` | 1セクションをリテラル検索し、限定した前後行を取得 |
@@ -91,6 +94,32 @@ claude mcp list
 | `x1pen_capture_screen` | 640x400のエミュレーター画面をPNG取得 |
 
 AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
+
+### 言語リファレンス
+
+MCPパッケージには、X1Pen FuzzyBASIC 1.2LとX1Pen内蔵SLANGコンパイラに対応する構造化リファレンスが同梱されています。ブラウザー未接続でも検索できるため、プログラム作成前に仕様を確認できます。
+
+最初に`x1pen_get_language_profile`を呼ぶと、同梱profileを確認できます。X1Penへ接続済みなら、ブラウザーが報告したprofile IDとの互換性も返します。
+
+リファレンスは全件取得せず、`x1pen_search_reference`で必要な項目を検索します。応答は短い要約とstable IDだけです。
+
+```json
+{
+  "language": "slang",
+  "query": "tile sprite scroll",
+  "maxResults": 5
+}
+```
+
+必要な項目だけ`x1pen_get_reference`で取得します。1回に指定できるIDは10件までで、既定の応答上限は32 KiBです。
+
+```json
+{
+  "ids": ["slang.include.tile-sprite"]
+}
+```
+
+収録内容には、一般的な言語構文だけでなく、SLANGの正確なコンパイラrevision、`ENV_TYPE=1`のLSX-Dodgers環境、X1Pen同梱runtime/include API、FuzzyBASIC 1.2LのX1拡張を含みます。ゲーム開発で利用するPCGについては、FuzzyBASICの`PCGDEF` / `TCOLOR`、SLANGの`PCGDEF` / `PCGDEFS`、24-byte BRGパターン形式、TILELIBとの初期化順序まで独立項目として収録しています。代表サンプルは現在のX1Pen tokenizer/compilerで自動検証しています。未知のAPIや複雑な引数規約については、リファレンス確認後も`x1pen_validate`で検証してください。
 
 ### 大きなプログラムの扱い
 

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1218,6 +1218,16 @@ window.__X1PEN_MODE = true;
     }
 
     function getAutomationStatus() {
+        var sourceMode = inferSourceMode(
+            basicEditor ? basicEditor.getValue().trim() : '',
+            asmEditor ? asmEditor.getValue().trim() : '',
+            slangEditor ? slangEditor.getValue().trim() : ''
+        );
+        var activeLanguageProfile = sourceMode === 'slang'
+            ? { language: 'slang', id: 'x1pen-slang-c9e8f53-lsx' }
+            : (sourceMode === 'basic+asm'
+                ? { language: 'fuzzybasic', id: 'x1pen-fuzzybasic-1.2L' }
+                : null);
         return {
             instanceId: automationInstanceId,
             revision: automationRevision,
@@ -1228,7 +1238,23 @@ window.__X1PEN_MODE = true;
             interactionLocked: automationInteractionLocked,
             title: document.title,
             url: location.href,
-            status: elStatus ? elStatus.textContent : ''
+            status: elStatus ? elStatus.textContent : '',
+            sourceMode: sourceMode,
+            activeLanguageProfile: activeLanguageProfile,
+            languageProfiles: {
+                fuzzybasic: {
+                    id: 'x1pen-fuzzybasic-1.2L',
+                    version: COLD_STATE_VERSION[COLD_STATE_FILE],
+                    runtime: COLD_STATE_FILE
+                },
+                slang: {
+                    id: 'x1pen-slang-c9e8f53-lsx',
+                    compilerRevision: 'c9e8f5315d8d44a413368045d78439a4ec8da3fc',
+                    environment: 'lsx-dodgers',
+                    envType: 1,
+                    defaultOrg: 0x100
+                }
+            }
         };
     }
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,8 +1,8 @@
 # x1pen-mcp
 
-`x1pen-mcp` is a local MCP server that lets Codex and Claude Code edit, validate, run, and inspect programs in the X1Pen tab already open in Chrome or Edge.
+`x1pen-mcp` is a local MCP server that lets Codex and Claude Code edit, validate, run, and inspect programs in the X1Pen tab already open in Chrome or Edge. It also includes bounded, offline-searchable references for X1Pen FuzzyBASIC and SLANG.
 
-The server communicates only through stdio and `127.0.0.1`. It requires Node.js 20 or later and the X1Pen Connector browser extension.
+The server communicates only through stdio and `127.0.0.1`. It requires Node.js 20 or later. Browser-control tools require the X1Pen Connector extension; the bundled reference tools do not.
 
 ## Codex
 
@@ -11,7 +11,7 @@ Add the following server to your Codex MCP configuration. Pinning the version pr
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.1.0"]
+args = ["-y", "x1pen-mcp@2.2.0"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -22,7 +22,7 @@ Register the server at user scope to make it available from any project.
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.1.0
+  npx -y x1pen-mcp@2.2.0
 ```
 
 Use `claude mcp list` or `/mcp` to check the connection.
@@ -35,5 +35,15 @@ Use `claude mcp list` or `/mcp` to check the connection.
 4. Select **Connect this tab** on the X1Pen tab.
 
 The pairing code changes whenever the MCP server process restarts. One browser extension connection can be paired with one running MCP server at a time.
+
+## Language reference
+
+The reference tools work before browser pairing because the data is bundled in this package:
+
+- `x1pen_get_language_profile` lists the bundled profiles and compares them with a connected X1Pen version.
+- `x1pen_search_reference` returns short summaries and stable reference IDs.
+- `x1pen_get_reference` returns full details only for selected IDs, with a response-size limit.
+
+Search first and fetch only the entries needed for the current program. This avoids putting a complete language manual into the model context.
 
 See the [complete setup and tool documentation](https://github.com/ho-ogino/xmil-web/blob/main/docs/X1PEN_MCP.md) for details.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {
@@ -10,7 +10,9 @@
     "LICENSE",
     "README.md",
     "THIRD_PARTY_LICENSES.md",
+    "reference",
     "x1pen-bridge.mjs",
+    "x1pen-reference.mjs",
     "x1pen-server.mjs"
   ],
   "engines": {

--- a/mcp/reference/fuzzybasic.json
+++ b/mcp/reference/fuzzybasic.json
@@ -1,0 +1,276 @@
+[
+  {
+    "id": "fuzzybasic.program.structure",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "Program lines, statements, comments and labels",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["line number", "label", "comment", "statement separator"],
+    "summary": "X1Pen accepts numbered FuzzyBASIC program lines. Separate multiple statements with a colon, use an apostrophe for a comment, and write a label between backslashes.",
+    "syntax": [
+      "10 PRINT \"HELLO\"",
+      "20 A=1:PRINT A",
+      "100 \\DRAW\\ PRINT \"DRAW\"",
+      "110 ' comment"
+    ],
+    "notes": [
+      "Lines without a decimal line number from 1 through 65535 are ignored by the X1Pen tokenizer.",
+      "Labels improve readability but are resolved by searching program text and can be slower than line-number targets.",
+      "A period can abbreviate a keyword after enough leading characters to select it, but full spellings are safer for generated code."
+    ],
+    "examples": [
+      {
+        "title": "Minimal program",
+        "source": "10 PRINT \"HELLO FROM X1PEN\"\n20 END"
+      }
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.values.operators",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "Integer values, variables and operators",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["arithmetic", "comparison", "bitwise", "AND OR XOR", "hex binary"],
+    "summary": "FuzzyBASIC is integer-oriented and exposes arithmetic, comparison and bit operations close to the Z80 machine.",
+    "syntax": [
+      "A=B+C*D",
+      "IF A>=10 THEN PRINT A",
+      "A=B AND C",
+      "A=HIGH(W):B=LOW(W)"
+    ],
+    "notes": [
+      "Useful numeric and bit functions include HIGH, LOW, NOT, BIT, SET, RESET, ROTL, ROTR, ROTLD, ROTRD, MULH, MOD and PARITY.",
+      "The tokenizer accepts case-insensitive keywords. Use explicit parentheses when mixing arithmetic, comparison and AND/OR/XOR."
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.control.conditionals",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "IF statements and branching",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["IF THEN ELSE END IF", "GOTO", "GOSUB", "ON"],
+    "summary": "Use IF/THEN/ELSE for conditional execution, including block IF terminated by END IF. GOTO, GOSUB and ON provide direct branching.",
+    "syntax": [
+      "IF condition THEN statement",
+      "IF condition THEN ... ELSE ... END IF",
+      "GOTO line-or-label",
+      "GOSUB line-or-label"
+    ],
+    "notes": [
+      "When leaving a block IF or loop with GOTO, account for the interpreter's nesting stacks; an unmatched stack frame can remain active.",
+      "RETURN returns from GOSUB. RET PROC and RET FUNC belong to PROC and FUNC calls instead."
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.control.loops",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "FOR, REPEAT and WHILE loops",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["FOR NEXT", "REPEAT UNTIL", "WHILE WEND", "loop stack"],
+    "summary": "FuzzyBASIC provides counted FOR/NEXT loops, post-test REPEAT/UNTIL loops and pre-test WHILE/WEND loops.",
+    "syntax": [
+      "FOR I=1 TO 10: ... :NEXT I",
+      "FOR I=10 TO 1 STEP -1: ... :NEXT I",
+      "REPEAT: ... :UNTIL condition",
+      "WHILE condition: ... :WEND"
+    ],
+    "notes": [
+      "FOR is generally fastest, followed by REPEAT and WHILE.",
+      "Do not jump out of a loop casually: loop state is kept on interpreter stacks. In particular WEND always returns to its WHILE."
+    ],
+    "examples": [
+      {
+        "title": "Count from one to five",
+        "source": "10 FOR I=1 TO 5\n20 PRINT I\n30 NEXT I\n40 END"
+      }
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.subroutines.proc",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "PROC, LOCAL and RET PROC",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["procedure", "local variables", "RETPROC", "variable stack"],
+    "summary": "PROC calls a subroutine after saving the variables selected by LOCAL, optionally assigns up to six argument values, and RET PROC restores those variables before returning.",
+    "syntax": [
+      "LOCAL A,B,C,D,E,F",
+      "PROC target,arg1,arg2",
+      "RET PROC"
+    ],
+    "notes": [
+      "Each PROC call uses 12 bytes of variable-stack storage for six saved variables.",
+      "Use only LOCAL-selected variables inside a procedure when you want isolation from the caller."
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.subroutines.func",
+    "language": "fuzzybasic",
+    "kind": "syntax",
+    "title": "FUNC and RET FUNC",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["function", "RETFUNC", "recursive function"],
+    "summary": "FUNC is the expression-valued counterpart of PROC. It saves LOCAL variables, calls a subroutine, and RET FUNC returns the specified value.",
+    "syntax": [
+      "A=FUNC(target,arg1,arg2)",
+      "RET FUNC expression"
+    ],
+    "notes": [
+      "FUNC uses both the variable stack and the Z80 stack; complex expressions and recursion require adequate stack space.",
+      "VSTACK changes the boundary between the variable stack and machine stack."
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.machine.memory-io",
+    "language": "fuzzybasic",
+    "kind": "runtime",
+    "title": "Memory, I/O and block transfer",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["PEEK POKE", "WPEEK WPOKE", "INP OUT", "WINP WOUT", "LDIR LDDR TRANS", "USR"],
+    "summary": "Read and write byte or word memory and I/O directly, call machine-language routines, and use native block-transfer statements for efficient data movement.",
+    "syntax": [
+      "A=PEEK(address):POKE address,value",
+      "W=WPEEK(address):WPOKE address,value",
+      "A=INP(port):OUT port,value",
+      "W=WINP(port):WOUT port,value",
+      "LDIR source,destination,length",
+      "A=USR(address)"
+    ],
+    "notes": [
+      "LDIR and LDDR mirror the corresponding Z80 transfer directions. TRANS chooses a direction from the source and destination addresses.",
+      "CALL, CALL@, USR, USR@ and USR^A through USR^H are low-level interfaces; confirm register and memory conventions before use."
+    ],
+    "sourceUrls": ["https://retropc.net/ohishi/s-os/fubasic.htm"]
+  },
+  {
+    "id": "fuzzybasic.x1.graphics",
+    "language": "fuzzybasic",
+    "kind": "x1-extension",
+    "title": "X1 graphics extensions",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["TILE", "TRIANGLE", "MAGIC", "COLOR", "PCGDEF", "TCOLOR", "LINE", "BOX", "CIRCLE", "PALET"],
+    "summary": "X1Pen 1.2L adds X1-oriented tile, triangle, MAGIC, color and PCG operations alongside FuzzyBASIC's graphics commands.",
+    "syntax": [
+      "LINE ...",
+      "BOX ...",
+      "CIRCLE ...",
+      "PALET ...",
+      "TILE ...",
+      "TRIANGLE ...",
+      "MAGIC ...",
+      "COLOR ...",
+      "PCGDEF ...",
+      "TCOLOR ..."
+    ],
+    "notes": [
+      "These extensions are X1Pen profile features and are not guaranteed by the historical generic FuzzyBASIC documentation.",
+      "Search for the individual keyword, then validate the program in X1Pen because graphics arguments depend on the selected screen and runtime state."
+    ],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_tokenizer.js"]
+  },
+  {
+    "id": "fuzzybasic.x1.pcg-definition",
+    "language": "fuzzybasic",
+    "kind": "x1-extension",
+    "title": "Defining X1 PCG characters with PCGDEF",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["PCGDEF", "TCOLOR", "programmable character generator", "character pattern", "BRG planes", "game graphics"],
+    "summary": "PCGDEF copies one 8x8 X1 programmable character from a 24-byte BRG pattern, and TCOLOR selects the text/PCG attribute used when printing it.",
+    "syntax": [
+      "WIDTH 40",
+      "PCGDEF characterCode,address",
+      "TCOLOR attribute",
+      "PRINT CHR$(characterCode)"
+    ],
+    "notes": [
+      "Set WIDTH before defining PCG characters; the runtime prepares a non-displayed text area according to 40- or 80-column mode.",
+      "One character is 24 bytes: 8 rows, with three bytes per row in Blue, Red, Green order. Bit 7 is the leftmost pixel.",
+      "PCGDEF waits for vertical blank while writing the hardware. Define assets during setup rather than in the per-frame game loop.",
+      "In X1Pen BASIC+ASM mode, put pattern bytes at an ASM ORG, load PROGRAM.BIN at that address, then pass the same address to PCGDEF.",
+      "Increment the pattern address by 24 for each consecutive character. Character codes share the text character-code space."
+    ],
+    "examples": [
+      {
+        "title": "Load and display one PCG character",
+        "source": "10 LIMIT &HAFFF\n20 BLOAD \"PROGRAM.BIN\",&HB000\n30 WIDTH 40\n40 TCOLOR $27\n50 PCGDEF 128,$B000\n60 PRINT CHR$(128)\n70 TCOLOR 7\n80 END",
+        "asmSource": "ORG $B000\n; 8 rows, each Blue/Red/Green\nDB %00111100,0,0\nDB %01111110,0,0\nDB %11011011,0,0\nDB %11111111,0,0\nDB %10100101,0,0\nDB %11111111,0,0\nDB %01100110,0,0\nDB %00111100,0,0"
+      }
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/FuzzyBASIC/blob/main/src/pcgdef.asm",
+      "https://github.com/ho-ogino/FuzzyBASIC/blob/main/assets/PCG_LSX.BAS"
+    ]
+  },
+  {
+    "id": "fuzzybasic.x1.sound-input",
+    "language": "fuzzybasic",
+    "kind": "x1-extension",
+    "title": "Sound, joystick and keyboard input",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["SOUND", "JOY", "INKEY", "GET", "BEEP"],
+    "summary": "Use SOUND and BEEP for audio, JOY for joystick state, and INKEY/GET for keyboard-oriented input in the X1Pen profile.",
+    "syntax": [
+      "SOUND ...",
+      "A=JOY(port)",
+      "A=INKEY",
+      "A=GET",
+      "BEEP value"
+    ],
+    "notes": [
+      "JOY is an X1Pen 1.2L extension token.",
+      "Interactive input is visible in the emulator canvas; MCP screen capture can inspect output but does not replace program input handling."
+    ],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_tokenizer.js"]
+  },
+  {
+    "id": "fuzzybasic.text.x1-characters",
+    "language": "fuzzybasic",
+    "kind": "x1-extension",
+    "title": "X1 character conversion and escapes",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["unicode", "katakana", "hiragana", "escape", "named escape", "xNN"],
+    "summary": "The X1Pen tokenizer converts supported Unicode characters to X1 codes and accepts explicit hexadecimal or named escapes for characters that are difficult to enter directly.",
+    "syntax": [
+      "\\xNN",
+      "\\{name}"
+    ],
+    "notes": [
+      "Unsupported non-ASCII input produces a tokenizer error that identifies the Unicode code point.",
+      "Use x1pen_validate after introducing Japanese text or control-character escapes."
+    ],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_tokenizer.js"]
+  },
+  {
+    "id": "fuzzybasic.keywords.catalog",
+    "language": "fuzzybasic",
+    "kind": "catalog",
+    "title": "Accepted X1Pen FuzzyBASIC keywords",
+    "profiles": ["x1pen-fuzzybasic-1.2L"],
+    "aliases": ["reserved words", "commands", "statements", "functions", "keyword list"],
+    "summary": "The X1Pen tokenizer's accepted vocabulary includes editor commands, control flow, file operations, machine-level operations, graphics, sound and conversion functions.",
+    "syntax": [
+      "Control: IF THEN ELSE END IF FOR TO STEP NEXT REPEAT UNTIL WHILE WEND ON GOTO GOSUB RETURN",
+      "Procedures: LOCAL PROC RET PROC FUNC RET FUNC PUSH PULL POP VSTACK",
+      "Memory/I-O: PEEK WPEEK POKE WPOKE INP WINP OUT WOUT LDIR LDDR TRANS USR USR@",
+      "Graphics/audio: GRAPH LINE BOX CIRCLE PALET SPLINE TILE TRIANGLE MAGIC COLOR PCGDEF TCOLOR SOUND JOY",
+      "Strings/output: PRINT CHR$ LEFT$ RIGHT$ MSG MSX SPC STRING STR TAB HEX2 HEX4 DECI PN"
+    ],
+    "notes": [
+      "This catalog summarizes the exact tokenizer table; it is not a claim that every keyword behaves identically on every historical FuzzyBASIC build.",
+      "For an individual keyword not covered by a dedicated entry, consult the linked manual and verify it with x1pen_validate."
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_tokenizer.js",
+      "https://retropc.net/ohishi/s-os/fubasic.htm"
+    ]
+  }
+]

--- a/mcp/reference/manifest.json
+++ b/mcp/reference/manifest.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "referenceVersion": "2026-08-04",
+  "defaultProfiles": {
+    "fuzzybasic": "x1pen-fuzzybasic-1.2L",
+    "slang": "x1pen-slang-c9e8f53-lsx"
+  },
+  "profiles": [
+    {
+      "id": "x1pen-fuzzybasic-1.2L",
+      "language": "fuzzybasic",
+      "displayName": "X1Pen FuzzyBASIC 1.2L",
+      "runtime": "fuzzybasic_cold.v2.xmst",
+      "notes": "X1Pen tokenizer and X1-specific graphics, sound, joystick and character extensions.",
+      "sourceUrls": [
+        "https://retropc.net/ohishi/s-os/fubasic.htm"
+      ]
+    },
+    {
+      "id": "x1pen-slang-c9e8f53-lsx",
+      "language": "slang",
+      "displayName": "X1Pen SLANG c9e8f53 / LSX-Dodgers",
+      "compilerRevision": "c9e8f5315d8d44a413368045d78439a4ec8da3fc",
+      "environment": {
+        "ENV_TYPE": 1,
+        "defaultOrg": 256,
+        "runtime": "lsx-dodgers"
+      },
+      "notes": "The exact browser compiler snapshot and X1Pen-provided runtime/include library set.",
+      "sourceUrls": [
+        "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"
+      ]
+    }
+  ]
+}

--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -1,0 +1,429 @@
+[
+  {
+    "id": "slang.program.structure",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "Program structure, blocks and comments",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["MAIN", "BEGIN END", "free format", "comments", "braces"],
+    "summary": "SLANG is free-format and requires MAIN(). Blocks may use braces, brackets, parentheses, Japanese corner brackets, or BEGIN ... END;.",
+    "syntax": [
+      "MAIN() BEGIN ... END;",
+      "MAIN() { ... }",
+      "// line comment",
+      "/* block comment */",
+      "(* block comment *)"
+    ],
+    "notes": [
+      "A function name and its opening parenthesis cannot be separated by whitespace. An array name and its opening bracket cannot be separated by whitespace.",
+      "Strings and // comments cannot continue onto the next source line.",
+      "MAIN() may appear anywhere but must be defined."
+    ],
+    "examples": [
+      {
+        "title": "Minimal X1Pen SLANG program",
+        "source": "MAIN() BEGIN\n  PRINT(\"HELLO FROM X1PEN\", /);\nEND;"
+      }
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.data.types-declarations",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "BYTE, WORD, FLOAT, VAR, ARRAY and CONST",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["types", "variables", "arrays", "constants", "indirect variable", "24-bit float"],
+    "summary": "WORD is the default 16-bit type, BYTE is 8-bit, and the X1Pen compiler adds 24-bit FLOAT. VAR declares variables, ARRAY allocates indexed storage, and CONST defines compile-time values.",
+    "syntax": [
+      "VAR A, BYTE B, FLOAT F;",
+      "VAR BYTE P[]:$C000;",
+      "ARRAY BYTE BUFFER[255];",
+      "ARRAY FLOAT VALUES[3]={1.0, 2.0, 3.0, 4.0};",
+      "CONST SCREEN=$D000;"
+    ],
+    "notes": [
+      "ARRAY T NAME[n] allocates indexes 0 through n, so it contains n+1 elements.",
+      "BYTE uses 1 byte in static storage. Local BYTE and WORD values occupy 2-byte argument/local slots; FLOAT occupies 3 bytes.",
+      "Integer values convert to FLOAT automatically. Convert FLOAT to an integer explicitly with FTOI.",
+      "A VAR declared with [] is indirect: its value is treated as the base address for indexed memory access."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.functions.typed",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "Functions, arguments and return types",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["function", "RETURN", "typed arguments", "FLOAT return", "local variables"],
+    "summary": "Functions can declare BYTE, WORD or FLOAT parameters and return types. WORD is the default; FLOAT functions return a 24-bit value and require explicit FTOI conversion when consumed as an integer.",
+    "syntax": [
+      "SQUARE(X) BEGIN RETURN(X*X); END;",
+      "FSQUARE:FLOAT(FLOAT X) BEGIN RETURN(X*X); END;",
+      "RETURN;",
+      "RETURN(expression);",
+      "END(expression);"
+    ],
+    "notes": [
+      "Typed functions enforce argument counts and types. Legacy untyped declarations retain looser compatibility behavior.",
+      "WORD return values use HL; FLOAT return values use AHL.",
+      "Declarations before a function block are static. Declarations inside the block are dynamic locals, limited to 240 bytes per function."
+    ],
+    "examples": [
+      {
+        "title": "Typed integer function",
+        "source": "DOUBLE(WORD X) BEGIN\n  RETURN(X*2);\nEND;\n\nMAIN() BEGIN\n  PRINT(DOUBLE(21), /);\nEND;"
+      }
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.machine.calling-convention",
+    "language": "slang",
+    "kind": "runtime",
+    "title": "MACHINE declarations and calling convention",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["external routine", "register arguments", "Z80", "HL DE BC", "machine function"],
+    "summary": "MACHINE binds a SLANG function name to an external Z80 routine. Argument count controls whether values are passed in registers or on the stack.",
+    "syntax": [
+      "MACHINE MON(0):$1F8E;",
+      "MACHINE ROUTINE(2):address;",
+      "MACHINE VARARGS():address;"
+    ],
+    "notes": [
+      "0 arguments: CALL only. 1: HL. 2: HL then DE. 3: HL, DE and BC. 4 or more: stack.",
+      "If the argument count is omitted, arguments go on the stack and HL receives the argument count.",
+      "MACHINE functions return WORD only in this compiler snapshot; a FLOAT return annotation is rejected."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.control.flow",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "IF, loops, CASE, EXIT and CONTINUE",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["IF ELSE", "FOR NEXT", "WHILE WEND", "REPEAT UNTIL", "LOOP", "CASE", "break"],
+    "summary": "SLANG supports structured conditionals and loops, CASE selection, EXIT, multi-level EXIT(n), and CONTINUE.",
+    "syntax": [
+      "IF expression [THEN] statement [ELSE statement] [ENDIF;]",
+      "FOR variable=first TO last [DO] statement [NEXT;]",
+      "FOR variable=first DOWNTO last [DO] statement [NEXT;]",
+      "WHILE expression [DO] statement [WEND;]",
+      "REPEAT statement UNTIL expression;",
+      "LOOP statement;",
+      "EXIT;  EXIT(n);  CONTINUE;"
+    ],
+    "notes": [
+      "FOR is do-while-like: its body executes before the end value is tested. A range that already passed its end can still execute once.",
+      "CASE tests clauses from top to bottom and exits after the first match. Clauses may contain a value, a range with TO, or comma-separated values.",
+      "ELSE IF may also be written ELSEIF or EF."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.expressions.operators",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "Operators and signed arithmetic",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["operator precedence", "signed operators", "dot operators", "compound assignment", "logical and or"],
+    "summary": "Ordinary integer arithmetic and comparisons are unsigned where relevant. Dot operators provide signed multiply, divide, shifts and comparisons; the X1Pen compiler also supports logical &&/|| and compound assignments.",
+    "syntax": [
+      "+ - * / MOD << >> AND OR XOR",
+      ".*. ./. .MOD. .<<. .>>. .<. .<=. .>. .>=.",
+      "== <> != < <= > >=",
+      "&& ||",
+      "+= -= *= /=",
+      "condition ? value1 : value2"
+    ],
+    "notes": [
+      "AND, OR and XOR have lower precedence than comparison operators in the historical precedence table; use parentheses for clarity.",
+      "Relation results use TRUE=1 and FALSE=0.",
+      "The ampersand address operator returns the address of a variable or array element."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.preprocessor.includes",
+    "language": "slang",
+    "kind": "syntax",
+    "title": "Preprocessor, includes and environment constants",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["#INCLUDE", "#IF", "#ELSE", "#ENDIF", "#MODULE", "ENV_TYPE", "OS_TYPE"],
+    "summary": "Use #INCLUDE for bundled libraries and #IF for environment-dependent code. X1Pen compiles for ENV_TYPE=1, the LSX-Dodgers environment.",
+    "syntax": [
+      "#INCLUDE GRAPHF.LIB",
+      "#IF ENV_TYPE == 1",
+      "...",
+      "#ELSE",
+      "...",
+      "#ENDIF"
+    ],
+    "notes": [
+      "X1Pen sets ENV_TYPE to 1 and uses a default ORG of $0100.",
+      "The compiler supports include nesting up to 8 levels.",
+      "X1Pen bundles GRAPH.LIB, GRAPHF.LIB, SOROBAN.LIB, CHIPLIB.LIB, SPRLIB.LIB, TILELIB.LIB, TILESPR.LIB and UILIB.LIB. Other local files are not available through the browser VFS."
+    ],
+    "sourceUrls": [
+      "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
+      "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen.js"
+    ]
+  },
+  {
+    "id": "slang.output.print-strings",
+    "language": "slang",
+    "kind": "runtime",
+    "title": "PRINT formatting, strings and escapes",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["PRINT", "FORM$", "HEX2$", "HEX4$", "MSX$", "newline", "string escape"],
+    "summary": "PRINT accepts strings, numbers and formatting items. A slash emits a newline; string literals are zero-terminated addresses and support X1/S-OS control escapes.",
+    "syntax": [
+      "PRINT(\"VALUE=\", VALUE, /);",
+      "PRINT(HEX4$(ADDRESS), /);",
+      "PRINT(MSX$(POINTER));",
+      "'\\N'  '\\/'  '\\C'  '\\R'  '\\L'  '\\U'  '\\D'  '\\0'"
+    ],
+    "notes": [
+      "Common formatters include FORM$, DECI$, PN$, HEX2$, HEX4$, MSG$, MSX$, STR$, CHR$, SPC$, CR$ and TAB$.",
+      "The newline escape is backslash-N or backslash-slash and has value $0D. Backslash-C is clear-screen control $0C."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.machine.system-access",
+    "language": "slang",
+    "kind": "runtime",
+    "title": "System arrays, registers and core runtime functions",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["MEM", "MEMW", "PORT", "PORTW", "SOS", "registers", "BIT SET RESET", "MEMCPY MEMSET"],
+    "summary": "SLANG exposes byte/word memory and port arrays, S-OS work arrays, Z80 register variables, and core helper routines supplied by the X1Pen runtime.",
+    "syntax": [
+      "MEM[address]  MEMW[address]",
+      "PORT[port]  PORTW[port]",
+      "SOS[index]  SOSW[index]",
+      "^A ^AF ^BC ^DE ^HL ^IX ^IY ^SP ^CARRY ^ZERO",
+      "BIT(value,n) SET(value,n) RESET(value,n)",
+      "MEMCPY(destination,source,length) MEMSET(destination,value,length)",
+      "ABS(value) SGN(value) SEX(value) RND(limit) MIN(a,b) MAX(a,b)"
+    ],
+    "notes": [
+      "CALL and GETREG exchange values through registered Z80 register variables.",
+      "@KBUFF is the address of the keyboard input buffer."
+    ],
+    "sourceUrls": [
+      "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/core.asm"
+    ]
+  },
+  {
+    "id": "slang.runtime.lsx-io-files",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "X1Pen LSX input and file runtime",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE"],
+    "summary": "The X1Pen LSX runtime provides keyboard/line input and LSX file operations in addition to the core SLANG functions.",
+    "syntax": [
+      "INKEY(mode)",
+      "INPUT()",
+      "GETL(address)",
+      "GETLIN(address,length)",
+      "LINPUT(address,length)",
+      "FOPEN(...) FSEEK(...) FGETC(...) FPUTC(...) FCLOSE(...) FREAD(...) FWRITE(...)"
+    ],
+    "notes": [
+      "File APIs are low-level LSX runtime bindings. Search for the exact function name, inspect compiler diagnostics, and validate against the bundled runtime before relying on an argument convention.",
+      "INKEY takes one mode argument; INPUT takes none; GETL takes one; GETLIN and LINPUT take two."
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_input.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_file.asm"
+    ]
+  },
+  {
+    "id": "slang.x1.pcg-definition",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "Defining X1 PCG characters with PCGDEF and PCGDEFS",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["PCGDEF", "PCGDEFS", "programmable character generator", "BRG", "24-byte tile", "game graphics", "glyph"],
+    "summary": "The X1Pen runtime defines one PCG glyph with PCGDEF or a consecutive range with PCGDEFS. Each 8x8 glyph is a 24-byte Blue/Red/Green interleaved bitmap.",
+    "syntax": [
+      "WIDTH(40);",
+      "PCGDEF(index, patternAddress);",
+      "PCGDEFS(startIndex, patternAddress, count);",
+      "PRINT(CHR$(index));"
+    ],
+    "notes": [
+      "Call WIDTH before PCGDEF/PCGDEFS because PCG setup depends on 40- or 80-column mode.",
+      "Pattern format is 8 rows x 3 bytes. Each row is Blue, Red, Green; bit 7 is the leftmost pixel.",
+      "PCGDEFS advances the source pointer by 24 and the character index by 1 for every glyph.",
+      "Hardware registration consumes one vertical blank per glyph, approximately count/60 seconds for PCGDEFS. Load assets during initialization, not every frame.",
+      "After registration the source pattern buffer can be reused. TILELIB map and index arrays, by contrast, remain referenced during drawing.",
+      "PCG indexes are 0 through 255 and share the text character-code space."
+    ],
+    "examples": [
+      {
+        "title": "Define and display a blue PCG glyph",
+        "source": "ARRAY BYTE GLYPH[] = {\n  $3C,0,0, $7E,0,0, $DB,0,0, $FF,0,0,\n  $A5,0,0, $FF,0,0, $66,0,0, $3C,0,0\n};\n\nMAIN() BEGIN\n  WIDTH(40);\n  PCGDEFS(128, GLYPH, 1);\n  PRINT(CHR$(128), /);\nEND;"
+      }
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_pcg.asm",
+      "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/examples/tile/README.md"
+    ]
+  },
+  {
+    "id": "slang.include.tile-sprite",
+    "language": "slang",
+    "kind": "library",
+    "title": "TILELIB, SPRLIB and TILESPR APIs",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["tile map", "sprite", "scroll", "animation", "TILE_SYNC_SPR_PAGE"],
+    "summary": "X1Pen bundles a PCG tile-map library, a software-sprite library and a helper that synchronizes their double-buffer pages.",
+    "syntax": [
+      "#INCLUDE TILELIB.LIB",
+      "TILE_INIT() TILE_FILL_MAP() TILE_SET_MAP(3 args) TILE_SET_MAPSIZE(2 args)",
+      "TILE_SET_SCROLL(2 args) TILE_SET_ANIM(1 arg) TILE_SET_ANIM_RATE(2 args) TILE_ANIM_TICK()",
+      "TILE_SET_PAGE(1 arg) TILE_SET_OFS(2 args) TILE_SET_SIZE(2 args) TILE_INVALIDATE()",
+      "#INCLUDE SPRLIB.LIB",
+      "SPR_INIT() SPR_SET_PATTERN(2 args) SPR_SET_POS(3 args) SPR_SET_SHOW(2 args) SPR_IS_ACTIVE(1 arg) SPR_UPDATE()",
+      "#INCLUDE TILESPR.LIB",
+      "TILE_SYNC_SPR_PAGE()"
+    ],
+    "notes": [
+      "Initialize each subsystem before setting maps, patterns or positions. Call animation/update functions from the program's frame loop.",
+      "TILELIB uses 8x8 PCG glyphs as tiles. Four tile indexes in TL, TR, BL, BR order form one 16x16 super-chip; the map stores one super-chip number per byte.",
+      "Recommended setup order: WIDTH(40), PCGDEFS, TILE_INIT, TILE_SET_MAP, TILE_SET_MAPSIZE, optional animation setup, then TILE_FILL_MAP.",
+      "TILE_SET_MAP(map,index,0) keeps pointers to both arrays; keep them alive. Its third argument is reserved and must be 0.",
+      "TILE_SET_SCROLL uses character units (8 pixels). TILE_SET_MAPSIZE uses super-chip units. TILE_SET_SIZE uses character units and an even width is recommended.",
+      "For animation, reserve consecutive groups of up to four PCG indexes, set the threshold with TILE_SET_ANIM, call TILE_ANIM_TICK from VSYNC_PROC, and call TILE_FILL_MAP each frame.",
+      "The signatures list parameter counts because the libraries bind their public calls with MACHINE declarations; consult the library source for argument meaning and memory layout."
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/TILELIB.LIB",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/SPRLIB.LIB",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/TILESPR.LIB"
+    ]
+  },
+  {
+    "id": "slang.include.chiplib",
+    "language": "slang",
+    "kind": "library",
+    "title": "CHIPLIB tile-chip and sprite APIs",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["CHIP_INIT", "CHIP_DRAW", "CHIP_SET_MAP", "CHIP_SET_SCROLL", "CHIP_SPR"],
+    "summary": "CHIPLIB exposes a compact tile-chip renderer, animation controls and a small sprite composition interface.",
+    "syntax": [
+      "#INCLUDE CHIPLIB.LIB",
+      "CHIP_INIT() CHIP_DRAW_VVRAM() CHIP_FILL_MAP()",
+      "CHIP_DRAW(3 args) CHIP_MASK_DRAW(3 args)",
+      "CHIP_SET_OFS(2 args) CHIP_SET_SIZE(2 args) CHIP_SET_MAP(3 args) CHIP_SET_MAPSIZE(2 args)",
+      "CHIP_SET_SCROLL(2 args) CHIP_SET_VVRAMSIZE(2 args)",
+      "CHIP_SET_ANIM(1 arg) CHIP_SET_ANIM_RATE(2 args) CHIP_ANIM_TICK()",
+      "CHIP_SPR_START() CHIP_SPR_POS(2 args) CHIP_SPR_ADD(3 args) CHIP_SPR_FLASH(1 arg)"
+    ],
+    "notes": [
+      "Call CHIP_INIT before drawing. Configure offsets, sizes, map and VVRAM dimensions before the main draw loop.",
+      "The public declarations specify argument counts; use the bundled CHIPLIB.LIB comments and validation to confirm each argument's units."
+    ],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/CHIPLIB.LIB"]
+  },
+  {
+    "id": "slang.include.ui",
+    "language": "slang",
+    "kind": "library",
+    "title": "UILIB text UI API",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["UI_AT", "UI_SET_COLOR", "UI_PUTC", "UI_PUTS", "UI_FILL", "UI_BOX", "UI_FONT_ADDR"],
+    "summary": "UILIB provides cursor positioning, color, character/string output, fill and box operations for compact text-oriented interfaces.",
+    "syntax": [
+      "#INCLUDE UILIB.LIB",
+      "UI_AT(x,y)",
+      "UI_SET_COLOR(color)",
+      "UI_PUTC(character)",
+      "UI_PUTS(address)",
+      "UI_FILL(2 args)",
+      "UI_BOX(2 args)",
+      "UI_FONT_ADDR()"
+    ],
+    "notes": [
+      "UI_PUTS receives an address, normally a zero-terminated SLANG string literal or buffer.",
+      "The fill and box calls use compact packed arguments defined by UILIB; inspect its comments when constructing nontrivial layouts."
+    ],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/UILIB.LIB"]
+  },
+  {
+    "id": "slang.include.graph-soroban",
+    "language": "slang",
+    "kind": "library",
+    "title": "GRAPH, GRAPHF and SOROBAN libraries",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["3D graphics", "floating point", "LINEC", "CIRCLEC", "SOROBAN", "trigonometry"],
+    "summary": "GRAPH provides the historical geometry package, GRAPHF adds FLOAT/color variants, and SOROBAN provides the older software numeric package.",
+    "syntax": [
+      "#INCLUDE GRAPH.LIB",
+      "@INIT(...) @CLS(...) @MODE(...) @PALET(...) @WINDOW(...) @LINE(...) @SPLINE(...) @BOX(...) @TRIANGLE(...) @FULL(...) @CIRCLE(...) ",
+      "#INCLUDE GRAPHF.LIB",
+      "@LINEC(...) @SPLINEC(...) @BOXC(...) @TRIANGLEC(...) @FULLC(...) @CIRCLEC(...) ",
+      "#INCLUDE SOROBAN.LIB"
+    ],
+    "notes": [
+      "GRAPH and GRAPHF are substantial packages with shared global buffers and compile-time feature switches; start from their headers and initialization routines rather than mixing calls blindly.",
+      "Prefer GRAPHF and native FLOAT for new X1Pen programs that need floating-point calculations. SOROBAN remains useful for compatibility with older SLANG sources.",
+      "SOROBAN includes single/double numeric operations, conversion, comparison, arithmetic, square root, trigonometric, exponential and logarithmic routines."
+    ],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/GRAPH.LIB",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/GRAPHF.LIB",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/SOROBAN.LIB"
+    ]
+  },
+  {
+    "id": "slang.x1pen.build-profile",
+    "language": "slang",
+    "kind": "profile",
+    "title": "X1Pen compiler and LSX-Dodgers build profile",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["compiler revision", "c9e8f53", "ENV_TYPE 1", "ORG 0100", "generated ASM", "LSX"],
+    "summary": "X1Pen uses SLANG compiler snapshot c9e8f53, compiles with ENV_TYPE=1 and default ORG=$0100, assembles the generated Z80 source, then runs it under LSX-Dodgers.",
+    "syntax": [
+      "ENV_TYPE = 1",
+      "default ORG = $0100",
+      "sourceMode = slang"
+    ],
+    "notes": [
+      "The ASM editor content is generated output in SLANG mode. Edit the SLANG source, not the generated ASM.",
+      "x1pen_validate compiles SLANG and assembles its generated output without running it.",
+      "The MCP reference profile is tied to the exact compiler commit c9e8f5315d8d44a413368045d78439a4ec8da3fc."
+    ],
+    "sourceUrls": [
+      "https://github.com/h-o-soft/SLANG-compiler/tree/c9e8f5315d8d44a413368045d78439a4ec8da3fc",
+      "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen.js"
+    ]
+  },
+  {
+    "id": "slang.limits.gotchas",
+    "language": "slang",
+    "kind": "limits",
+    "title": "Compiler limits and common mistakes",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "aliases": ["limitations", "errors", "gotchas", "array size", "whitespace", "FOR executes once"],
+    "summary": "Keep function names attached to '(', array names attached to '[', remember that array bounds are inclusive, and stay within compiler nesting and storage limits.",
+    "syntax": [
+      "CALL()     // valid",
+      "CALL ()    // invalid",
+      "ARRAY BYTE A[9];  // A[0] through A[9], ten elements"
+    ],
+    "notes": [
+      "Dynamic local area: 240 bytes per function. Argument work: up to 8 arguments. Loop nesting: 16 levels.",
+      "Maximum source line length: 255 characters. Maximum name length: 32 characters. Include nesting: 8 levels.",
+      "FOR executes its body before checking the end condition.",
+      "FLOAT-to-integer conversion is not implicit; use FTOI.",
+      "Validate frequently because included libraries consume memory and may impose initialization or buffer-address requirements not expressed by the language type system."
+    ],
+    "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  }
+]

--- a/mcp/x1pen-reference.mjs
+++ b/mcp/x1pen-reference.mjs
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+
+const REFERENCE_DIR = new URL('./reference/', import.meta.url);
+const MANIFEST = readJson('manifest.json');
+const ENTRIES = Object.freeze([
+  ...readJson('fuzzybasic.json'),
+  ...readJson('slang.json'),
+]);
+const ENTRY_BY_ID = new Map(ENTRIES.map((entry) => [entry.id, entry]));
+
+function readJson(filename) {
+  return JSON.parse(readFileSync(new URL(filename, REFERENCE_DIR), 'utf8'));
+}
+
+function normalize(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}_$@^]+/gu, ' ')
+    .trim();
+}
+
+function searchableText(entry) {
+  return normalize([
+    entry.id,
+    entry.kind,
+    entry.title,
+    ...(entry.aliases || []),
+    entry.summary,
+    ...(entry.syntax || []),
+    ...(entry.notes || []),
+  ].join(' '));
+}
+
+function scoreEntry(entry, normalizedQuery, queryTokens) {
+  const title = normalize(entry.title);
+  const aliases = (entry.aliases || []).map(normalize);
+  const text = searchableText(entry);
+  if (!queryTokens.every((token) => text.includes(token))) return 0;
+
+  let score = queryTokens.length * 10;
+  if (title === normalizedQuery) score += 100;
+  if (aliases.includes(normalizedQuery)) score += 90;
+  if (title.includes(normalizedQuery)) score += 50;
+  if (aliases.some((alias) => alias.includes(normalizedQuery))) score += 40;
+  if (normalize(entry.id).includes(normalizedQuery)) score += 30;
+  for (const token of queryTokens) {
+    if (title.includes(token)) score += 8;
+    if (aliases.some((alias) => alias.includes(token))) score += 6;
+  }
+  return score;
+}
+
+function matchesProfile(entry, profile) {
+  return !profile || entry.profiles.includes(profile);
+}
+
+export function getReferenceManifest() {
+  return structuredClone(MANIFEST);
+}
+
+export function searchReference({ language, query, profile, kinds, maxResults = 8 }) {
+  const normalizedQuery = normalize(query);
+  const queryTokens = [...new Set(normalizedQuery.split(/\s+/).filter(Boolean))];
+  if (queryTokens.length === 0) throw new Error('query must contain searchable characters');
+
+  const allowedKinds = kinds ? new Set(kinds) : null;
+  const scored = ENTRIES
+    .filter((entry) => (!language || entry.language === language)
+      && matchesProfile(entry, profile)
+      && (!allowedKinds || allowedKinds.has(entry.kind)))
+    .map((entry) => ({ entry, score: scoreEntry(entry, normalizedQuery, queryTokens) }))
+    .filter(({ score }) => score > 0)
+    .sort((left, right) => right.score - left.score || left.entry.id.localeCompare(right.entry.id));
+
+  return {
+    query,
+    ...(language ? { language } : {}),
+    ...(profile ? { profile } : {}),
+    totalMatches: scored.length,
+    matches: scored.slice(0, maxResults).map(({ entry, score }) => ({
+      id: entry.id,
+      language: entry.language,
+      kind: entry.kind,
+      title: entry.title,
+      summary: entry.summary,
+      score,
+    })),
+    truncated: scored.length > maxResults,
+  };
+}
+
+export function getReferenceEntries({ ids, maxCharacters = 32 * 1024 }) {
+  const entries = [];
+  const omittedIds = [];
+  let characterCount = 0;
+
+  for (const id of [...new Set(ids)]) {
+    const entry = ENTRY_BY_ID.get(id);
+    if (!entry) throw new Error(`Unknown reference ID: ${id}`);
+    const entrySize = JSON.stringify(entry).length;
+    if (characterCount + entrySize > maxCharacters) {
+      omittedIds.push(id);
+      continue;
+    }
+    entries.push(structuredClone(entry));
+    characterCount += entrySize;
+  }
+
+  return {
+    entries,
+    omittedIds,
+    characterCount,
+    truncated: omittedIds.length > 0,
+  };
+}
+
+export function validateReferenceData() {
+  const profileIds = new Set(MANIFEST.profiles.map((profile) => profile.id));
+  const errors = [];
+  if (ENTRY_BY_ID.size !== ENTRIES.length) errors.push('Reference IDs must be unique');
+  for (const entry of ENTRIES) {
+    for (const field of ['id', 'language', 'kind', 'title', 'summary']) {
+      if (!entry[field]) errors.push(`${entry.id || '<unknown>'}: missing ${field}`);
+    }
+    if (!Array.isArray(entry.profiles) || entry.profiles.length === 0) {
+      errors.push(`${entry.id}: profiles must not be empty`);
+    } else {
+      for (const profile of entry.profiles) {
+        if (!profileIds.has(profile)) errors.push(`${entry.id}: unknown profile ${profile}`);
+      }
+    }
+  }
+  return { manifest: MANIFEST, entries: ENTRIES, errors };
+}

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -7,12 +7,19 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as z from 'zod/v4';
 import { X1PenBridge } from './x1pen-bridge.mjs';
+import {
+  getReferenceEntries,
+  getReferenceManifest,
+  searchReference,
+} from './x1pen-reference.mjs';
 
 const PACKAGE = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 const MAX_SOURCE_LENGTH = 512 * 1024;
 const DEFAULT_RANGE_CHARACTERS = 32 * 1024;
 const MAX_RANGE_CHARACTERS = 128 * 1024;
 const SOURCE_SECTIONS = ['basic', 'asm', 'slang'];
+const REFERENCE_LANGUAGES = ['fuzzybasic', 'slang'];
+const REFERENCE_KINDS = ['syntax', 'runtime', 'x1-extension', 'catalog', 'library', 'profile', 'limits'];
 
 function textResult(value) {
   return {
@@ -289,6 +296,61 @@ export function createX1PenMcpServer(options = {}) {
     inputSchema: { sessionId: z.string().min(1) },
     annotations: { openWorldHint: false },
   }, handleTool(async ({ sessionId }) => textResult(bridge.selectSession(sessionId))));
+
+  server.registerTool('x1pen_get_language_profile', {
+    description: 'List the bundled FuzzyBASIC and SLANG reference profiles and, when connected, compare them with the exact profiles reported by X1Pen.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      includeActive: z.boolean().default(true)
+        .describe('Read profile IDs from the connected X1Pen tab when one is available'),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, includeActive }) => {
+    const manifest = getReferenceManifest();
+    const result = { ...manifest, active: null, reportedProfiles: null, compatible: null };
+    if (!includeActive) return textResult(result);
+
+    const sessions = bridge.listSessions();
+    if (!sessionId && sessions.length === 0) {
+      result.note = 'Reference data is available offline; connect an X1Pen tab to identify its active profiles.';
+      return textResult(result);
+    }
+
+    const status = await bridge.sendCommand('getStatus', {}, sessionId);
+    if (!status || !status.languageProfiles) {
+      result.note = 'The connected X1Pen does not report language profile IDs. Update X1Pen to compare reference compatibility.';
+      return textResult(result);
+    }
+    result.active = status.activeLanguageProfile || null;
+    result.reportedProfiles = status.languageProfiles;
+    const bundledIds = new Set(manifest.profiles.map((profile) => profile.id));
+    const activeIds = Object.values(status.languageProfiles)
+      .map((profile) => profile && profile.id)
+      .filter(Boolean);
+    result.compatible = activeIds.every((id) => bundledIds.has(id));
+    return textResult(result);
+  }));
+
+  server.registerTool('x1pen_search_reference', {
+    description: 'Search the bundled X1Pen FuzzyBASIC and SLANG reference. Returns compact summaries and stable IDs; use x1pen_get_reference for selected details.',
+    inputSchema: {
+      query: z.string().min(1).max(1_024),
+      language: z.enum(REFERENCE_LANGUAGES).optional(),
+      profile: z.string().min(1).max(128).optional(),
+      kinds: z.array(z.enum(REFERENCE_KINDS)).min(1).max(REFERENCE_KINDS.length).optional(),
+      maxResults: z.number().int().min(1).max(20).default(8),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async (args) => textResult(searchReference(args))));
+
+  server.registerTool('x1pen_get_reference', {
+    description: 'Get complete reference entries for stable IDs returned by x1pen_search_reference, with a bounded response size.',
+    inputSchema: {
+      ids: z.array(z.string().min(1).max(128)).min(1).max(10),
+      maxCharacters: z.number().int().min(1).max(MAX_RANGE_CHARACTERS).default(DEFAULT_RANGE_CHARACTERS),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async (args) => textResult(getReferenceEntries(args))));
 
   server.registerTool('x1pen_get_program', {
     description: 'Get a compact program summary and explicitly selected complete sources. Defaults to metadata only; prefer get_source/search_source for large sources.',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pack:mcp": "npm pack ./mcp",
     "test:automation": "node --test tests/x1pen_automation_test.mjs",
     "test:bridge": "node --test tests/x1pen_bridge_test.mjs",
-    "test:mcp": "node --test tests/x1pen_mcp_test.mjs",
+    "test:mcp": "node --test tests/x1pen_mcp_test.mjs tests/x1pen_reference_test.mjs",
     "test:mcp-package": "node --test tests/x1pen_mcp_package_test.mjs"
   }
 }

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -148,6 +148,11 @@ test('connection state and AI interaction lock are visible', async () => {
   });
   assert.equal(locked.status.connected, true);
   assert.equal(locked.status.interactionLocked, true);
+  assert.equal(locked.status.languageProfiles.fuzzybasic.id, 'x1pen-fuzzybasic-1.2L');
+  assert.equal(locked.status.languageProfiles.slang.id, 'x1pen-slang-c9e8f53-lsx');
+  assert.equal(locked.status.languageProfiles.slang.envType, 1);
+  assert.equal(locked.status.sourceMode, 'basic+asm');
+  assert.equal(locked.status.activeLanguageProfile.id, 'x1pen-fuzzybasic-1.2L');
   assert.equal(locked.panelInert, true);
   assert.equal(locked.overlay, 'AI test');
   assert.equal(locked.badgeHidden, false);

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -41,7 +41,11 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'README.md',
       'THIRD_PARTY_LICENSES.md',
       'package.json',
+      'reference/fuzzybasic.json',
+      'reference/manifest.json',
+      'reference/slang.json',
       'x1pen-bridge.mjs',
+      'x1pen-reference.mjs',
       'x1pen-server.mjs',
     ]);
 
@@ -56,7 +60,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.1.0');
+    assert.equal(manifest.version, '2.2.0');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');
@@ -72,13 +76,21 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     await client.connect(transport);
 
     const tools = await client.listTools();
-    assert.equal(tools.tools.length, 13);
+    assert.equal(tools.tools.length, 16);
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
+    assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_search_reference'));
     const connection = await client.callTool({ name: 'x1pen_connection_info', arguments: {} });
     const info = JSON.parse(connection.content[0].text);
     assert.equal(info.host, '127.0.0.1');
     assert.ok(Number.isInteger(info.port));
     assert.match(info.pairingCode, /^\d{6}$/);
+
+    const reference = await client.callTool({
+      name: 'x1pen_search_reference',
+      arguments: { query: 'PROC LOCAL' },
+    });
+    const matches = JSON.parse(reference.content[0].text);
+    assert.equal(matches.matches[0].id, 'fuzzybasic.subroutines.proc');
   } finally {
     if (client) await client.close();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -57,6 +57,16 @@ const fakeBridge = {
       return clone(currentProgram);
     }
     if (method === 'validate') return { ok: true, diagnostics: [] };
+    if (method === 'getStatus') {
+      return {
+        ready: true,
+        activeLanguageProfile: { language: 'fuzzybasic', id: 'x1pen-fuzzybasic-1.2L' },
+        languageProfiles: {
+          fuzzybasic: { id: 'x1pen-fuzzybasic-1.2L' },
+          slang: { id: 'x1pen-slang-c9e8f53-lsx' },
+        },
+      };
+    }
     if (method === 'captureScreen') return `data:image/png;base64,${Buffer.from('png').toString('base64')}`;
     return { ok: true };
   },
@@ -95,17 +105,51 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_apply_edits',
     'x1pen_capture_screen',
     'x1pen_connection_info',
+    'x1pen_get_language_profile',
     'x1pen_get_program',
+    'x1pen_get_reference',
     'x1pen_get_source',
     'x1pen_get_status',
     'x1pen_list_sessions',
     'x1pen_run',
+    'x1pen_search_reference',
     'x1pen_search_source',
     'x1pen_select_session',
     'x1pen_set_program',
     'x1pen_stop',
     'x1pen_validate',
   ]);
+});
+
+test('language reference tools search compact results and fetch selected details', async () => {
+  const searchResult = await client.callTool({
+    name: 'x1pen_search_reference',
+    arguments: { language: 'slang', query: 'TILE_SET_SCROLL' },
+  });
+  const search = jsonContent(searchResult);
+  assert.equal(search.totalMatches, 1);
+  assert.equal(search.matches[0].id, 'slang.include.tile-sprite');
+  assert.equal(search.matches[0].syntax, undefined);
+
+  const detailResult = await client.callTool({
+    name: 'x1pen_get_reference',
+    arguments: { ids: [search.matches[0].id] },
+  });
+  const detail = jsonContent(detailResult);
+  assert.equal(detail.entries[0].id, 'slang.include.tile-sprite');
+  assert.ok(detail.entries[0].syntax.some((line) => line.includes('TILE_SET_SCROLL')));
+  assert.equal(detail.truncated, false);
+});
+
+test('language profile reports bundled data and connected X1Pen compatibility', async () => {
+  const result = await client.callTool({ name: 'x1pen_get_language_profile', arguments: {} });
+  const profile = jsonContent(result);
+  assert.equal(profile.schemaVersion, 1);
+  assert.equal(profile.profiles.length, 2);
+  assert.equal(profile.active.id, 'x1pen-fuzzybasic-1.2L');
+  assert.equal(profile.reportedProfiles.slang.id, 'x1pen-slang-c9e8f53-lsx');
+  assert.equal(profile.compatible, true);
+  assert.equal(calls.at(-1).method, 'getStatus');
 });
 
 test('get_program defaults to metadata only and excludes generated ASM', async () => {

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import { test } from 'node:test';
+import {
+  getReferenceEntries,
+  searchReference,
+  validateReferenceData,
+} from '../mcp/x1pen-reference.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function loadBrowserGlobal(filename, exportName) {
+  const context = { window: {} };
+  vm.runInNewContext(readFileSync(join(repoRoot, filename), 'utf8'), context, { filename });
+  return context.window[exportName];
+}
+
+function loadSlangVfs() {
+  const vfs = {};
+  for (const directory of ['assets/slang_runtime', 'assets/slang_include']) {
+    for (const filename of readdirSync(join(repoRoot, directory))) {
+      if (/\.(?:asm|lib)$/i.test(filename)) {
+        vfs[filename] = readFileSync(join(repoRoot, directory, filename), 'utf8');
+      }
+    }
+  }
+  return vfs;
+}
+
+test('reference data has unique IDs and known profiles', () => {
+  const validation = validateReferenceData();
+  assert.deepEqual(validation.errors, []);
+  assert.equal(validation.manifest.schemaVersion, 1);
+  assert.ok(validation.entries.length >= 25);
+});
+
+test('reference search is deterministic, filtered and summary-only', () => {
+  const first = searchReference({ language: 'slang', query: 'FLOAT return', maxResults: 3 });
+  const second = searchReference({ language: 'slang', query: 'FLOAT return', maxResults: 3 });
+  assert.deepEqual(first, second);
+  assert.ok(first.matches.length > 0);
+  assert.ok(first.matches.every((match) => match.language === 'slang'));
+  assert.ok(first.matches.every((match) => match.syntax === undefined));
+});
+
+test('reference detail output honors maxCharacters', () => {
+  const result = getReferenceEntries({
+    ids: ['slang.program.structure', 'slang.include.graph-soroban'],
+    maxCharacters: 900,
+  });
+  assert.ok(result.entries.length < 2);
+  assert.ok(result.omittedIds.length > 0);
+  assert.equal(result.truncated, true);
+});
+
+test('bundled FuzzyBASIC examples are accepted by the X1Pen tokenizer', () => {
+  const tokenizer = loadBrowserGlobal('html/x1pen_tokenizer.js', 'X1PenTokenizer');
+  const { entries } = validateReferenceData();
+  const examples = entries
+    .filter((entry) => entry.language === 'fuzzybasic')
+    .flatMap((entry) => entry.examples || []);
+  assert.ok(examples.length >= 2);
+  for (const example of examples) {
+    const bytes = tokenizer.tokenizeProgram(example.source);
+    assert.ok(bytes.length > 2, `${example.title} must produce program bytes`);
+  }
+});
+
+test('bundled SLANG examples compile with the exact X1Pen compiler and VFS', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const vfs = loadSlangVfs();
+  const { entries } = validateReferenceData();
+  const examples = entries
+    .filter((entry) => entry.language === 'slang')
+    .flatMap((entry) => entry.examples || []);
+  assert.ok(examples.length >= 2);
+  for (const example of examples) {
+    const result = compiler.compile(example.source, vfs, {
+      defaultOrg: 0x100,
+      codeReadonly: false,
+      defines: { ENV_TYPE: 1 },
+    });
+    assert.equal(result.errors.length, 0, `${example.title}: ${JSON.stringify(result.errors)}`);
+    assert.ok(result.asm.length > 0, `${example.title} must generate ASM`);
+  }
+});
+
+test('documented include API names exist in the bundled libraries', () => {
+  const selectedApis = {
+    'CHIPLIB.LIB': ['CHIP_INIT', 'CHIP_SET_MAP', 'CHIP_SPR_ADD'],
+    'SPRLIB.LIB': ['SPR_INIT', 'SPR_SET_POS', 'SPR_UPDATE'],
+    'TILELIB.LIB': ['TILE_INIT', 'TILE_SET_SCROLL', 'TILE_INVALIDATE'],
+    'TILESPR.LIB': ['TILE_SYNC_SPR_PAGE'],
+    'UILIB.LIB': ['UI_AT', 'UI_PUTS', 'UI_BOX'],
+  };
+  const documented = JSON.stringify(getReferenceEntries({
+    ids: ['slang.include.tile-sprite', 'slang.include.chiplib', 'slang.include.ui'],
+    maxCharacters: 32 * 1024,
+  }).entries);
+
+  for (const [filename, names] of Object.entries(selectedApis)) {
+    const source = readFileSync(join(repoRoot, 'assets/slang_include', filename), 'utf8');
+    for (const name of names) {
+      assert.match(source, new RegExp(`\\b${name}\\b`), `${name} must exist in ${filename}`);
+      assert.ok(documented.includes(name), `${name} must be covered by the reference`);
+    }
+  }
+});
+
+test('PCG reference matches the bundled X1 runtime contract', () => {
+  const runtime = readFileSync(join(repoRoot, 'assets/slang_runtime/libx1_pcg.asm'), 'utf8');
+  const details = JSON.stringify(getReferenceEntries({
+    ids: ['fuzzybasic.x1.pcg-definition', 'slang.x1.pcg-definition', 'slang.include.tile-sprite'],
+    maxCharacters: 32 * 1024,
+  }).entries);
+  for (const name of ['PCGDEF', 'PCGDEFS']) {
+    assert.match(runtime, new RegExp(`; @name ${name}\\b`));
+    assert.ok(details.includes(name));
+  }
+  assert.match(runtime, /HL = STARTIDX .* DE = ADDR \(24 bytes\/tile\), BC = COUNT/);
+  assert.ok(details.includes('24-byte'));
+  assert.ok(details.includes('Blue, Red, Green'));
+});


### PR DESCRIPTION
## Summary

- bundle 29 structured, offline-searchable reference entries for X1Pen FuzzyBASIC 1.2L and SLANG c9e8f53 / LSX-Dodgers
- add `x1pen_get_language_profile`, `x1pen_search_reference`, and `x1pen_get_reference` with compact search results and bounded detail responses
- report exact language profile IDs and the active authoring profile from X1Pen Automation API
- add detailed PCG support for FuzzyBASIC and SLANG, including 24-byte BRG patterns, `PCGDEF` / `PCGDEFS`, BASIC+ASM and compiled examples, and TILELIB setup/animation guidance
- publish the reference files in `x1pen-mcp` 2.2.0 and update Codex / Claude Code setup docs

## Validation

- `./build.sh`
- `npm run test:mcp` (18 tests)
- `npm run test:automation` (5 tests)
- `npm run test:bridge` (4 tests)
- `npm run test:mcp-package` (packed install and offline reference search)

Reference examples are checked against the current X1Pen tokenizer and exact bundled SLANG compiler/VFS. Selected include APIs and PCG runtime contracts are checked against the source assets.