### PR TITLE
Add Z80 debugger core APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(EMSCRIPTEN)
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s ALLOW_MEMORY_GROWTH=1")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s INITIAL_MEMORY=67108864") # 64MB
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s GLOBAL_BASE=131072") # 128KB: stack-first layout 対策
-    set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_FUNCTIONS='[\"_main\",\"_malloc\",\"_free\",\"_js_xmil_start\",\"_js_xmil_stop\",\"_js_xmil_reset\",\"_js_xmil_nmi\",\"_js_xmil_power_off\",\"_js_xmil_power_on\",\"_js_insert_disk\",\"_js_set_rom_type\",\"_js_set_dip_sw\",\"_js_set_skip_line\",\"_js_set_motor\",\"_js_set_motor_volume\",\"_js_eject_disk\",\"_js_insert_cmt\",\"_js_cmt_eject\",\"_js_cmt_play\",\"_js_cmt_stop\",\"_js_cmt_ff\",\"_js_cmt_rew\",\"_js_get_cmt_cmd\",\"_js_get_cmt_pos\",\"_js_get_cmt_end\",\"_js_get_cmt_freq\",\"_js_set_sasi_path\",\"_js_set_joystick\",\"_js_set_key_mode\",\"_js_set_mouse\",\"_js_reload_fonts\",\"_js_key_down\",\"_js_key_up\",\"_js_save_state\",\"_js_load_state\",\"_js_get_load_warnings\",\"_js_get_dip_sw\",\"_js_get_rom_type\",\"_js_fdd_flush\",\"_js_emm_flush\",\"_js_emm_reset_slot\",\"_js_emm_take_dirty_slots\",\"_js_set_sound_sw\",\"_js_get_sound_sw\",\"_js_get_main_ram\"]'")
+    set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_FUNCTIONS='[\"_main\",\"_malloc\",\"_free\",\"_js_xmil_start\",\"_js_xmil_stop\",\"_js_xmil_reset\",\"_js_xmil_nmi\",\"_js_xmil_power_off\",\"_js_xmil_power_on\",\"_js_insert_disk\",\"_js_set_rom_type\",\"_js_set_dip_sw\",\"_js_set_skip_line\",\"_js_set_motor\",\"_js_set_motor_volume\",\"_js_eject_disk\",\"_js_insert_cmt\",\"_js_cmt_eject\",\"_js_cmt_play\",\"_js_cmt_stop\",\"_js_cmt_ff\",\"_js_cmt_rew\",\"_js_get_cmt_cmd\",\"_js_get_cmt_pos\",\"_js_get_cmt_end\",\"_js_get_cmt_freq\",\"_js_set_sasi_path\",\"_js_set_joystick\",\"_js_set_key_mode\",\"_js_set_mouse\",\"_js_reload_fonts\",\"_js_key_down\",\"_js_key_up\",\"_js_save_state\",\"_js_load_state\",\"_js_get_load_warnings\",\"_js_get_dip_sw\",\"_js_get_rom_type\",\"_js_fdd_flush\",\"_js_emm_flush\",\"_js_emm_reset_slot\",\"_js_emm_take_dirty_slots\",\"_js_set_sound_sw\",\"_js_get_sound_sw\",\"_js_get_main_ram\",\"_js_debug_pause\",\"_js_debug_resume\",\"_js_debug_step\",\"_js_debug_get_state\",\"_js_debug_replace_breakpoints\",\"_js_debug_read_memory\"]'")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -s EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\",\"FS\",\"wasmMemory\"]'")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} -sUSE_ZLIB=1")
     set(EM_LINK_FLAGS "${EM_LINK_FLAGS} --pre-js ${CMAKE_SOURCE_DIR}/html/pre.js")
@@ -90,6 +90,7 @@ set_source_files_properties(
 
 # プラットフォーム抽象化層のソース
 set(PLATFORM_SOURCES
+    platform/debugger_core.cpp
     platform/platform_graphics.cpp
     platform/platform_audio.cpp
     platform/platform_input.cpp

--- a/platform/debugger_core.cpp
+++ b/platform/debugger_core.cpp
@@ -11,6 +11,18 @@ static uint16_t g_stop_address = 0;
 static bool g_step_requested = false;
 static bool g_skip_breakpoint_once = false;
 static uint16_t g_skip_breakpoint_address = 0;
+uint8_t debugger_fast_flags = 0;
+
+static void refresh_fast_flags() {
+    debugger_fast_flags = 0;
+    if (g_state == DEBUGGER_PAUSED || g_breakpoint_count > 0 ||
+        g_skip_breakpoint_once) {
+        debugger_fast_flags |= DEBUGGER_FAST_BEFORE_INSTRUCTION;
+    }
+    if (g_step_requested) {
+        debugger_fast_flags |= DEBUGGER_FAST_AFTER_INSTRUCTION;
+    }
+}
 
 static bool has_breakpoint(uint16_t address) {
     return (g_breakpoints[address >> 3] & (uint8_t)(1u << (address & 7))) != 0;
@@ -22,6 +34,7 @@ static void set_paused(DebuggerStopReason reason, uint16_t address) {
     g_stop_address = address;
     g_step_requested = false;
     g_sequence++;
+    refresh_fast_flags();
 }
 
 bool debugger_is_paused() {
@@ -36,14 +49,16 @@ void debugger_pause(uint16_t pc) {
 
 void debugger_resume(uint16_t pc) {
     if (g_state == DEBUGGER_RUNNING) return;
-    g_skip_breakpoint_once =
-        g_stop_reason == DEBUGGER_STOP_BREAKPOINT && g_stop_address == pc;
+    // Continue always executes the instruction at the current PC once. This
+    // also covers stepping or manually pausing on an armed breakpoint.
+    g_skip_breakpoint_once = true;
     g_skip_breakpoint_address = pc;
     g_step_requested = false;
     g_state = DEBUGGER_RUNNING;
     g_stop_reason = DEBUGGER_STOP_NONE;
     g_stop_address = pc;
     g_sequence++;
+    refresh_fast_flags();
 }
 
 bool debugger_begin_step(uint16_t pc) {
@@ -55,15 +70,18 @@ bool debugger_begin_step(uint16_t pc) {
     g_stop_reason = DEBUGGER_STOP_NONE;
     g_stop_address = pc;
     g_sequence++;
+    refresh_fast_flags();
     return true;
 }
 
 bool debugger_should_stop_before_instruction(uint16_t pc) {
     if (g_state == DEBUGGER_PAUSED) return true;
 
-    if (g_skip_breakpoint_once && g_skip_breakpoint_address == pc) {
+    if (g_skip_breakpoint_once) {
+        bool skip = g_skip_breakpoint_address == pc;
         g_skip_breakpoint_once = false;
-        return false;
+        refresh_fast_flags();
+        if (skip) return false;
     }
 
     if (!has_breakpoint(pc)) return false;
@@ -79,7 +97,7 @@ bool debugger_after_instruction(uint16_t pc) {
 }
 
 bool debugger_replace_breakpoints(const uint16_t *addresses, int count) {
-    if (count < 0 || count > 0x10000 || (count > 0 && addresses == 0)) {
+    if (count < 0 || count > 0x10000 || (count > 0 && addresses == nullptr)) {
         return false;
     }
 
@@ -95,6 +113,7 @@ bool debugger_replace_breakpoints(const uint16_t *addresses, int count) {
         }
     }
     g_sequence++;
+    refresh_fast_flags();
     return true;
 }
 
@@ -106,6 +125,7 @@ void debugger_on_machine_reset(uint16_t pc) {
         ? DEBUGGER_STOP_MANUAL
         : DEBUGGER_STOP_NONE;
     g_sequence++;
+    refresh_fast_flags();
 }
 
 DebuggerStatus debugger_get_status() {

--- a/platform/debugger_core.cpp
+++ b/platform/debugger_core.cpp
@@ -1,0 +1,119 @@
+#include "debugger_core.h"
+
+#include <string.h>
+
+static uint8_t g_breakpoints[0x10000 / 8];
+static uint32_t g_breakpoint_count = 0;
+static uint32_t g_sequence = 0;
+static DebuggerRunState g_state = DEBUGGER_RUNNING;
+static DebuggerStopReason g_stop_reason = DEBUGGER_STOP_NONE;
+static uint16_t g_stop_address = 0;
+static bool g_step_requested = false;
+static bool g_skip_breakpoint_once = false;
+static uint16_t g_skip_breakpoint_address = 0;
+
+static bool has_breakpoint(uint16_t address) {
+    return (g_breakpoints[address >> 3] & (uint8_t)(1u << (address & 7))) != 0;
+}
+
+static void set_paused(DebuggerStopReason reason, uint16_t address) {
+    g_state = DEBUGGER_PAUSED;
+    g_stop_reason = reason;
+    g_stop_address = address;
+    g_step_requested = false;
+    g_sequence++;
+}
+
+bool debugger_is_paused() {
+    return g_state == DEBUGGER_PAUSED;
+}
+
+void debugger_pause(uint16_t pc) {
+    if (g_state == DEBUGGER_PAUSED) return;
+    g_skip_breakpoint_once = false;
+    set_paused(DEBUGGER_STOP_MANUAL, pc);
+}
+
+void debugger_resume(uint16_t pc) {
+    if (g_state == DEBUGGER_RUNNING) return;
+    g_skip_breakpoint_once =
+        g_stop_reason == DEBUGGER_STOP_BREAKPOINT && g_stop_address == pc;
+    g_skip_breakpoint_address = pc;
+    g_step_requested = false;
+    g_state = DEBUGGER_RUNNING;
+    g_stop_reason = DEBUGGER_STOP_NONE;
+    g_stop_address = pc;
+    g_sequence++;
+}
+
+bool debugger_begin_step(uint16_t pc) {
+    if (g_state != DEBUGGER_PAUSED) return false;
+    g_skip_breakpoint_once = true;
+    g_skip_breakpoint_address = pc;
+    g_step_requested = true;
+    g_state = DEBUGGER_RUNNING;
+    g_stop_reason = DEBUGGER_STOP_NONE;
+    g_stop_address = pc;
+    g_sequence++;
+    return true;
+}
+
+bool debugger_should_stop_before_instruction(uint16_t pc) {
+    if (g_state == DEBUGGER_PAUSED) return true;
+
+    if (g_skip_breakpoint_once && g_skip_breakpoint_address == pc) {
+        g_skip_breakpoint_once = false;
+        return false;
+    }
+
+    if (!has_breakpoint(pc)) return false;
+    set_paused(DEBUGGER_STOP_BREAKPOINT, pc);
+    return true;
+}
+
+bool debugger_after_instruction(uint16_t pc) {
+    if (!g_step_requested) return false;
+    g_skip_breakpoint_once = false;
+    set_paused(DEBUGGER_STOP_STEP, pc);
+    return true;
+}
+
+bool debugger_replace_breakpoints(const uint16_t *addresses, int count) {
+    if (count < 0 || count > 0x10000 || (count > 0 && addresses == 0)) {
+        return false;
+    }
+
+    memset(g_breakpoints, 0, sizeof(g_breakpoints));
+    g_breakpoint_count = 0;
+    for (int i = 0; i < count; i++) {
+        uint16_t address = addresses[i];
+        uint8_t mask = (uint8_t)(1u << (address & 7));
+        uint8_t *entry = &g_breakpoints[address >> 3];
+        if ((*entry & mask) == 0) {
+            *entry |= mask;
+            g_breakpoint_count++;
+        }
+    }
+    g_sequence++;
+    return true;
+}
+
+void debugger_on_machine_reset(uint16_t pc) {
+    g_step_requested = false;
+    g_skip_breakpoint_once = false;
+    g_stop_address = pc;
+    g_stop_reason = (g_state == DEBUGGER_PAUSED)
+        ? DEBUGGER_STOP_MANUAL
+        : DEBUGGER_STOP_NONE;
+    g_sequence++;
+}
+
+DebuggerStatus debugger_get_status() {
+    DebuggerStatus status;
+    status.sequence = g_sequence;
+    status.state = g_state;
+    status.stop_reason = g_stop_reason;
+    status.stop_address = g_stop_address;
+    status.breakpoint_count = g_breakpoint_count;
+    return status;
+}

--- a/platform/debugger_core.h
+++ b/platform/debugger_core.h
@@ -1,0 +1,101 @@
+#ifndef XMIL_DEBUGGER_CORE_H
+#define XMIL_DEBUGGER_CORE_H
+
+#include <stdint.h>
+
+enum DebuggerRunState {
+    DEBUGGER_RUNNING = 0,
+    DEBUGGER_PAUSED = 1
+};
+
+enum DebuggerStopReason {
+    DEBUGGER_STOP_NONE = 0,
+    DEBUGGER_STOP_MANUAL = 1,
+    DEBUGGER_STOP_BREAKPOINT = 2,
+    DEBUGGER_STOP_STEP = 3
+};
+
+enum DebuggerMemoryMapping {
+    DEBUGGER_MEMORY_MAIN = 0,
+    DEBUGGER_MEMORY_BIOS = 1,
+    DEBUGGER_MEMORY_BANK = 2
+};
+
+enum DebuggerStateWord {
+    DEBUGGER_STATE_VERSION = 0,
+    DEBUGGER_STATE_WORD_COUNT,
+    DEBUGGER_STATE_SEQUENCE,
+    DEBUGGER_STATE_RUN_STATE,
+    DEBUGGER_STATE_STOP_REASON,
+    DEBUGGER_STATE_STOP_ADDRESS,
+    DEBUGGER_STATE_BREAKPOINT_COUNT,
+    DEBUGGER_STATE_EMULATOR_RUNNING,
+    DEBUGGER_STATE_AF,
+    DEBUGGER_STATE_BC,
+    DEBUGGER_STATE_DE,
+    DEBUGGER_STATE_HL,
+    DEBUGGER_STATE_IX,
+    DEBUGGER_STATE_IY,
+    DEBUGGER_STATE_PC,
+    DEBUGGER_STATE_SP,
+    DEBUGGER_STATE_AF2,
+    DEBUGGER_STATE_BC2,
+    DEBUGGER_STATE_DE2,
+    DEBUGGER_STATE_HL2,
+    DEBUGGER_STATE_I,
+    DEBUGGER_STATE_R,
+    DEBUGGER_STATE_IM,
+    DEBUGGER_STATE_IFF1,
+    DEBUGGER_STATE_IFF2,
+    DEBUGGER_STATE_CYCLES,
+    DEBUGGER_STATE_LOW_MEMORY_MAPPING,
+    DEBUGGER_STATE_LOW_MEMORY_BANK,
+    DEBUGGER_STATE_ROM_TYPE,
+    DEBUGGER_STATE_ROM_SWITCH,
+    DEBUGGER_STATE_LASTMEM,
+    DEBUGGER_STATE_WORDS
+};
+
+struct Z80DebugRegisters {
+    uint16_t af;
+    uint16_t bc;
+    uint16_t de;
+    uint16_t hl;
+    uint16_t ix;
+    uint16_t iy;
+    uint16_t pc;
+    uint16_t sp;
+    uint16_t af2;
+    uint16_t bc2;
+    uint16_t de2;
+    uint16_t hl2;
+    uint8_t i;
+    uint8_t r;
+    uint8_t im;
+    uint8_t iff1;
+    uint8_t iff2;
+    uint32_t cycles;
+};
+
+struct DebuggerStatus {
+    uint32_t sequence;
+    DebuggerRunState state;
+    DebuggerStopReason stop_reason;
+    uint16_t stop_address;
+    uint32_t breakpoint_count;
+};
+
+bool debugger_is_paused();
+void debugger_pause(uint16_t pc);
+void debugger_resume(uint16_t pc);
+bool debugger_begin_step(uint16_t pc);
+bool debugger_should_stop_before_instruction(uint16_t pc);
+bool debugger_after_instruction(uint16_t pc);
+bool debugger_replace_breakpoints(const uint16_t *addresses, int count);
+void debugger_on_machine_reset(uint16_t pc);
+DebuggerStatus debugger_get_status();
+
+uint16_t z80w_get_pc();
+void z80w_get_debug_registers(Z80DebugRegisters *registers);
+
+#endif

--- a/platform/debugger_core.h
+++ b/platform/debugger_core.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+// C++-only debugger core interface. JavaScript calls the js_debug_* wrappers
+// exported from platform_main.cpp rather than these functions directly.
+
 enum DebuggerRunState {
     DEBUGGER_RUNNING = 0,
     DEBUGGER_PAUSED = 1
@@ -56,26 +59,10 @@ enum DebuggerStateWord {
     DEBUGGER_STATE_WORDS
 };
 
-struct Z80DebugRegisters {
-    uint16_t af;
-    uint16_t bc;
-    uint16_t de;
-    uint16_t hl;
-    uint16_t ix;
-    uint16_t iy;
-    uint16_t pc;
-    uint16_t sp;
-    uint16_t af2;
-    uint16_t bc2;
-    uint16_t de2;
-    uint16_t hl2;
-    uint8_t i;
-    uint8_t r;
-    uint8_t im;
-    uint8_t iff1;
-    uint8_t iff2;
-    uint32_t cycles;
-};
+// DEBUGGER_STATE_SEQUENCE changes on control/configuration transitions as well
+// as stops. Consumers must compare RUN_STATE and STOP_REASON when detecting a
+// new stop. CYCLES wraps modulo 2^32. LOW_MEMORY_BANK is UINT32_MAX unless
+// LOW_MEMORY_MAPPING is BANK.
 
 struct DebuggerStatus {
     uint32_t sequence;
@@ -84,6 +71,23 @@ struct DebuggerStatus {
     uint16_t stop_address;
     uint32_t breakpoint_count;
 };
+
+enum DebuggerFastFlag {
+    DEBUGGER_FAST_BEFORE_INSTRUCTION = 1,
+    DEBUGGER_FAST_AFTER_INSTRUCTION = 2
+};
+
+// Read-only outside debugger_core.cpp. These inline checks keep the normal CPU
+// hot path to one load and branch while no debugger operation is armed.
+extern uint8_t debugger_fast_flags;
+
+static inline bool debugger_before_instruction_armed() {
+    return (debugger_fast_flags & DEBUGGER_FAST_BEFORE_INSTRUCTION) != 0;
+}
+
+static inline bool debugger_after_instruction_armed() {
+    return (debugger_fast_flags & DEBUGGER_FAST_AFTER_INSTRUCTION) != 0;
+}
 
 bool debugger_is_paused();
 void debugger_pause(uint16_t pc);
@@ -94,8 +98,5 @@ bool debugger_after_instruction(uint16_t pc);
 bool debugger_replace_breakpoints(const uint16_t *addresses, int count);
 void debugger_on_machine_reset(uint16_t pc);
 DebuggerStatus debugger_get_status();
-
-uint16_t z80w_get_pc();
-void z80w_get_debug_registers(Z80DebugRegisters *registers);
 
 #endif

--- a/platform/platform_audio.cpp
+++ b/platform/platform_audio.cpp
@@ -141,6 +141,10 @@ void Platform_Audio_Pause(BOOL pause) {
     g_audio.playing = !pause;
 }
 
+BOOL Platform_Audio_IsPlaying(void) {
+    return g_audio.playing;
+}
+
 void Platform_Audio_SetVolume(int volume) {
     // Web Audio APIでボリューム制御
     EM_ASM({

--- a/platform/platform_audio.h
+++ b/platform/platform_audio.h
@@ -19,6 +19,7 @@ void Platform_Audio_UnlockBuffer(int bytes_written);
 void Platform_Audio_Play(void);
 void Platform_Audio_Stop(void);
 void Platform_Audio_Pause(BOOL pause);
+BOOL Platform_Audio_IsPlaying(void);
 
 // ボリューム制御（0-100）
 void Platform_Audio_SetVolume(int volume);

--- a/platform/platform_main.cpp
+++ b/platform/platform_main.cpp
@@ -27,6 +27,9 @@
 #include "X1_SASI.H"
 #include "FDD_D88.H"
 #include "FDD_2D.H"
+#include "debugger_core.h"
+
+BYTE __fastcall Z80_RDMEM(WORD adrs);
 
 // web_sound.cpp で定義されているサウンドパラメータ (dsounds.h より)
 extern WORD  ds_rate;
@@ -94,7 +97,7 @@ static double g_audio_acc      = 0.0;  // サンプル端数の蓄積
 
 // メインループのコールバック（Emscriptenから毎フレーム呼ばれる）
 void main_loop() {
-    if (!g_running) {
+    if (!g_running || debugger_is_paused()) {
         return;
     }
 
@@ -124,6 +127,11 @@ void main_loop() {
     mouse_callback();
 
     x1r_exec();
+
+    if (debugger_is_paused()) {
+        Platform_Audio_Stop();
+        return;
+    }
 
     // AudioWorklet へのバッチ転送（SPN フォールバック時は xmilFlushAudio が未定義で no-op）
     EM_ASM({ if (window.xmilFlushAudio) window.xmilFlushAudio(); });
@@ -179,7 +187,7 @@ void xmil_term() {
 void xmil_start() {
     if (g_running) return;
     g_running = TRUE;
-    Platform_Audio_Play();
+    if (!debugger_is_paused()) Platform_Audio_Play();
 }
 
 // エミュレータの停止
@@ -471,7 +479,12 @@ int js_emm_take_dirty_slots(void) {
 
 EMSCRIPTEN_KEEPALIVE
 int js_load_state(const BYTE *data, int size) {
-    return load_full_state(data, size);
+    int result = load_full_state(data, size);
+    if (result >= 0) {
+        x1r_reset_frame_execution();
+        debugger_on_machine_reset(z80w_get_pc());
+    }
+    return result;
 }
 
 EMSCRIPTEN_KEEPALIVE
@@ -482,6 +495,100 @@ const char* js_get_load_warnings(void) {
 EMSCRIPTEN_KEEPALIVE
 BYTE* js_get_main_ram(void) {
     return mMAIN;
+}
+
+// ---- Z80 debugger core ----
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_pause(void) {
+    debugger_pause(z80w_get_pc());
+    if (g_running) Platform_Audio_Stop();
+    return 1;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_resume(void) {
+    debugger_resume(z80w_get_pc());
+    if (g_running) Platform_Audio_Play();
+    return 1;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_step(void) {
+    if (!debugger_begin_step(z80w_get_pc())) return 0;
+    Platform_Audio_Stop();
+    x1r_exec();
+    return debugger_is_paused() ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_replace_breakpoints(const uint16_t *addresses, int count) {
+    return debugger_replace_breakpoints(addresses, count) ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_read_memory(int address, BYTE *output, int length) {
+    if (!output || address < 0 || length <= 0 || length > 4096 ||
+        address > 0x10000 - length) {
+        return -1;
+    }
+
+    for (int i = 0; i < length; i++) {
+        output[i] = Z80_RDMEM((WORD)(address + i));
+    }
+    return length;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int js_debug_get_state(uint32_t *output, int word_capacity) {
+    if (!output) return -1;
+    if (word_capacity < DEBUGGER_STATE_WORDS) return -DEBUGGER_STATE_WORDS;
+
+    DebuggerStatus status = debugger_get_status();
+    Z80DebugRegisters registers;
+    z80w_get_debug_registers(&registers);
+
+    int mapping = DEBUGGER_MEMORY_MAIN;
+    int bank = -1;
+    if (x1flg.ROM_TYPE >= 2 && !(lastmem & 0x10)) {
+        mapping = DEBUGGER_MEMORY_BANK;
+        bank = lastmem & 15;
+    } else if (x1flg.ROM_SW) {
+        mapping = DEBUGGER_MEMORY_BIOS;
+    }
+
+    output[DEBUGGER_STATE_VERSION] = 1;
+    output[DEBUGGER_STATE_WORD_COUNT] = DEBUGGER_STATE_WORDS;
+    output[DEBUGGER_STATE_SEQUENCE] = status.sequence;
+    output[DEBUGGER_STATE_RUN_STATE] = status.state;
+    output[DEBUGGER_STATE_STOP_REASON] = status.stop_reason;
+    output[DEBUGGER_STATE_STOP_ADDRESS] = status.stop_address;
+    output[DEBUGGER_STATE_BREAKPOINT_COUNT] = status.breakpoint_count;
+    output[DEBUGGER_STATE_EMULATOR_RUNNING] = g_running ? 1 : 0;
+    output[DEBUGGER_STATE_AF] = registers.af;
+    output[DEBUGGER_STATE_BC] = registers.bc;
+    output[DEBUGGER_STATE_DE] = registers.de;
+    output[DEBUGGER_STATE_HL] = registers.hl;
+    output[DEBUGGER_STATE_IX] = registers.ix;
+    output[DEBUGGER_STATE_IY] = registers.iy;
+    output[DEBUGGER_STATE_PC] = registers.pc;
+    output[DEBUGGER_STATE_SP] = registers.sp;
+    output[DEBUGGER_STATE_AF2] = registers.af2;
+    output[DEBUGGER_STATE_BC2] = registers.bc2;
+    output[DEBUGGER_STATE_DE2] = registers.de2;
+    output[DEBUGGER_STATE_HL2] = registers.hl2;
+    output[DEBUGGER_STATE_I] = registers.i;
+    output[DEBUGGER_STATE_R] = registers.r;
+    output[DEBUGGER_STATE_IM] = registers.im;
+    output[DEBUGGER_STATE_IFF1] = registers.iff1;
+    output[DEBUGGER_STATE_IFF2] = registers.iff2;
+    output[DEBUGGER_STATE_CYCLES] = registers.cycles;
+    output[DEBUGGER_STATE_LOW_MEMORY_MAPPING] = mapping;
+    output[DEBUGGER_STATE_LOW_MEMORY_BANK] = (uint32_t)bank;
+    output[DEBUGGER_STATE_ROM_TYPE] = x1flg.ROM_TYPE;
+    output[DEBUGGER_STATE_ROM_SWITCH] = x1flg.ROM_SW;
+    output[DEBUGGER_STATE_LASTMEM] = lastmem;
+    return DEBUGGER_STATE_WORDS;
 }
 
 #ifdef __cplusplus

--- a/platform/platform_main.cpp
+++ b/platform/platform_main.cpp
@@ -28,6 +28,7 @@
 #include "FDD_D88.H"
 #include "FDD_2D.H"
 #include "debugger_core.h"
+#include "z80_debug.h"
 
 BYTE __fastcall Z80_RDMEM(WORD adrs);
 
@@ -539,6 +540,9 @@ int js_debug_read_memory(int address, BYTE *output, int length) {
     return length;
 }
 
+// Fixed uint32_t ABI described by DebuggerStateWord. Returns the word count on
+// success, -1 for a null output pointer, or -DEBUGGER_STATE_WORDS when the
+// supplied capacity is too small.
 EMSCRIPTEN_KEEPALIVE
 int js_debug_get_state(uint32_t *output, int word_capacity) {
     if (!output) return -1;

--- a/platform/web_sound.cpp
+++ b/platform/web_sound.cpp
@@ -15,6 +15,7 @@
 #include "x1.h"
 #include "dsounds.h"
 #include "opm.h"
+#include "platform_audio.h"
 
 //----------------------------------------------------------------------------
 // PCM グローバル変数 (DSOUNDS.CPP の代替)
@@ -103,6 +104,10 @@ static void web_ds_streammakes(DWORD N) {
     INX1F_resetsamplepos();               // pcmmakepos を 0 にリセット
     memset(pcmbuffer, 0, N * PCMMUL);    // OPM/PSG は加算なのでゼロクリア必須
     INX1F_makesample(N);                  // pcmbuffer[0..N*4-1] に INT16 ステレオ書き込み
+
+    // Single-step still advances sound-chip state, but paused audio must not
+    // accumulate stale PCM that would be played after debugger resume.
+    if (!Platform_Audio_IsPlaying()) return;
 
     // JS リングバッファに INT16 ステレオデータを書き込む
     // オーバーフロー保護: 書き込み可能なスペースを超えた分は破棄する

--- a/platform/z80_debug.h
+++ b/platform/z80_debug.h
@@ -1,0 +1,30 @@
+#ifndef XMIL_Z80_DEBUG_H
+#define XMIL_Z80_DEBUG_H
+
+#include <stdint.h>
+
+struct Z80DebugRegisters {
+    uint16_t af;
+    uint16_t bc;
+    uint16_t de;
+    uint16_t hl;
+    uint16_t ix;
+    uint16_t iy;
+    uint16_t pc;
+    uint16_t sp;
+    uint16_t af2;
+    uint16_t bc2;
+    uint16_t de2;
+    uint16_t hl2;
+    uint8_t i;
+    uint8_t r;
+    uint8_t im;
+    uint8_t iff1;
+    uint8_t iff2;
+    uint32_t cycles; // Wraps modulo 2^32.
+};
+
+uint16_t z80w_get_pc();
+void z80w_get_debug_registers(Z80DebugRegisters *registers);
+
+#endif

--- a/platform/z80_wrapper.cpp
+++ b/platform/z80_wrapper.cpp
@@ -15,6 +15,7 @@
 #include "X1_DMA.H"
 #include "X1_DMAM.H"
 #include "x1_irq.h"
+#include "debugger_core.h"
 
 // X1 memory and I/O functions (will be linked from X1 code)
 BYTE __fastcall Z80_RDMEM(WORD adrs);
@@ -30,6 +31,14 @@ extern unsigned short BreakICount;
 static z80_t g_cpu;
 static uint64_t g_pins = 0;
 static int g_cycles = 0;
+
+// chips overlaps the next M1 fetch with completion of the previous opcode.
+// At z80_opdone(), g_cpu.pc already points past the opcode being fetched, while
+// the address pins identify the instruction a debugger must display and match.
+static inline uint16_t current_instruction_address() {
+    if (z80_opdone(&g_cpu)) return (uint16_t)Z80_GET_ADDR(g_pins);
+    return g_cpu.pc;
+}
 
 
 // Z80 registers structure (for compatibility with original code)
@@ -198,6 +207,10 @@ void Z80_Execute(void) {
     // chips z80.h samples INT at instruction boundaries and enters IORQ+M1
     // when IFF1 is set. Vector fetch happens in handle_tick() at that time.
     do {
+        if (debugger_should_stop_before_instruction(current_instruction_address())) {
+            sync_registers_from_chips();
+            return;
+        }
         if ((dma.DMA_CMND & 3) && dma.DMA_ENBL) {
             x1_dma();
         }
@@ -209,9 +222,40 @@ void Z80_Execute(void) {
         } while (!z80_opdone(&g_cpu));
         add_z80_icount((WORD)inst_cycles);
         g_cycles += inst_cycles;
+        if (debugger_after_instruction(current_instruction_address())) {
+            sync_registers_from_chips();
+            return;
+        }
     } while (Z80_ICount < BreakICount);
 
     sync_registers_from_chips();
+}
+
+uint16_t z80w_get_pc() {
+    return current_instruction_address();
+}
+
+void z80w_get_debug_registers(Z80DebugRegisters *registers) {
+    if (!registers) return;
+
+    registers->af = (uint16_t)((g_cpu.a << 8) | g_cpu.f);
+    registers->bc = (uint16_t)((g_cpu.b << 8) | g_cpu.c);
+    registers->de = (uint16_t)((g_cpu.d << 8) | g_cpu.e);
+    registers->hl = (uint16_t)((g_cpu.h << 8) | g_cpu.l);
+    registers->ix = g_cpu.ix;
+    registers->iy = g_cpu.iy;
+    registers->pc = current_instruction_address();
+    registers->sp = g_cpu.sp;
+    registers->af2 = g_cpu.af2;
+    registers->bc2 = g_cpu.bc2;
+    registers->de2 = g_cpu.de2;
+    registers->hl2 = g_cpu.hl2;
+    registers->i = g_cpu.i;
+    registers->r = g_cpu.r;
+    registers->im = g_cpu.im;
+    registers->iff1 = g_cpu.iff1 ? 1 : 0;
+    registers->iff2 = g_cpu.iff2 ? 1 : 0;
+    registers->cycles = (uint32_t)g_cycles;
 }
 
 // Execute one Z80 instruction (T_TUNE mode)

--- a/platform/z80_wrapper.cpp
+++ b/platform/z80_wrapper.cpp
@@ -16,6 +16,7 @@
 #include "X1_DMAM.H"
 #include "x1_irq.h"
 #include "debugger_core.h"
+#include "z80_debug.h"
 
 // X1 memory and I/O functions (will be linked from X1 code)
 BYTE __fastcall Z80_RDMEM(WORD adrs);
@@ -30,7 +31,9 @@ extern unsigned short BreakICount;
 // Z80 CPU state
 static z80_t g_cpu;
 static uint64_t g_pins = 0;
-static int g_cycles = 0;
+// Exposed debugger cycle counter. Unsigned overflow intentionally wraps modulo
+// 2^32, preserving the existing four-byte save-state field.
+static uint32_t g_cycles = 0;
 
 // chips overlaps the next M1 fetch with completion of the previous opcode.
 // At z80_opdone(), g_cpu.pc already points past the opcode being fetched, while
@@ -207,7 +210,8 @@ void Z80_Execute(void) {
     // chips z80.h samples INT at instruction boundaries and enters IORQ+M1
     // when IFF1 is set. Vector fetch happens in handle_tick() at that time.
     do {
-        if (debugger_should_stop_before_instruction(current_instruction_address())) {
+        if (debugger_before_instruction_armed() &&
+            debugger_should_stop_before_instruction(current_instruction_address())) {
             sync_registers_from_chips();
             return;
         }
@@ -222,7 +226,8 @@ void Z80_Execute(void) {
         } while (!z80_opdone(&g_cpu));
         add_z80_icount((WORD)inst_cycles);
         g_cycles += inst_cycles;
-        if (debugger_after_instruction(current_instruction_address())) {
+        if (debugger_after_instruction_armed() &&
+            debugger_after_instruction(current_instruction_address())) {
             sync_registers_from_chips();
             return;
         }
@@ -255,11 +260,16 @@ void z80w_get_debug_registers(Z80DebugRegisters *registers) {
     registers->im = g_cpu.im;
     registers->iff1 = g_cpu.iff1 ? 1 : 0;
     registers->iff2 = g_cpu.iff2 ? 1 : 0;
-    registers->cycles = (uint32_t)g_cycles;
+    registers->cycles = g_cycles;
 }
 
 // Execute one Z80 instruction (T_TUNE mode)
 void Z80_ExecuteOne(void) {
+    if (debugger_before_instruction_armed() &&
+        debugger_should_stop_before_instruction(current_instruction_address())) {
+        sync_registers_from_chips();
+        return;
+    }
     int inst_cycles = 0;
     do {
         g_pins = z80_tick(&g_cpu, g_pins);
@@ -270,6 +280,9 @@ void Z80_ExecuteOne(void) {
     g_cycles += inst_cycles;
     // Match original T_TUNE path: execute DMA service after one instruction.
     x1_dma();
+    if (debugger_after_instruction_armed()) {
+        debugger_after_instruction(current_instruction_address());
+    }
     sync_registers_from_chips();
 }
 
@@ -350,7 +363,7 @@ int z80w_save_state(BYTE *buf, int maxlen) {
 
     // wrapper globals
     SS_WRITE_U64(buf, pos, g_pins);
-    SS_WRITE_I32(buf, pos, g_cycles);
+    SS_WRITE_U32(buf, pos, g_cycles);
     SS_WRITE_U16(buf, pos, Z80_ICount);
 
     return pos;
@@ -399,7 +412,7 @@ int z80w_load_state(const BYTE *buf, int len) {
 
     // wrapper globals
     SS_READ_U64(buf, pos, g_pins);
-    SS_READ_I32(buf, pos, g_cycles);
+    SS_READ_U32(buf, pos, g_cycles);
     SS_READ_U16(buf, pos, Z80_ICount);
 
     // sync the compatibility R struct from restored chips state

--- a/src/X1.H
+++ b/src/X1.H
@@ -67,6 +67,9 @@ void x1r_init(void);
 void x1r_term(void);
 
 void x1r_exec(void);
+#if T_TUNE
+void x1r_reset_frame_execution(void);
+#endif
 
 X1_IOR x1_dipsw_r(WORD port);
 
@@ -94,4 +97,3 @@ void makecaption(BYTE flg, WORKCLOCK_T *workclock);
 
 #define	DIP_RESOLUTE	1
 #define	DIP_BOOTMEDIA	4
-

--- a/src/X1.cpp
+++ b/src/X1.cpp
@@ -38,6 +38,7 @@
 #include	"fdd_mtr.h"
 #include	"state_save.h"
 #include	"debugger_core.h"
+#include	"z80_debug.h"
 #endif
 
 	X1_FLAG		x1flg = {250, 0, 1, 1, 0};
@@ -774,7 +775,6 @@ int x1_save_state(BYTE *buf, int maxlen)
 int x1_load_state(const BYTE *buf, int len)
 {
 	int pos = 0;
-	frame_active = 0;
 
 	/* scalar statics */
 	SS_READ_U16(buf, pos, v_cnt);

--- a/src/X1.cpp
+++ b/src/X1.cpp
@@ -37,6 +37,7 @@
 #include	"drawinfo.h"
 #include	"fdd_mtr.h"
 #include	"state_save.h"
+#include	"debugger_core.h"
 #endif
 
 	X1_FLAG		x1flg = {250, 0, 1, 1, 0};
@@ -66,6 +67,7 @@ static void x1_V_SYNC_event_callback(int param);
 	static EVENT	DISP_event = EVENT_VALUE("DISPLAY",0,NULL,0);
 	EV_TIME		H_SYNC_interval;
 	static BYTE V_SYNC_done; /* V-BLANK FOUND FLAG */
+	static BYTE frame_active;
 
 static void x1_1msec_event(int param);
 	static EVENT scpu_event = EVENT_VALUE("subCPU,SIO",TIME_IN_MSEC(1),x1_1msec_event,0);
@@ -256,6 +258,8 @@ BYTE reset_x1(BYTE ROM_TYPE, BYTE SOUND_SW, BYTE DIP_SW) {
 
 	Z80_Reset();
 #if T_TUNE
+	debugger_on_machine_reset(z80w_get_pc());
+	x1r_reset_frame_execution();
 	/* setup event timers */
 	event_init(1);
 	event_setup_cpu(0,4000000L,&Z80_ICount);
@@ -377,52 +381,62 @@ void x1r_init(void) {
 
 
 #if T_TUNE
+void x1r_reset_frame_execution(void) {
+	frame_active = 0;
+}
+
 void x1r_exec(void) {
 
 extern	BYTE	disp_flashscreen;
 
-	TRACE_START();
+	if (!frame_active) {
+		TRACE_START();
 
-	/* set CPU speed */
-	event_setup_cpu(0, 1000000L * xmilcfg.CPU8MHz,&Z80_ICount);
+		/* set CPU speed */
+		event_setup_cpu(0, 1000000L * xmilcfg.CPU8MHz,&Z80_ICount);
 
-	xmilcfg.DISPSYNC &= 1;
+		xmilcfg.DISPSYNC &= 1;
 
-	if(xmilcfg.DISPSYNC ==1)
-	{
-		/* set display update event */
-		if(disp_flashscreen)
-		{	/* V-BLANK */
-			DISP_event.callback = x1_DISP_callback;
-			DISP_event.interval = 0;
-			event_set(&DISP_event, H_SYNC_interval*crtc.CRT_YL);
-			v_cnt = crtc.CRT_YL;
+		if(xmilcfg.DISPSYNC ==1)
+		{
+			/* set display update event */
+			if(disp_flashscreen)
+			{	/* V-BLANK */
+				DISP_event.callback = x1_DISP_callback;
+				DISP_event.interval = 0;
+				event_set(&DISP_event, H_SYNC_interval*crtc.CRT_YL);
+				v_cnt = crtc.CRT_YL;
+			}
+			else
+			{	/* H-SYNC */
+				DISP_event.callback = x1_DISP_raster_callback;
+				DISP_event.interval = H_SYNC_interval;
+				event_set(&DISP_event ,H_SYNC_interval);
+				v_cnt = 0;
+			}
 		}
 		else
-		{	/* H-SYNC */
-			DISP_event.callback = x1_DISP_raster_callback;
-			DISP_event.interval = H_SYNC_interval;
-			event_set(&DISP_event ,H_SYNC_interval);
-			v_cnt = 0;
+		{	/* V-SYNC */
+			DISP_event.callback = x1_DISP_callback;
+			DISP_event.interval = 0;
+			event_set(&DISP_event, event_timeleft(&V_SYNC_event));
+			v_cnt = 266;
 		}
-	}
-	else
-	{	/* V-SYNC */
-		DISP_event.callback = x1_DISP_callback;
-		DISP_event.interval = 0;
-		event_set(&DISP_event, event_timeleft(&V_SYNC_event));
-		v_cnt = 266;
+
+		V_SYNC_done = 0;
+		frame_active = 1;
 	}
 
-	/* execute */
-	V_SYNC_done = 0;
-	do
+	/* Execute until V-SYNC or a debugger stop. event_update() must run even
+	 * on a stop so the scheduler commits the completed instruction cycles. */
+	while(!V_SYNC_done)
 	{
 		/* run for next event */
 		Z80_Execute();
 		/* event update */
 		event_update();
-	}while(!V_SYNC_done);
+		if (debugger_is_paused() && !V_SYNC_done) return;
+	}
 
 	// if display update was not done , finish here
 	if(event_enabled(&DISP_event))
@@ -433,6 +447,7 @@ extern	BYTE	disp_flashscreen;
 
 	/* sound update of this frame */
 	x1_sound_update_frame();
+	frame_active = 0;
 
 	if (++flame >= 60) {
 		flame = 0;
@@ -759,6 +774,7 @@ int x1_save_state(BYTE *buf, int maxlen)
 int x1_load_state(const BYTE *buf, int len)
 {
 	int pos = 0;
+	frame_active = 0;
 
 	/* scalar statics */
 	SS_READ_U16(buf, pos, v_cnt);

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -15,6 +15,24 @@ const mimeTypes = {
   '.json': 'application/json; charset=utf-8',
   '.wasm': 'application/wasm',
 };
+const DBG = Object.freeze({
+  VERSION: 0,
+  WORD_COUNT: 1,
+  SEQUENCE: 2,
+  RUN_STATE: 3,
+  STOP_REASON: 4,
+  STOP_ADDRESS: 5,
+  BREAKPOINT_COUNT: 6,
+  EMULATOR_RUNNING: 7,
+  AF: 8,
+  PC: 14,
+  CYCLES: 25,
+  LOW_MEMORY_MAPPING: 26,
+  LOW_MEMORY_BANK: 27,
+  WORDS: 31,
+});
+const DBG_STATE = Object.freeze({ RUNNING: 0, PAUSED: 1 });
+const DBG_STOP = Object.freeze({ NONE: 0, MANUAL: 1, BREAKPOINT: 2, STEP: 3 });
 
 let server;
 let browser;
@@ -52,6 +70,40 @@ async function launchChromium() {
     if (process.platform !== 'darwin') throw error;
     return chromium.launch({ channel: 'chrome', headless: true });
   }
+}
+
+async function readDebuggerState() {
+  return page.evaluate((words) => {
+    const module = window.Module;
+    const ptr = module._malloc(words * 4);
+    try {
+      return {
+        result: module._js_debug_get_state(ptr, words),
+        state: Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, words)),
+      };
+    } finally {
+      module._free(ptr);
+    }
+  }, DBG.WORDS);
+}
+
+async function waitForDebuggerStop(reason, address, minimumSequence = 0, previousCycles = null) {
+  await page.waitForFunction(({ dbg, reason: expectedReason, address: expectedAddress,
+    minimumSequence: minSequence, previousCycles: oldCycles }) => {
+    const module = window.Module;
+    const ptr = module._malloc(dbg.WORDS * 4);
+    try {
+      if (module._js_debug_get_state(ptr, dbg.WORDS) !== dbg.WORDS) return false;
+      const state = new Uint32Array(module.wasmMemory.buffer, ptr, dbg.WORDS);
+      return state[dbg.RUN_STATE] === 1 &&
+        state[dbg.STOP_REASON] === expectedReason &&
+        state[dbg.PC] === expectedAddress &&
+        state[dbg.SEQUENCE] > minSequence &&
+        (oldCycles === null || state[dbg.CYCLES] !== oldCycles);
+    } finally {
+      module._free(ptr);
+    }
+  }, { dbg: DBG, reason, address, minimumSequence, previousCycles });
 }
 
 before(async () => {
@@ -227,24 +279,10 @@ test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 
     }
   }, { address: programAddress, bytes: expectedBytes });
 
-  const breakpointAddress = await page.evaluate(() => {
-    const module = window.Module;
-    module._js_debug_pause();
-    const statePtr = module._malloc(31 * 4);
-    try {
-      module._js_debug_get_state(statePtr, 31);
-      return new Uint32Array(module.wasmMemory.buffer, statePtr, 31)[14];
-    } finally {
-      module._free(statePtr);
-    }
-  });
-  assert.ok(
-    breakpointAddress >= programAddress && breakpointAddress <= programAddress + 2,
-    `program counter should be in the test loop, got ${breakpointAddress.toString(16)}h`,
-  );
-
+  const sequenceBeforeBreakpoint = (await readDebuggerState()).state[DBG.SEQUENCE];
   await page.evaluate((address) => {
     const module = window.Module;
+    module._js_debug_pause();
     const ptr = module._malloc(2);
     try {
       new Uint16Array(module.wasmMemory.buffer, ptr, 1)[0] = address;
@@ -255,31 +293,19 @@ test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 
       module._free(ptr);
     }
     module._js_debug_resume();
-  }, breakpointAddress);
+  }, programAddress);
+  await waitForDebuggerStop(DBG_STOP.BREAKPOINT, programAddress, sequenceBeforeBreakpoint);
 
-  await page.waitForFunction((address) => {
+  const stopped = await page.evaluate(({ address, length, words }) => {
     const module = window.Module;
-    const ptr = module._malloc(31 * 4);
-    try {
-      const result = module._js_debug_get_state(ptr, 31);
-      if (result !== 31) return false;
-      const state = new Uint32Array(module.wasmMemory.buffer, ptr, 31);
-      return state[3] === 1 && state[4] === 2 && state[14] === address;
-    } finally {
-      module._free(ptr);
-    }
-  }, breakpointAddress);
-
-  const stopped = await page.evaluate(({ address, length }) => {
-    const module = window.Module;
-    const statePtr = module._malloc(31 * 4);
+    const statePtr = module._malloc(words * 4);
     const memoryPtr = module._malloc(length);
     try {
-      const stateResult = module._js_debug_get_state(statePtr, 31);
+      const stateResult = module._js_debug_get_state(statePtr, words);
       const memoryResult = module._js_debug_read_memory(address, memoryPtr, length);
       return {
         stateResult,
-        state: Array.from(new Uint32Array(module.wasmMemory.buffer, statePtr, 31)),
+        state: Array.from(new Uint32Array(module.wasmMemory.buffer, statePtr, words)),
         memoryResult,
         memory: Array.from(new Uint8Array(module.wasmMemory.buffer, memoryPtr, length)),
         invalidRead: module._js_debug_read_memory(0xFFFF, memoryPtr, 2),
@@ -288,75 +314,51 @@ test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 
       module._free(memoryPtr);
       module._free(statePtr);
     }
-  }, { address: programAddress, length: expectedBytes.length });
+  }, { address: programAddress, length: expectedBytes.length, words: DBG.WORDS });
 
-  assert.equal(stopped.stateResult, 31);
-  assert.equal(stopped.state[0], 1, 'debug state ABI version');
-  assert.equal(stopped.state[3], 1, 'paused');
-  assert.equal(stopped.state[4], 2, 'breakpoint stop');
-  assert.equal(stopped.state[5], breakpointAddress);
-  assert.equal(stopped.state[6], 1);
-  assert.equal(stopped.state[14], breakpointAddress);
+  assert.equal(stopped.stateResult, DBG.WORDS);
+  assert.equal(stopped.state[DBG.VERSION], 1, 'debug state ABI version');
+  assert.equal(stopped.state[DBG.WORD_COUNT], DBG.WORDS);
+  assert.equal(stopped.state[DBG.RUN_STATE], DBG_STATE.PAUSED);
+  assert.equal(stopped.state[DBG.STOP_REASON], DBG_STOP.BREAKPOINT);
+  assert.equal(stopped.state[DBG.STOP_ADDRESS], programAddress);
+  assert.equal(stopped.state[DBG.BREAKPOINT_COUNT], 1);
+  assert.equal(stopped.state[DBG.PC], programAddress);
   assert.deepEqual(stopped.memory, expectedBytes);
   assert.equal(stopped.memoryResult, expectedBytes.length);
   assert.equal(stopped.invalidRead, -1);
-  const accumulatorBeforeFirst = stopped.state[8] >>> 8;
+  const accumulatorBeforeFirst = stopped.state[DBG.AF] >>> 8;
 
   const afterFirstStep = await page.evaluate(() => {
     const module = window.Module;
     if (module._js_debug_step() !== 1) throw new Error('step failed');
-    const ptr = module._malloc(31 * 4);
-    try {
-      module._js_debug_get_state(ptr, 31);
-      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
-    } finally {
-      module._free(ptr);
-    }
+    return 1;
   });
-  assert.equal(afterFirstStep[4], 3, 'single-step stop');
-  const expectedAfterFirst = breakpointAddress === programAddress + 2
-    ? programAddress
-    : breakpointAddress + 1;
-  assert.equal(afterFirstStep[14], expectedAfterFirst);
-  const accumulatorAfterFirst = afterFirstStep[8] >>> 8;
-  assert.equal(
-    accumulatorAfterFirst,
-    (accumulatorBeforeFirst + Number(breakpointAddress === programAddress + 1)) & 0xFF,
-  );
+  assert.equal(afterFirstStep, 1);
+  const firstState = (await readDebuggerState()).state;
+  assert.equal(firstState[DBG.STOP_REASON], DBG_STOP.STEP);
+  assert.equal(firstState[DBG.PC], programAddress + 1);
+  assert.equal(firstState[DBG.AF] >>> 8, accumulatorBeforeFirst);
 
-  const afterSecondStep = await page.evaluate(() => {
-    const module = window.Module;
-    module._js_debug_step();
-    const ptr = module._malloc(31 * 4);
-    try {
-      module._js_debug_get_state(ptr, 31);
-      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
-    } finally {
-      module._free(ptr);
-    }
-  });
-  const expectedAfterSecond = expectedAfterFirst === programAddress + 2
-    ? programAddress
-    : expectedAfterFirst + 1;
-  assert.equal(afterSecondStep[14], expectedAfterSecond);
-  assert.equal(
-    afterSecondStep[8] >>> 8,
-    (accumulatorAfterFirst + Number(expectedAfterFirst === programAddress + 1)) & 0xFF,
-  );
+  assert.equal(await page.evaluate(() => window.Module._js_debug_step()), 1);
+  const secondState = (await readDebuggerState()).state;
+  assert.equal(secondState[DBG.PC], programAddress + 2);
+  assert.equal(secondState[DBG.AF] >>> 8, (accumulatorBeforeFirst + 1) & 0xFF);
 
-  const sequenceBeforeResume = afterSecondStep[2];
+  assert.equal(await page.evaluate(() => window.Module._js_debug_step()), 1);
+  const landedOnBreakpoint = (await readDebuggerState()).state;
+  assert.equal(landedOnBreakpoint[DBG.STOP_REASON], DBG_STOP.STEP);
+  assert.equal(landedOnBreakpoint[DBG.PC], programAddress);
+
+  const sequenceBeforeResume = landedOnBreakpoint[DBG.SEQUENCE];
+  const cyclesBeforeResume = landedOnBreakpoint[DBG.CYCLES];
   await page.evaluate(() => window.Module._js_debug_resume());
-  await page.waitForFunction(({ address, sequence }) => {
-    const module = window.Module;
-    const ptr = module._malloc(31 * 4);
-    try {
-      module._js_debug_get_state(ptr, 31);
-      const state = new Uint32Array(module.wasmMemory.buffer, ptr, 31);
-      return state[2] > sequence && state[4] === 2 && state[14] === address;
-    } finally {
-      module._free(ptr);
-    }
-  }, { address: breakpointAddress, sequence: sequenceBeforeResume });
+  await waitForDebuggerStop(
+    DBG_STOP.BREAKPOINT,
+    programAddress,
+    sequenceBeforeResume,
+    cyclesBeforeResume,
+  );
 
   const manualStop = await page.evaluate(async () => {
     const module = window.Module;
@@ -364,17 +366,13 @@ test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 
     module._js_debug_resume();
     await new Promise((resolve) => setTimeout(resolve, 30));
     module._js_debug_pause();
-    const ptr = module._malloc(31 * 4);
-    try {
-      module._js_debug_get_state(ptr, 31);
-      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
-    } finally {
-      module._free(ptr);
-    }
+    return true;
   });
-  assert.equal(manualStop[3], 1);
-  assert.equal(manualStop[4], 1);
-  assert.equal(manualStop[6], 0);
+  assert.equal(manualStop, true);
+  const manualState = (await readDebuggerState()).state;
+  assert.equal(manualState[DBG.RUN_STATE], DBG_STATE.PAUSED);
+  assert.equal(manualState[DBG.STOP_REASON], DBG_STOP.MANUAL);
+  assert.equal(manualState[DBG.BREAKPOINT_COUNT], 0);
 
   await page.evaluate(() => window.Module._js_debug_resume());
 });

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -196,3 +196,185 @@ test('automation validation and capture return structured results', async () => 
   assert.equal(png.readUInt32BE(16), 640);
   assert.equal(png.readUInt32BE(20), 400);
 });
+
+test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 60_000 }, async () => {
+  const programAddress = 0x0100;
+  const expectedBytes = [0x00, 0x3C, 0xC3, 0x00, 0x01]; // NOP; INC A; JP 0100h
+
+  const initial = await page.evaluate(async () => {
+    const module = window.Module;
+    if (module._js_debug_replace_breakpoints(0, 0) !== 1) {
+      throw new Error('failed to clear breakpoints');
+    }
+
+    await window.X1PenAutomation.setProgram({
+      sourceMode: 'asm',
+      asm: 'ORG 0100h\nNOP\nINC A\nJP 0100h',
+    });
+    return window.X1PenAutomation.run();
+  });
+  assert.equal(initial.ok, true);
+
+  await page.waitForFunction(({ address, bytes }) => {
+    const module = window.Module;
+    const ptr = module._malloc(bytes.length);
+    try {
+      if (module._js_debug_read_memory(address, ptr, bytes.length) !== bytes.length) return false;
+      const memory = new Uint8Array(module.wasmMemory.buffer, ptr, bytes.length);
+      return bytes.every((value, index) => memory[index] === value);
+    } finally {
+      module._free(ptr);
+    }
+  }, { address: programAddress, bytes: expectedBytes });
+
+  const breakpointAddress = await page.evaluate(() => {
+    const module = window.Module;
+    module._js_debug_pause();
+    const statePtr = module._malloc(31 * 4);
+    try {
+      module._js_debug_get_state(statePtr, 31);
+      return new Uint32Array(module.wasmMemory.buffer, statePtr, 31)[14];
+    } finally {
+      module._free(statePtr);
+    }
+  });
+  assert.ok(
+    breakpointAddress >= programAddress && breakpointAddress <= programAddress + 2,
+    `program counter should be in the test loop, got ${breakpointAddress.toString(16)}h`,
+  );
+
+  await page.evaluate((address) => {
+    const module = window.Module;
+    const ptr = module._malloc(2);
+    try {
+      new Uint16Array(module.wasmMemory.buffer, ptr, 1)[0] = address;
+      if (module._js_debug_replace_breakpoints(ptr, 1) !== 1) {
+        throw new Error('failed to set breakpoint');
+      }
+    } finally {
+      module._free(ptr);
+    }
+    module._js_debug_resume();
+  }, breakpointAddress);
+
+  await page.waitForFunction((address) => {
+    const module = window.Module;
+    const ptr = module._malloc(31 * 4);
+    try {
+      const result = module._js_debug_get_state(ptr, 31);
+      if (result !== 31) return false;
+      const state = new Uint32Array(module.wasmMemory.buffer, ptr, 31);
+      return state[3] === 1 && state[4] === 2 && state[14] === address;
+    } finally {
+      module._free(ptr);
+    }
+  }, breakpointAddress);
+
+  const stopped = await page.evaluate(({ address, length }) => {
+    const module = window.Module;
+    const statePtr = module._malloc(31 * 4);
+    const memoryPtr = module._malloc(length);
+    try {
+      const stateResult = module._js_debug_get_state(statePtr, 31);
+      const memoryResult = module._js_debug_read_memory(address, memoryPtr, length);
+      return {
+        stateResult,
+        state: Array.from(new Uint32Array(module.wasmMemory.buffer, statePtr, 31)),
+        memoryResult,
+        memory: Array.from(new Uint8Array(module.wasmMemory.buffer, memoryPtr, length)),
+        invalidRead: module._js_debug_read_memory(0xFFFF, memoryPtr, 2),
+      };
+    } finally {
+      module._free(memoryPtr);
+      module._free(statePtr);
+    }
+  }, { address: programAddress, length: expectedBytes.length });
+
+  assert.equal(stopped.stateResult, 31);
+  assert.equal(stopped.state[0], 1, 'debug state ABI version');
+  assert.equal(stopped.state[3], 1, 'paused');
+  assert.equal(stopped.state[4], 2, 'breakpoint stop');
+  assert.equal(stopped.state[5], breakpointAddress);
+  assert.equal(stopped.state[6], 1);
+  assert.equal(stopped.state[14], breakpointAddress);
+  assert.deepEqual(stopped.memory, expectedBytes);
+  assert.equal(stopped.memoryResult, expectedBytes.length);
+  assert.equal(stopped.invalidRead, -1);
+  const accumulatorBeforeFirst = stopped.state[8] >>> 8;
+
+  const afterFirstStep = await page.evaluate(() => {
+    const module = window.Module;
+    if (module._js_debug_step() !== 1) throw new Error('step failed');
+    const ptr = module._malloc(31 * 4);
+    try {
+      module._js_debug_get_state(ptr, 31);
+      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
+    } finally {
+      module._free(ptr);
+    }
+  });
+  assert.equal(afterFirstStep[4], 3, 'single-step stop');
+  const expectedAfterFirst = breakpointAddress === programAddress + 2
+    ? programAddress
+    : breakpointAddress + 1;
+  assert.equal(afterFirstStep[14], expectedAfterFirst);
+  const accumulatorAfterFirst = afterFirstStep[8] >>> 8;
+  assert.equal(
+    accumulatorAfterFirst,
+    (accumulatorBeforeFirst + Number(breakpointAddress === programAddress + 1)) & 0xFF,
+  );
+
+  const afterSecondStep = await page.evaluate(() => {
+    const module = window.Module;
+    module._js_debug_step();
+    const ptr = module._malloc(31 * 4);
+    try {
+      module._js_debug_get_state(ptr, 31);
+      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
+    } finally {
+      module._free(ptr);
+    }
+  });
+  const expectedAfterSecond = expectedAfterFirst === programAddress + 2
+    ? programAddress
+    : expectedAfterFirst + 1;
+  assert.equal(afterSecondStep[14], expectedAfterSecond);
+  assert.equal(
+    afterSecondStep[8] >>> 8,
+    (accumulatorAfterFirst + Number(expectedAfterFirst === programAddress + 1)) & 0xFF,
+  );
+
+  const sequenceBeforeResume = afterSecondStep[2];
+  await page.evaluate(() => window.Module._js_debug_resume());
+  await page.waitForFunction(({ address, sequence }) => {
+    const module = window.Module;
+    const ptr = module._malloc(31 * 4);
+    try {
+      module._js_debug_get_state(ptr, 31);
+      const state = new Uint32Array(module.wasmMemory.buffer, ptr, 31);
+      return state[2] > sequence && state[4] === 2 && state[14] === address;
+    } finally {
+      module._free(ptr);
+    }
+  }, { address: breakpointAddress, sequence: sequenceBeforeResume });
+
+  const manualStop = await page.evaluate(async () => {
+    const module = window.Module;
+    module._js_debug_replace_breakpoints(0, 0);
+    module._js_debug_resume();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    module._js_debug_pause();
+    const ptr = module._malloc(31 * 4);
+    try {
+      module._js_debug_get_state(ptr, 31);
+      return Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, 31));
+    } finally {
+      module._free(ptr);
+    }
+  });
+  assert.equal(manualStop[3], 1);
+  assert.equal(manualStop[4], 1);
+  assert.equal(manualStop[6], 0);
+
+  await page.evaluate(() => window.Module._js_debug_resume());
+});


### PR DESCRIPTION
## Summary
- add machine-level pause, resume, single-step, and logical-address breakpoints
- expose fixed-layout register/state and CPU-visible mapped-memory WASM APIs
- preserve scheduler state when execution stops in the middle of a frame
- account for the chips Z80 overlapped M1 fetch when reporting and matching PC
- add an X1Pen browser integration test covering break, step, resume, register state, and mapped memory

## Scope
This PR provides the debugger core only. UI, MCP bridge tools, disassembly, watchpoints, register/memory mutation, tracing, and SLANG source maps are intentionally deferred. Debugger state is not added to emulator save-state data.

## Verification
- `./build.sh`
- `npm run test:automation` (6/6 passed)