### PR TITLE
Add X1Pen debugger browser adapter

### DIFF
--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -903,6 +903,9 @@ window.__X1PEN_MODE = true;
         }
 
         // 9. モード別のエミュレータ開始
+        // A previous debugger session may have left the machine paused. A new
+        // Run always starts execution while preserving configured breakpoints.
+        if (module._js_debug_resume) module._js_debug_resume();
         if (isLsxMode) {
             // LSX-Dodgers モード: コマンドプロンプトから PROG を実行
             console.log('[x1pen] starting emulator (LSX-Dodgers mode)');
@@ -1231,6 +1234,276 @@ window.__X1PEN_MODE = true;
         };
     }
 
+    var DEBUGGER_STATE_WORD = Object.freeze({
+        VERSION: 0,
+        WORD_COUNT: 1,
+        SEQUENCE: 2,
+        RUN_STATE: 3,
+        STOP_REASON: 4,
+        STOP_ADDRESS: 5,
+        BREAKPOINT_COUNT: 6,
+        EMULATOR_RUNNING: 7,
+        AF: 8,
+        BC: 9,
+        DE: 10,
+        HL: 11,
+        IX: 12,
+        IY: 13,
+        PC: 14,
+        SP: 15,
+        AF2: 16,
+        BC2: 17,
+        DE2: 18,
+        HL2: 19,
+        I: 20,
+        R: 21,
+        IM: 22,
+        IFF1: 23,
+        IFF2: 24,
+        CYCLES: 25,
+        LOW_MEMORY_MAPPING: 26,
+        LOW_MEMORY_BANK: 27,
+        ROM_TYPE: 28,
+        ROM_SWITCH: 29,
+        LASTMEM: 30,
+        WORDS: 31
+    });
+    var DEBUGGER_RUN_STATE_NAMES = ['running', 'paused'];
+    var DEBUGGER_STOP_REASON_NAMES = ['none', 'manual', 'breakpoint', 'step'];
+    var DEBUGGER_MEMORY_MAPPING_NAMES = ['main', 'bios', 'bank'];
+    var DEBUGGER_MAX_READ_LENGTH = 4096;
+
+    function requireDebuggerModule() {
+        if (!module || !module._js_debug_get_state || !module.wasmMemory) {
+            throw new Error('X1Pen debugger is not ready');
+        }
+        return module;
+    }
+
+    function debuggerEnumName(names, value) {
+        return names[value] === undefined ? 'unknown' : names[value];
+    }
+
+    function decodeDebuggerPair(value, highName, lowName, target) {
+        target[highName] = (value >>> 8) & 0xFF;
+        target[lowName] = value & 0xFF;
+    }
+
+    function decodeDebuggerState(state) {
+        var word = DEBUGGER_STATE_WORD;
+        var registers = {
+            af: state[word.AF],
+            bc: state[word.BC],
+            de: state[word.DE],
+            hl: state[word.HL],
+            ix: state[word.IX],
+            iy: state[word.IY],
+            pc: state[word.PC],
+            sp: state[word.SP],
+            af2: state[word.AF2],
+            bc2: state[word.BC2],
+            de2: state[word.DE2],
+            hl2: state[word.HL2],
+            i: state[word.I],
+            r: state[word.R],
+            im: state[word.IM],
+            iff1: state[word.IFF1] !== 0,
+            iff2: state[word.IFF2] !== 0
+        };
+        decodeDebuggerPair(registers.af, 'a', 'f', registers);
+        decodeDebuggerPair(registers.bc, 'b', 'c', registers);
+        decodeDebuggerPair(registers.de, 'd', 'e', registers);
+        decodeDebuggerPair(registers.hl, 'h', 'l', registers);
+        decodeDebuggerPair(registers.af2, 'a2', 'f2', registers);
+        decodeDebuggerPair(registers.bc2, 'b2', 'c2', registers);
+        decodeDebuggerPair(registers.de2, 'd2', 'e2', registers);
+        decodeDebuggerPair(registers.hl2, 'h2', 'l2', registers);
+
+        var mappingCode = state[word.LOW_MEMORY_MAPPING];
+        return {
+            version: state[word.VERSION],
+            sequence: state[word.SEQUENCE],
+            runState: debuggerEnumName(DEBUGGER_RUN_STATE_NAMES, state[word.RUN_STATE]),
+            runStateCode: state[word.RUN_STATE],
+            stopReason: debuggerEnumName(DEBUGGER_STOP_REASON_NAMES, state[word.STOP_REASON]),
+            stopReasonCode: state[word.STOP_REASON],
+            stopAddress: state[word.STOP_ADDRESS],
+            breakpointCount: state[word.BREAKPOINT_COUNT],
+            emulatorRunning: state[word.EMULATOR_RUNNING] !== 0,
+            registers: registers,
+            cycles: state[word.CYCLES],
+            memory: {
+                lowMapping: debuggerEnumName(DEBUGGER_MEMORY_MAPPING_NAMES, mappingCode),
+                lowMappingCode: mappingCode,
+                lowBank: mappingCode === 2 ? state[word.LOW_MEMORY_BANK] : null,
+                romType: state[word.ROM_TYPE],
+                romSwitch: state[word.ROM_SWITCH] !== 0,
+                lastmem: state[word.LASTMEM]
+            }
+        };
+    }
+
+    function getAutomationDebuggerState() {
+        var debuggerModule = requireDebuggerModule();
+        var wordCount = DEBUGGER_STATE_WORD.WORDS;
+        var ptr = debuggerModule._malloc(wordCount * 4);
+        if (!ptr) throw new Error('Failed to allocate debugger state buffer');
+        try {
+            var result = debuggerModule._js_debug_get_state(ptr, wordCount);
+            if (result !== wordCount) {
+                throw new Error('Unsupported debugger state ABI: ' + result);
+            }
+            var raw = Array.from(new Uint32Array(debuggerModule.wasmMemory.buffer, ptr, wordCount));
+            if (raw[DEBUGGER_STATE_WORD.VERSION] !== 1 ||
+                raw[DEBUGGER_STATE_WORD.WORD_COUNT] !== wordCount) {
+                throw new Error('Unsupported debugger state version: ' + raw[DEBUGGER_STATE_WORD.VERSION]);
+            }
+            return decodeDebuggerState(raw);
+        } finally {
+            debuggerModule._free(ptr);
+        }
+    }
+
+    function callAutomationDebuggerControl(exportName, operation) {
+        var debuggerModule = requireDebuggerModule();
+        if (!debuggerModule[exportName] || debuggerModule[exportName]() !== 1) {
+            throw new Error('Debugger ' + operation + ' failed');
+        }
+        return getAutomationDebuggerState();
+    }
+
+    function normalizeDebuggerAddress(value, name) {
+        if (!Number.isInteger(value) || value < 0 || value > 0xFFFF) {
+            throw new TypeError((name || 'address') + ' must be an integer from 0 to 65535');
+        }
+        return value;
+    }
+
+    function setAutomationDebuggerBreakpoints(addresses) {
+        if (!Array.isArray(addresses)) throw new TypeError('addresses must be an array');
+        var normalized = [];
+        var seen = new Set();
+        for (var i = 0; i < addresses.length; i++) {
+            var address = normalizeDebuggerAddress(addresses[i], 'addresses[' + i + ']');
+            if (!seen.has(address)) {
+                seen.add(address);
+                normalized.push(address);
+            }
+        }
+        normalized.sort(function(left, right) { return left - right; });
+
+        var debuggerModule = requireDebuggerModule();
+        var ptr = 0;
+        try {
+            if (normalized.length > 0) {
+                ptr = debuggerModule._malloc(normalized.length * 2);
+                if (!ptr) throw new Error('Failed to allocate debugger breakpoint buffer');
+                new Uint16Array(debuggerModule.wasmMemory.buffer, ptr, normalized.length).set(normalized);
+            }
+            if (!debuggerModule._js_debug_replace_breakpoints ||
+                debuggerModule._js_debug_replace_breakpoints(ptr, normalized.length) !== 1) {
+                throw new Error('Failed to replace debugger breakpoints');
+            }
+        } finally {
+            if (ptr) debuggerModule._free(ptr);
+        }
+        return getAutomationDebuggerState();
+    }
+
+    function readAutomationDebuggerMemory(address, length) {
+        address = normalizeDebuggerAddress(address);
+        if (!Number.isInteger(length) || length < 1 || length > DEBUGGER_MAX_READ_LENGTH) {
+            throw new TypeError('length must be an integer from 1 to ' + DEBUGGER_MAX_READ_LENGTH);
+        }
+        if (address + length > 0x10000) throw new RangeError('memory range exceeds 65535');
+
+        var debuggerModule = requireDebuggerModule();
+        var ptr = debuggerModule._malloc(length);
+        if (!ptr) throw new Error('Failed to allocate debugger memory buffer');
+        try {
+            var result = debuggerModule._js_debug_read_memory(address, ptr, length);
+            if (result !== length) throw new Error('Debugger memory read failed: ' + result);
+            return {
+                address: address,
+                length: length,
+                bytes: Array.from(new Uint8Array(debuggerModule.wasmMemory.buffer, ptr, length))
+            };
+        } finally {
+            debuggerModule._free(ptr);
+        }
+    }
+
+    function waitForAutomationDebuggerPause(options) {
+        options = options || {};
+        if (typeof options !== 'object' || Array.isArray(options)) {
+            throw new TypeError('options must be an object');
+        }
+        var hasAfterSequence = options.afterSequence !== undefined;
+        if (hasAfterSequence && (!Number.isInteger(options.afterSequence) ||
+            options.afterSequence < 0 || options.afterSequence > 0xFFFFFFFF)) {
+            throw new TypeError('afterSequence must be an unsigned 32-bit integer');
+        }
+        if (options.stopReason !== undefined &&
+            DEBUGGER_STOP_REASON_NAMES.indexOf(options.stopReason) < 0) {
+            throw new TypeError('stopReason must be none, manual, breakpoint or step');
+        }
+        if (options.address !== undefined) normalizeDebuggerAddress(options.address);
+        var timeoutMs = options.timeoutMs === undefined ? 5000 : options.timeoutMs;
+        var pollIntervalMs = options.pollIntervalMs === undefined ? 16 : options.pollIntervalMs;
+        if (!Number.isFinite(timeoutMs) || timeoutMs < 0 || timeoutMs > 60000) {
+            throw new TypeError('timeoutMs must be from 0 to 60000');
+        }
+        if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 1 || pollIntervalMs > 1000) {
+            throw new TypeError('pollIntervalMs must be from 1 to 1000');
+        }
+
+        var matches = function(state) {
+            return state.runState === 'paused' &&
+                (!hasAfterSequence || state.sequence !== options.afterSequence) &&
+                (options.stopReason === undefined || state.stopReason === options.stopReason) &&
+                (options.address === undefined || state.stopAddress === options.address);
+        };
+        var deadline = Date.now() + timeoutMs;
+        return new Promise(function(resolve, reject) {
+            var poll = function() {
+                var state;
+                try {
+                    state = getAutomationDebuggerState();
+                } catch(e) {
+                    reject(e);
+                    return;
+                }
+                if (matches(state)) {
+                    resolve(state);
+                    return;
+                }
+                if (Date.now() >= deadline) {
+                    reject(new Error('Timed out waiting for debugger pause'));
+                    return;
+                }
+                setTimeout(poll, pollIntervalMs);
+            };
+            poll();
+        });
+    }
+
+    var automationDebuggerApi = Object.freeze({
+        version: 1,
+        getState: getAutomationDebuggerState,
+        pause: function() {
+            return callAutomationDebuggerControl('_js_debug_pause', 'pause');
+        },
+        resume: function() {
+            return callAutomationDebuggerControl('_js_debug_resume', 'resume');
+        },
+        step: function() {
+            return callAutomationDebuggerControl('_js_debug_step', 'step');
+        },
+        setBreakpoints: setAutomationDebuggerBreakpoints,
+        readMemory: readAutomationDebuggerMemory,
+        waitForPause: waitForAutomationDebuggerPause
+    });
+
     function getAutomationStatus() {
         var sourceMode = inferSourceMode(
             basicEditor ? basicEditor.getValue().trim() : '',
@@ -1255,6 +1528,13 @@ window.__X1PEN_MODE = true;
             status: elStatus ? elStatus.textContent : '',
             sourceMode: sourceMode,
             activeLanguageProfile: activeLanguageProfile,
+            capabilities: {
+                debugger: {
+                    version: automationDebuggerApi.version,
+                    addressSpaceSize: 0x10000,
+                    maxReadLength: DEBUGGER_MAX_READ_LENGTH
+                }
+            },
             languageProfiles: {
                 fuzzybasic: {
                     id: 'x1pen-fuzzybasic-1.2L',
@@ -1366,6 +1646,7 @@ window.__X1PEN_MODE = true;
                 return getAutomationStatus();
             });
         },
+        debugger: automationDebuggerApi,
         getStatus: getAutomationStatus,
         captureScreen: captureAutomationScreen,
         setConnectionState: setAutomationConnectionState,

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -28,6 +28,7 @@ window.__X1PEN_MODE = true;
     automationReadyPromise.catch(function() {});
     var automationOperationQueue = Promise.resolve();
     var automationPendingOperations = 0;
+    var automationPendingRuns = 0;
     var automationRevision = 0;
     var automationConnected = false;
     var automationInteractionLocked = false;
@@ -1273,8 +1274,15 @@ window.__X1PEN_MODE = true;
     var DEBUGGER_MEMORY_MAPPING_NAMES = ['main', 'bios', 'bank'];
     var DEBUGGER_MAX_READ_LENGTH = 4096;
 
+    function isDebuggerModuleAvailable() {
+        return !!(module && module.wasmMemory && module._malloc && module._free &&
+            module._js_debug_get_state && module._js_debug_pause && module._js_debug_resume &&
+            module._js_debug_step && module._js_debug_replace_breakpoints &&
+            module._js_debug_read_memory);
+    }
+
     function requireDebuggerModule() {
-        if (!module || !module._js_debug_get_state || !module.wasmMemory) {
+        if (!isDebuggerModuleAvailable()) {
             throw new Error('X1Pen debugger is not ready');
         }
         return module;
@@ -1320,6 +1328,7 @@ window.__X1PEN_MODE = true;
         decodeDebuggerPair(registers.hl2, 'h2', 'l2', registers);
 
         var mappingCode = state[word.LOW_MEMORY_MAPPING];
+        var mappingName = debuggerEnumName(DEBUGGER_MEMORY_MAPPING_NAMES, mappingCode);
         return {
             version: state[word.VERSION],
             sequence: state[word.SEQUENCE],
@@ -1333,9 +1342,9 @@ window.__X1PEN_MODE = true;
             registers: registers,
             cycles: state[word.CYCLES],
             memory: {
-                lowMapping: debuggerEnumName(DEBUGGER_MEMORY_MAPPING_NAMES, mappingCode),
+                lowMapping: mappingName,
                 lowMappingCode: mappingCode,
-                lowBank: mappingCode === 2 ? state[word.LOW_MEMORY_BANK] : null,
+                lowBank: mappingName === 'bank' ? state[word.LOW_MEMORY_BANK] : null,
                 romType: state[word.ROM_TYPE],
                 romSwitch: state[word.ROM_SWITCH] !== 0,
                 lastmem: state[word.LASTMEM]
@@ -1366,10 +1375,22 @@ window.__X1PEN_MODE = true;
 
     function callAutomationDebuggerControl(exportName, operation) {
         var debuggerModule = requireDebuggerModule();
-        if (!debuggerModule[exportName] || debuggerModule[exportName]() !== 1) {
+        if (operation === 'step' && getAutomationDebuggerState().runState !== 'paused') {
+            throw new Error('Debugger step requires the paused state');
+        }
+        if (debuggerModule[exportName]() !== 1) {
             throw new Error('Debugger ' + operation + ' failed');
         }
         return getAutomationDebuggerState();
+    }
+
+    function runAutomationDebuggerControl(exportName, operation) {
+        return automationReadyPromise.then(function() {
+            if (automationPendingRuns > 0) {
+                throw new Error('Debugger ' + operation + ' is unavailable while run setup is pending');
+            }
+            return callAutomationDebuggerControl(exportName, operation);
+        });
     }
 
     function normalizeDebuggerAddress(value, name) {
@@ -1415,7 +1436,7 @@ window.__X1PEN_MODE = true;
         if (!Number.isInteger(length) || length < 1 || length > DEBUGGER_MAX_READ_LENGTH) {
             throw new TypeError('length must be an integer from 1 to ' + DEBUGGER_MAX_READ_LENGTH);
         }
-        if (address + length > 0x10000) throw new RangeError('memory range exceeds 65535');
+        if (address + length > 0x10000) throw new RangeError('memory range exceeds the 64KB address space');
 
         var debuggerModule = requireDebuggerModule();
         var ptr = debuggerModule._malloc(length);
@@ -1439,6 +1460,8 @@ window.__X1PEN_MODE = true;
             throw new TypeError('options must be an object');
         }
         var hasAfterSequence = options.afterSequence !== undefined;
+        // Pass the sequence returned by resume(), not the sequence from the
+        // preceding stopped state. This distinguishes a later stop transition.
         if (hasAfterSequence && (!Number.isInteger(options.afterSequence) ||
             options.afterSequence < 0 || options.afterSequence > 0xFFFFFFFF)) {
             throw new TypeError('afterSequence must be an unsigned 32-bit integer');
@@ -1463,43 +1486,51 @@ window.__X1PEN_MODE = true;
                 (options.stopReason === undefined || state.stopReason === options.stopReason) &&
                 (options.address === undefined || state.stopAddress === options.address);
         };
-        var deadline = Date.now() + timeoutMs;
-        return new Promise(function(resolve, reject) {
-            var poll = function() {
-                var state;
-                try {
-                    state = getAutomationDebuggerState();
-                } catch(e) {
-                    reject(e);
-                    return;
-                }
-                if (matches(state)) {
-                    resolve(state);
-                    return;
-                }
-                if (Date.now() >= deadline) {
-                    reject(new Error('Timed out waiting for debugger pause'));
-                    return;
-                }
-                setTimeout(poll, pollIntervalMs);
-            };
-            poll();
+        return automationReadyPromise.then(function() {
+            var deadline = Date.now() + timeoutMs;
+            return new Promise(function(resolve, reject) {
+                var poll = function() {
+                    var state;
+                    try {
+                        state = getAutomationDebuggerState();
+                    } catch(e) {
+                        reject(e);
+                        return;
+                    }
+                    if (matches(state)) {
+                        resolve(state);
+                        return;
+                    }
+                    if (Date.now() >= deadline) {
+                        reject(new Error('Timed out waiting for debugger pause'));
+                        return;
+                    }
+                    setTimeout(poll, pollIntervalMs);
+                };
+                poll();
+            });
         });
     }
 
+    // Call X1PenAutomation.ready() before the synchronous observation methods
+    // getState() and readMemory(). Async debugger methods wait for readiness.
     var automationDebuggerApi = Object.freeze({
         version: 1,
         getState: getAutomationDebuggerState,
         pause: function() {
-            return callAutomationDebuggerControl('_js_debug_pause', 'pause');
+            return runAutomationDebuggerControl('_js_debug_pause', 'pause');
         },
         resume: function() {
-            return callAutomationDebuggerControl('_js_debug_resume', 'resume');
+            return runAutomationDebuggerControl('_js_debug_resume', 'resume');
         },
         step: function() {
-            return callAutomationDebuggerControl('_js_debug_step', 'step');
+            return runAutomationDebuggerControl('_js_debug_step', 'step');
         },
-        setBreakpoints: setAutomationDebuggerBreakpoints,
+        setBreakpoints: function(addresses) {
+            return queueAutomationOperation(function() {
+                return setAutomationDebuggerBreakpoints(addresses);
+            });
+        },
         readMemory: readAutomationDebuggerMemory,
         waitForPause: waitForAutomationDebuggerPause
     });
@@ -1530,6 +1561,7 @@ window.__X1PEN_MODE = true;
             activeLanguageProfile: activeLanguageProfile,
             capabilities: {
                 debugger: {
+                    available: isDebuggerModuleAvailable(),
                     version: automationDebuggerApi.version,
                     addressSpaceSize: 0x10000,
                     maxReadLength: DEBUGGER_MAX_READ_LENGTH
@@ -1630,7 +1662,8 @@ window.__X1PEN_MODE = true;
             return queueAutomationOperation(validateAutomationProgram);
         },
         run: function() {
-            return queueAutomationOperation(async function() {
+            automationPendingRuns++;
+            var result = queueAutomationOperation(async function() {
                 var ok = await onRunClick();
                 return {
                     ok: ok,
@@ -1638,6 +1671,13 @@ window.__X1PEN_MODE = true;
                     sourceMode: getAutomationProgram().sourceMode,
                     revision: automationRevision
                 };
+            });
+            return result.then(function(value) {
+                automationPendingRuns--;
+                return value;
+            }, function(error) {
+                automationPendingRuns--;
+                throw error;
             });
         },
         stop: function() {

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -28,7 +28,8 @@ window.__X1PEN_MODE = true;
     automationReadyPromise.catch(function() {});
     var automationOperationQueue = Promise.resolve();
     var automationPendingOperations = 0;
-    var automationPendingRuns = 0;
+    var automationQueuedRuns = 0;
+    var automationActiveRuns = 0;
     var automationRevision = 0;
     var automationConnected = false;
     var automationInteractionLocked = false;
@@ -686,6 +687,15 @@ window.__X1PEN_MODE = true;
     // ── RUN ──
 
     async function onRunClick() {
+        automationActiveRuns++;
+        try {
+            return await performRun();
+        } finally {
+            automationActiveRuns--;
+        }
+    }
+
+    async function performRun() {
         if (!module) return false;
 
         // 0. sourceMode / runMode 判定
@@ -1375,18 +1385,19 @@ window.__X1PEN_MODE = true;
 
     function callAutomationDebuggerControl(exportName, operation) {
         var debuggerModule = requireDebuggerModule();
-        if (operation === 'step' && getAutomationDebuggerState().runState !== 'paused') {
-            throw new Error('Debugger step requires the paused state');
-        }
         if (debuggerModule[exportName]() !== 1) {
             throw new Error('Debugger ' + operation + ' failed');
         }
         return getAutomationDebuggerState();
     }
 
+    function isRunSetupPending() {
+        return automationQueuedRuns > 0 || automationActiveRuns > 0;
+    }
+
     function runAutomationDebuggerControl(exportName, operation) {
         return automationReadyPromise.then(function() {
-            if (automationPendingRuns > 0) {
+            if (isRunSetupPending()) {
                 throw new Error('Debugger ' + operation + ' is unavailable while run setup is pending');
             }
             return callAutomationDebuggerControl(exportName, operation);
@@ -1454,14 +1465,14 @@ window.__X1PEN_MODE = true;
         }
     }
 
+    // afterSequence must be the sequence returned by resume(), not the one
+    // from the preceding stopped state, so it identifies a later stop.
     function waitForAutomationDebuggerPause(options) {
         options = options || {};
         if (typeof options !== 'object' || Array.isArray(options)) {
             throw new TypeError('options must be an object');
         }
         var hasAfterSequence = options.afterSequence !== undefined;
-        // Pass the sequence returned by resume(), not the sequence from the
-        // preceding stopped state. This distinguishes a later stop transition.
         if (hasAfterSequence && (!Number.isInteger(options.afterSequence) ||
             options.afterSequence < 0 || options.afterSequence > 0xFFFFFFFF)) {
             throw new TypeError('afterSequence must be an unsigned 32-bit integer');
@@ -1524,7 +1535,15 @@ window.__X1PEN_MODE = true;
             return runAutomationDebuggerControl('_js_debug_resume', 'resume');
         },
         step: function() {
-            return runAutomationDebuggerControl('_js_debug_step', 'step');
+            return automationReadyPromise.then(function() {
+                if (isRunSetupPending()) {
+                    throw new Error('Debugger step is unavailable while run setup is pending');
+                }
+                if (getAutomationDebuggerState().runState !== 'paused') {
+                    throw new Error('Debugger step requires the paused state');
+                }
+                return callAutomationDebuggerControl('_js_debug_step', 'step');
+            });
         },
         setBreakpoints: function(addresses) {
             return queueAutomationOperation(function() {
@@ -1662,7 +1681,9 @@ window.__X1PEN_MODE = true;
             return queueAutomationOperation(validateAutomationProgram);
         },
         run: function() {
-            automationPendingRuns++;
+            // Reserve the debugger guard before the operation queue advances;
+            // onRunClick separately covers UI, shortcut and Share-triggered runs.
+            automationQueuedRuns++;
             var result = queueAutomationOperation(async function() {
                 var ok = await onRunClick();
                 return {
@@ -1673,10 +1694,10 @@ window.__X1PEN_MODE = true;
                 };
             });
             return result.then(function(value) {
-                automationPendingRuns--;
+                automationQueuedRuns--;
                 return value;
             }, function(error) {
-                automationPendingRuns--;
+                automationQueuedRuns--;
                 throw error;
             });
         },

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -15,25 +15,6 @@ const mimeTypes = {
   '.json': 'application/json; charset=utf-8',
   '.wasm': 'application/wasm',
 };
-const DBG = Object.freeze({
-  VERSION: 0,
-  WORD_COUNT: 1,
-  SEQUENCE: 2,
-  RUN_STATE: 3,
-  STOP_REASON: 4,
-  STOP_ADDRESS: 5,
-  BREAKPOINT_COUNT: 6,
-  EMULATOR_RUNNING: 7,
-  AF: 8,
-  PC: 14,
-  CYCLES: 25,
-  LOW_MEMORY_MAPPING: 26,
-  LOW_MEMORY_BANK: 27,
-  WORDS: 31,
-});
-const DBG_STATE = Object.freeze({ RUNNING: 0, PAUSED: 1 });
-const DBG_STOP = Object.freeze({ NONE: 0, MANUAL: 1, BREAKPOINT: 2, STEP: 3 });
-
 let server;
 let browser;
 let page;
@@ -72,40 +53,6 @@ async function launchChromium() {
   }
 }
 
-async function readDebuggerState() {
-  return page.evaluate((words) => {
-    const module = window.Module;
-    const ptr = module._malloc(words * 4);
-    try {
-      return {
-        result: module._js_debug_get_state(ptr, words),
-        state: Array.from(new Uint32Array(module.wasmMemory.buffer, ptr, words)),
-      };
-    } finally {
-      module._free(ptr);
-    }
-  }, DBG.WORDS);
-}
-
-async function waitForDebuggerStop(reason, address, minimumSequence = 0, previousCycles = null) {
-  await page.waitForFunction(({ dbg, reason: expectedReason, address: expectedAddress,
-    minimumSequence: minSequence, previousCycles: oldCycles }) => {
-    const module = window.Module;
-    const ptr = module._malloc(dbg.WORDS * 4);
-    try {
-      if (module._js_debug_get_state(ptr, dbg.WORDS) !== dbg.WORDS) return false;
-      const state = new Uint32Array(module.wasmMemory.buffer, ptr, dbg.WORDS);
-      return state[dbg.RUN_STATE] === 1 &&
-        state[dbg.STOP_REASON] === expectedReason &&
-        state[dbg.PC] === expectedAddress &&
-        state[dbg.SEQUENCE] > minSequence &&
-        (oldCycles === null || state[dbg.CYCLES] !== oldCycles);
-    } finally {
-      module._free(ptr);
-    }
-  }, { dbg: DBG, reason, address, minimumSequence, previousCycles });
-}
-
 before(async () => {
   assert.ok(existsSync(join(distDir, 'x1pen.html')), 'dist/x1pen.html is missing; run ./build.sh first');
   await startStaticServer();
@@ -124,6 +71,9 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   const ready = await page.evaluate(() => window.X1PenAutomation.ready());
   assert.equal(ready.ready, true);
   assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
+  assert.equal(ready.capabilities.debugger.version, 1);
+  assert.equal(ready.capabilities.debugger.addressSpaceSize, 0x10000);
+  assert.equal(ready.capabilities.debugger.maxReadLength, 4096);
 
   const program = {
     sourceMode: 'basic+asm',
@@ -320,130 +270,127 @@ test('focus loss releases physical keys before automation command injection', { 
   }
 });
 
-test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 60_000 }, async () => {
+test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeout: 60_000 }, async () => {
   const programAddress = 0x0100;
   const expectedBytes = [0x00, 0x3C, 0xC3, 0x00, 0x01]; // NOP; INC A; JP 0100h
 
   const initial = await page.evaluate(async () => {
-    const module = window.Module;
-    if (module._js_debug_replace_breakpoints(0, 0) !== 1) {
-      throw new Error('failed to clear breakpoints');
-    }
-
+    const debuggerApi = window.X1PenAutomation.debugger;
+    debuggerApi.setBreakpoints([]);
     await window.X1PenAutomation.setProgram({
       sourceMode: 'asm',
       asm: 'ORG 0100h\nNOP\nINC A\nJP 0100h',
     });
-    return window.X1PenAutomation.run();
+    return {
+      debuggerVersion: debuggerApi.version,
+      run: await window.X1PenAutomation.run(),
+    };
   });
-  assert.equal(initial.ok, true);
+  assert.equal(initial.debuggerVersion, 1);
+  assert.equal(initial.run.ok, true);
 
   await page.waitForFunction(({ address, bytes }) => {
-    const module = window.Module;
-    const ptr = module._malloc(bytes.length);
-    try {
-      if (module._js_debug_read_memory(address, ptr, bytes.length) !== bytes.length) return false;
-      const memory = new Uint8Array(module.wasmMemory.buffer, ptr, bytes.length);
-      return bytes.every((value, index) => memory[index] === value);
-    } finally {
-      module._free(ptr);
-    }
+    const memory = window.X1PenAutomation.debugger.readMemory(address, bytes.length);
+    return bytes.every((value, index) => memory.bytes[index] === value);
   }, { address: programAddress, bytes: expectedBytes });
 
-  const sequenceBeforeBreakpoint = (await readDebuggerState()).state[DBG.SEQUENCE];
-  await page.evaluate((address) => {
-    const module = window.Module;
-    module._js_debug_pause();
-    const ptr = module._malloc(2);
-    try {
-      new Uint16Array(module.wasmMemory.buffer, ptr, 1)[0] = address;
-      if (module._js_debug_replace_breakpoints(ptr, 1) !== 1) {
-        throw new Error('failed to set breakpoint');
-      }
-    } finally {
-      module._free(ptr);
-    }
-    module._js_debug_resume();
+  const stopped = await page.evaluate(async (address) => {
+    const debuggerApi = window.X1PenAutomation.debugger;
+    debuggerApi.pause();
+    const configured = debuggerApi.setBreakpoints([address, address]);
+    const running = debuggerApi.resume();
+    const state = await debuggerApi.waitForPause({
+      afterSequence: running.sequence,
+      stopReason: 'breakpoint',
+      address,
+      timeoutMs: 5000,
+    });
+    return {
+      configured,
+      state,
+      memory: debuggerApi.readMemory(address, 5),
+    };
   }, programAddress);
-  await waitForDebuggerStop(DBG_STOP.BREAKPOINT, programAddress, sequenceBeforeBreakpoint);
+  assert.equal(stopped.configured.breakpointCount, 1, 'duplicate breakpoints are removed');
+  assert.equal(stopped.state.version, 1);
+  assert.equal(stopped.state.runState, 'paused');
+  assert.equal(stopped.state.runStateCode, 1);
+  assert.equal(stopped.state.stopReason, 'breakpoint');
+  assert.equal(stopped.state.stopReasonCode, 2);
+  assert.equal(stopped.state.stopAddress, programAddress);
+  assert.equal(stopped.state.breakpointCount, 1);
+  assert.equal(stopped.state.registers.pc, programAddress);
+  assert.equal(stopped.state.registers.a, stopped.state.registers.af >>> 8);
+  assert.equal(typeof stopped.state.registers.iff1, 'boolean');
+  assert.ok(['main', 'bios', 'bank'].includes(stopped.state.memory.lowMapping));
+  assert.deepEqual(stopped.memory.bytes, expectedBytes);
+  const accumulatorBeforeFirst = stopped.state.registers.a;
 
-  const stopped = await page.evaluate(({ address, length, words }) => {
-    const module = window.Module;
-    const statePtr = module._malloc(words * 4);
-    const memoryPtr = module._malloc(length);
-    try {
-      const stateResult = module._js_debug_get_state(statePtr, words);
-      const memoryResult = module._js_debug_read_memory(address, memoryPtr, length);
-      return {
-        stateResult,
-        state: Array.from(new Uint32Array(module.wasmMemory.buffer, statePtr, words)),
-        memoryResult,
-        memory: Array.from(new Uint8Array(module.wasmMemory.buffer, memoryPtr, length)),
-        invalidRead: module._js_debug_read_memory(0xFFFF, memoryPtr, 2),
-      };
-    } finally {
-      module._free(memoryPtr);
-      module._free(statePtr);
-    }
-  }, { address: programAddress, length: expectedBytes.length, words: DBG.WORDS });
-
-  assert.equal(stopped.stateResult, DBG.WORDS);
-  assert.equal(stopped.state[DBG.VERSION], 1, 'debug state ABI version');
-  assert.equal(stopped.state[DBG.WORD_COUNT], DBG.WORDS);
-  assert.equal(stopped.state[DBG.RUN_STATE], DBG_STATE.PAUSED);
-  assert.equal(stopped.state[DBG.STOP_REASON], DBG_STOP.BREAKPOINT);
-  assert.equal(stopped.state[DBG.STOP_ADDRESS], programAddress);
-  assert.equal(stopped.state[DBG.BREAKPOINT_COUNT], 1);
-  assert.equal(stopped.state[DBG.PC], programAddress);
-  assert.deepEqual(stopped.memory, expectedBytes);
-  assert.equal(stopped.memoryResult, expectedBytes.length);
-  assert.equal(stopped.invalidRead, -1);
-  const accumulatorBeforeFirst = stopped.state[DBG.AF] >>> 8;
-
-  const afterFirstStep = await page.evaluate(() => {
-    const module = window.Module;
-    if (module._js_debug_step() !== 1) throw new Error('step failed');
-    return 1;
+  const stepped = await page.evaluate(() => {
+    const debuggerApi = window.X1PenAutomation.debugger;
+    return [debuggerApi.step(), debuggerApi.step(), debuggerApi.step()];
   });
-  assert.equal(afterFirstStep, 1);
-  const firstState = (await readDebuggerState()).state;
-  assert.equal(firstState[DBG.STOP_REASON], DBG_STOP.STEP);
-  assert.equal(firstState[DBG.PC], programAddress + 1);
-  assert.equal(firstState[DBG.AF] >>> 8, accumulatorBeforeFirst);
+  assert.equal(stepped[0].stopReason, 'step');
+  assert.equal(stepped[0].registers.pc, programAddress + 1);
+  assert.equal(stepped[0].registers.a, accumulatorBeforeFirst);
+  assert.equal(stepped[1].registers.pc, programAddress + 2);
+  assert.equal(stepped[1].registers.a, (accumulatorBeforeFirst + 1) & 0xFF);
+  assert.equal(stepped[2].stopReason, 'step');
+  assert.equal(stepped[2].registers.pc, programAddress);
 
-  assert.equal(await page.evaluate(() => window.Module._js_debug_step()), 1);
-  const secondState = (await readDebuggerState()).state;
-  assert.equal(secondState[DBG.PC], programAddress + 2);
-  assert.equal(secondState[DBG.AF] >>> 8, (accumulatorBeforeFirst + 1) & 0xFF);
+  const resumedBreakpoint = await page.evaluate(async () => {
+    const debuggerApi = window.X1PenAutomation.debugger;
+    const before = debuggerApi.getState();
+    const running = debuggerApi.resume();
+    const stoppedAgain = await debuggerApi.waitForPause({
+      afterSequence: running.sequence,
+      stopReason: 'breakpoint',
+      address: 0x0100,
+      timeoutMs: 5000,
+    });
+    return { before, stoppedAgain };
+  });
+  assert.notEqual(resumedBreakpoint.stoppedAgain.cycles, resumedBreakpoint.before.cycles);
 
-  assert.equal(await page.evaluate(() => window.Module._js_debug_step()), 1);
-  const landedOnBreakpoint = (await readDebuggerState()).state;
-  assert.equal(landedOnBreakpoint[DBG.STOP_REASON], DBG_STOP.STEP);
-  assert.equal(landedOnBreakpoint[DBG.PC], programAddress);
-
-  const sequenceBeforeResume = landedOnBreakpoint[DBG.SEQUENCE];
-  const cyclesBeforeResume = landedOnBreakpoint[DBG.CYCLES];
-  await page.evaluate(() => window.Module._js_debug_resume());
-  await waitForDebuggerStop(
-    DBG_STOP.BREAKPOINT,
-    programAddress,
-    sequenceBeforeResume,
-    cyclesBeforeResume,
-  );
-
-  const manualStop = await page.evaluate(async () => {
-    const module = window.Module;
-    module._js_debug_replace_breakpoints(0, 0);
-    module._js_debug_resume();
+  const manualState = await page.evaluate(async () => {
+    const debuggerApi = window.X1PenAutomation.debugger;
+    debuggerApi.setBreakpoints([]);
+    debuggerApi.resume();
     await new Promise((resolve) => setTimeout(resolve, 30));
-    module._js_debug_pause();
-    return true;
+    return debuggerApi.pause();
   });
-  assert.equal(manualStop, true);
-  const manualState = (await readDebuggerState()).state;
-  assert.equal(manualState[DBG.RUN_STATE], DBG_STATE.PAUSED);
-  assert.equal(manualState[DBG.STOP_REASON], DBG_STOP.MANUAL);
-  assert.equal(manualState[DBG.BREAKPOINT_COUNT], 0);
+  assert.equal(manualState.runState, 'paused');
+  assert.equal(manualState.stopReason, 'manual');
+  assert.equal(manualState.breakpointCount, 0);
 
-  await page.evaluate(() => window.Module._js_debug_resume());
+  const validationErrors = await page.evaluate(async () => {
+    const debuggerApi = window.X1PenAutomation.debugger;
+    const errors = [];
+    for (const operation of [
+      () => debuggerApi.readMemory(0xFFFF, 2),
+      () => debuggerApi.setBreakpoints([-1]),
+      () => debuggerApi.waitForPause({ address: 0xFFFF, timeoutMs: 0 }),
+    ]) {
+      try {
+        await operation();
+        errors.push(null);
+      } catch (error) {
+        errors.push(error.message);
+      }
+    }
+    return errors;
+  });
+  assert.match(validationErrors[0], /range exceeds/);
+  assert.match(validationErrors[1], /0 to 65535/);
+  assert.match(validationErrors[2], /Timed out/);
+
+  const rerun = await page.evaluate(async () => {
+    const api = window.X1PenAutomation;
+    const before = api.debugger.getState();
+    const result = await api.run();
+    return { before, result, after: api.debugger.getState() };
+  });
+  assert.equal(rerun.before.runState, 'paused');
+  assert.equal(rerun.result.ok, true);
+  assert.equal(rerun.after.runState, 'running', 'Run must resume a paused debugger session');
 });

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -71,9 +71,22 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   const ready = await page.evaluate(() => window.X1PenAutomation.ready());
   assert.equal(ready.ready, true);
   assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
+  assert.equal(ready.capabilities.debugger.available, true);
   assert.equal(ready.capabilities.debugger.version, 1);
   assert.equal(ready.capabilities.debugger.addressSpaceSize, 0x10000);
   assert.equal(ready.capabilities.debugger.maxReadLength, 4096);
+
+  const unavailableCapability = await page.evaluate(() => {
+    const module = window.Module;
+    const saved = module._js_debug_step;
+    module._js_debug_step = null;
+    try {
+      return window.X1PenAutomation.getStatus().capabilities.debugger.available;
+    } finally {
+      module._js_debug_step = saved;
+    }
+  });
+  assert.equal(unavailableCapability, false);
 
   const program = {
     sourceMode: 'basic+asm',
@@ -276,7 +289,7 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
 
   const initial = await page.evaluate(async () => {
     const debuggerApi = window.X1PenAutomation.debugger;
-    debuggerApi.setBreakpoints([]);
+    await debuggerApi.setBreakpoints([]);
     await window.X1PenAutomation.setProgram({
       sourceMode: 'asm',
       asm: 'ORG 0100h\nNOP\nINC A\nJP 0100h',
@@ -290,15 +303,19 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.equal(initial.run.ok, true);
 
   await page.waitForFunction(({ address, bytes }) => {
-    const memory = window.X1PenAutomation.debugger.readMemory(address, bytes.length);
-    return bytes.every((value, index) => memory.bytes[index] === value);
+    try {
+      const memory = window.X1PenAutomation.debugger.readMemory(address, bytes.length);
+      return bytes.every((value, index) => memory.bytes[index] === value);
+    } catch {
+      return false;
+    }
   }, { address: programAddress, bytes: expectedBytes });
 
   const stopped = await page.evaluate(async (address) => {
     const debuggerApi = window.X1PenAutomation.debugger;
-    debuggerApi.pause();
-    const configured = debuggerApi.setBreakpoints([address, address]);
-    const running = debuggerApi.resume();
+    await debuggerApi.pause();
+    const configured = await debuggerApi.setBreakpoints([address, address]);
+    const running = await debuggerApi.resume();
     const state = await debuggerApi.waitForPause({
       afterSequence: running.sequence,
       stopReason: 'breakpoint',
@@ -326,9 +343,9 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.deepEqual(stopped.memory.bytes, expectedBytes);
   const accumulatorBeforeFirst = stopped.state.registers.a;
 
-  const stepped = await page.evaluate(() => {
+  const stepped = await page.evaluate(async () => {
     const debuggerApi = window.X1PenAutomation.debugger;
-    return [debuggerApi.step(), debuggerApi.step(), debuggerApi.step()];
+    return [await debuggerApi.step(), await debuggerApi.step(), await debuggerApi.step()];
   });
   assert.equal(stepped[0].stopReason, 'step');
   assert.equal(stepped[0].registers.pc, programAddress + 1);
@@ -341,7 +358,7 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   const resumedBreakpoint = await page.evaluate(async () => {
     const debuggerApi = window.X1PenAutomation.debugger;
     const before = debuggerApi.getState();
-    const running = debuggerApi.resume();
+    const running = await debuggerApi.resume();
     const stoppedAgain = await debuggerApi.waitForPause({
       afterSequence: running.sequence,
       stopReason: 'breakpoint',
@@ -354,8 +371,8 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
 
   const manualState = await page.evaluate(async () => {
     const debuggerApi = window.X1PenAutomation.debugger;
-    debuggerApi.setBreakpoints([]);
-    debuggerApi.resume();
+    await debuggerApi.setBreakpoints([]);
+    await debuggerApi.resume();
     await new Promise((resolve) => setTimeout(resolve, 30));
     return debuggerApi.pause();
   });
@@ -363,7 +380,7 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.equal(manualState.stopReason, 'manual');
   assert.equal(manualState.breakpointCount, 0);
 
-  const validationErrors = await page.evaluate(async () => {
+  const validation = await page.evaluate(async () => {
     const debuggerApi = window.X1PenAutomation.debugger;
     const errors = [];
     for (const operation of [
@@ -378,19 +395,55 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
         errors.push(error.message);
       }
     }
-    return errors;
+    const module = window.Module;
+    const ptr = module._malloc(2);
+    try {
+      return {
+        errors,
+        rawInvalidRead: module._js_debug_read_memory(0xFFFF, ptr, 2),
+      };
+    } finally {
+      module._free(ptr);
+    }
   });
-  assert.match(validationErrors[0], /range exceeds/);
-  assert.match(validationErrors[1], /0 to 65535/);
-  assert.match(validationErrors[2], /Timed out/);
+  assert.match(validation.errors[0], /64KB address space/);
+  assert.match(validation.errors[1], /0 to 65535/);
+  assert.match(validation.errors[2], /Timed out/);
+  assert.equal(validation.rawInvalidRead, -1);
 
   const rerun = await page.evaluate(async () => {
     const api = window.X1PenAutomation;
     const before = api.debugger.getState();
-    const result = await api.run();
-    return { before, result, after: api.debugger.getState() };
+    const runPromise = api.run();
+    const breakpointPromise = api.debugger.setBreakpoints([0x2345]);
+    const controlErrors = [];
+    for (const control of ['pause', 'resume', 'step']) {
+      try {
+        await api.debugger[control]();
+        controlErrors.push(null);
+      } catch (error) {
+        controlErrors.push(error.message);
+      }
+    }
+    const result = await runPromise;
+    const queuedBreakpoints = await breakpointPromise;
+    const after = api.debugger.getState();
+    let runningStepError = null;
+    try {
+      await api.debugger.step();
+    } catch (error) {
+      runningStepError = error.message;
+    }
+    const pausedAfterRun = await api.debugger.pause();
+    await api.debugger.setBreakpoints([]);
+    await api.debugger.resume();
+    return { before, result, after, controlErrors, runningStepError, pausedAfterRun, queuedBreakpoints };
   });
   assert.equal(rerun.before.runState, 'paused');
   assert.equal(rerun.result.ok, true);
   assert.equal(rerun.after.runState, 'running', 'Run must resume a paused debugger session');
+  assert.deepEqual(rerun.controlErrors.map((message) => /run setup is pending/.test(message)), [true, true, true]);
+  assert.match(rerun.runningStepError, /requires the paused state/);
+  assert.equal(rerun.pausedAfterRun.runState, 'paused');
+  assert.equal(rerun.queuedBreakpoints.breakpointCount, 1);
 });

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -446,4 +446,35 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.match(rerun.runningStepError, /requires the paused state/);
   assert.equal(rerun.pausedAfterRun.runState, 'paused');
   assert.equal(rerun.queuedBreakpoints.breakpointCount, 1);
+
+  const manualRun = await page.evaluate(async () => {
+    const api = window.X1PenAutomation;
+    document.getElementById('btn-run').click();
+
+    const controlErrors = [];
+    for (const control of ['pause', 'resume', 'step']) {
+      try {
+        await api.debugger[control]();
+        controlErrors.push(null);
+      } catch (error) {
+        controlErrors.push(error.message);
+      }
+    }
+
+    const deadline = Date.now() + 5000;
+    let paused;
+    while (!paused && Date.now() < deadline) {
+      try {
+        paused = await api.debugger.pause();
+      } catch (error) {
+        if (!/run setup is pending/.test(error.message)) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+    if (!paused) throw new Error('Manual Run did not finish setup');
+    await api.debugger.resume();
+    return { controlErrors, paused };
+  });
+  assert.deepEqual(manualRun.controlErrors.map((message) => /run setup is pending/.test(message)), [true, true, true]);
+  assert.equal(manualRun.paused.runState, 'paused');
 });


### PR DESCRIPTION
## Summary

- expose the Z80 debugger core as `X1PenAutomation.debugger` with named state and register fields
- add validated pause/resume/step, atomic breakpoint replacement, bounded memory reads, and filtered pause waiting
- advertise debugger capability limits through `getStatus()`
- make a normal X1Pen Run resume a previously paused debugger session
- guard debugger controls during Run setup across automation, UI, shortcut, and Share entry points
- move browser regression coverage from raw WASM arrays to the public adapter API

## Scope

This PR is the browser-facing layer only. Extension bridge and MCP debugger tools will follow in a separate PR and will not access `window.Module` directly.

## Verification

- `./build.sh`
- `npm run test:automation` (8/8)
- `npm run test:bridge` (4/4)
- `npm run test:mcp` (18/18)
- `npm run test:extension-package` (1/1)
