### PR TITLE
Fix stuck keys on focus loss and persist MCP edits

### DIFF
--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -343,6 +343,17 @@ window.__X1PEN_MODE = true;
 
     var LS_EDITOR_BASIC = 'x1pen_editor';
     var LS_EDITOR_ASM   = 'x1pen_editor_asm';
+    var LS_EDITOR_SLANG = 'x1pen_editor_slang';
+
+    function persistEditorSources(basic, asm, slang) {
+        try {
+            localStorage.setItem(LS_EDITOR_BASIC, basic);
+            localStorage.setItem(LS_EDITOR_ASM, asm);
+            localStorage.setItem(LS_EDITOR_SLANG, slang);
+        } catch(e) {
+            console.warn('[x1pen] Failed to persist editor sources:', e);
+        }
+    }
 
     var elBtnRun    = document.getElementById('btn-run');
     var elBtnStop   = document.getElementById('btn-stop');
@@ -398,7 +409,6 @@ window.__X1PEN_MODE = true;
           onBlur:  pauseCallbacks.onBlur }
     );
 
-    var LS_EDITOR_SLANG = 'x1pen_editor_slang';
     var slangEditor = window.X1PenEditor.create(
         document.getElementById('slang-editor-container'),
         { language: 'slang',
@@ -1131,6 +1141,7 @@ window.__X1PEN_MODE = true;
         basicEditor.setValue(normalized.basic, { silent: true });
         if (asmEditor) asmEditor.setValue(normalized.asm, { silent: true });
         if (slangEditor) slangEditor.setValue(normalized.slang, { silent: true });
+        persistEditorSources(normalized.basic, normalized.asm, normalized.slang);
         lastAsmTabOrigin = normalized.asm ? 'user' : null;
         pendingShareRuntime = null;
         lastRunWasShared = false;

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1137,10 +1137,13 @@ window.__X1PEN_MODE = true;
         if (expectedRevision !== undefined && expectedRevision !== automationRevision) {
             throw new Error('Revision conflict: expected ' + expectedRevision + ', current ' + automationRevision);
         }
+        if (!basicEditor || !asmEditor || !slangEditor) {
+            throw new Error('X1Pen editors are not ready');
+        }
         var normalized = normalizeAutomationProgram(program);
         basicEditor.setValue(normalized.basic, { silent: true });
-        if (asmEditor) asmEditor.setValue(normalized.asm, { silent: true });
-        if (slangEditor) slangEditor.setValue(normalized.slang, { silent: true });
+        asmEditor.setValue(normalized.asm, { silent: true });
+        slangEditor.setValue(normalized.slang, { silent: true });
         persistEditorSources(normalized.basic, normalized.asm, normalized.slang);
         lastAsmTabOrigin = normalized.asm ? 'user' : null;
         pendingShareRuntime = null;

--- a/platform/platform_input.cpp
+++ b/platform/platform_input.cpp
@@ -180,6 +180,27 @@ static EM_BOOL keyboard_callback(int eventType, const EmscriptenKeyboardEvent* e
     return TRUE;
 }
 
+static void release_all_keys(void) {
+    winkeyreleaseall106();
+}
+
+static EM_BOOL blur_callback(int eventType, const EmscriptenFocusEvent* e, void* userData) {
+    (void)eventType;
+    (void)e;
+    (void)userData;
+    release_all_keys();
+    return FALSE;
+}
+
+static EM_BOOL visibility_callback(int eventType,
+                                   const EmscriptenVisibilityChangeEvent* e,
+                                   void* userData) {
+    (void)eventType;
+    (void)userData;
+    if (e->hidden) release_all_keys();
+    return FALSE;
+}
+
 // Emscripten マウスイベントコールバック（Pointer Lock 対応）
 static EM_BOOL em_mouse_callback(int eventType, const EmscriptenMouseEvent* e, void* userData) {
     bool locked = xmilcfg.MOUSE_SW && isPointerLocked();
@@ -223,6 +244,10 @@ BOOL Platform_Input_Init(void) {
     // キーボードイベントリスナーの登録
     emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, keyboard_callback);
     emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, keyboard_callback);
+    // Alt+Tabなどではkeyupがブラウザへ戻らないため、フォーカス喪失時に
+    // エミュレータ内の押下状態をまとめて解放する。
+    emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, blur_callback);
+    emscripten_set_visibilitychange_callback(NULL, TRUE, visibility_callback);
 
     // マウスイベントリスナーの登録（Pointer Lock 中の取りこぼし防止のため document レベル）
     emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, NULL, TRUE, em_mouse_callback);

--- a/platform/platform_input.cpp
+++ b/platform/platform_input.cpp
@@ -180,7 +180,7 @@ static EM_BOOL keyboard_callback(int eventType, const EmscriptenKeyboardEvent* e
     return TRUE;
 }
 
-static void release_all_keys(void) {
+static void release_all_keyboard_keys(void) {
     winkeyreleaseall106();
 }
 
@@ -188,7 +188,7 @@ static EM_BOOL blur_callback(int eventType, const EmscriptenFocusEvent* e, void*
     (void)eventType;
     (void)e;
     (void)userData;
-    release_all_keys();
+    release_all_keyboard_keys();
     return FALSE;
 }
 
@@ -197,7 +197,7 @@ static EM_BOOL visibility_callback(int eventType,
                                    void* userData) {
     (void)eventType;
     (void)userData;
-    if (e->hidden) release_all_keys();
+    if (e->hidden) release_all_keyboard_keys();
     return FALSE;
 }
 
@@ -244,9 +244,9 @@ BOOL Platform_Input_Init(void) {
     // キーボードイベントリスナーの登録
     emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, keyboard_callback);
     emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, keyboard_callback);
-    // Alt+Tabなどではkeyupがブラウザへ戻らないため、フォーカス喪失時に
-    // エミュレータ内の押下状態をまとめて解放する。
-    emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, TRUE, blur_callback);
+    // Alt+Tabなどではkeyupがブラウザへ戻らないため、ウィンドウ自体の
+    // フォーカス喪失時に押下状態を解放する。ページ内要素のblurは拾わない。
+    emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, FALSE, blur_callback);
     emscripten_set_visibilitychange_callback(NULL, TRUE, visibility_callback);
 
     // マウスイベントリスナーの登録（Pointer Lock 中の取りこぼし防止のため document レベル）

--- a/src/INPUT.H
+++ b/src/INPUT.H
@@ -3,6 +3,7 @@ extern	BYTE	KEY_HIT;
 
 
 void winkeyinit106(void);
+void winkeyreleaseall106(void);
 void winkeyup106(WPARAM wParam, LPARAM lParam);
 void winkeydown106(WPARAM wParam, LPARAM lParam);
 
@@ -13,4 +14,3 @@ void keyboard_term(void);
 
 void keyboard_e3(BYTE *data);
 void keyboard_inkey(BYTE KEY_MODE, BYTE *data);
-

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -103,6 +103,24 @@ void winkeyinit106(void) {
 	keylog_printf("WINKEY INIT");
 }
 
+void winkeyreleaseall106(void) {
+
+	BOOL pressed = KEY_HIT;
+	for (unsigned int i = 0; i < sizeof(KEY_TBL); i++) {
+		if (KEY_TBL[i]) {
+			pressed = TRUE;
+			break;
+		}
+	}
+	if (!pressed) return;
+
+	ZeroMemory(KEY_TBL, sizeof(KEY_TBL));
+	KEY_INT = 1;
+	KEY_HIT = 0;
+	KEY_CHR = 0;
+	keylog_printf("WINKEY RELEASE ALL");
+}
+
 
 void winkeydown106(WPARAM wParam, LPARAM lParam) {
 

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -249,6 +249,50 @@ test('automation validation and capture return structured results', async () => 
   assert.equal(png.readUInt32BE(20), 400);
 });
 
+test('focus loss releases physical keys before automation command injection', { timeout: 60_000 }, async () => {
+  const markerAddress = 0x4000;
+  const marker = [0x12, 0x34, 0x56, 0x78];
+  await page.evaluate(async () => {
+    await window.X1PenAutomation.setProgram({
+      sourceMode: 'asm',
+      asm: [
+        'ORG 0100h',
+        'LD A,012h',
+        'LD (04000h),A',
+        'LD A,034h',
+        'LD (04001h),A',
+        'LD A,056h',
+        'LD (04002h),A',
+        'LD A,078h',
+        'LD (04003h),A',
+        'LOOP:',
+        'JP LOOP',
+      ].join('\n'),
+    });
+    document.getElementById('canvas').focus();
+  });
+
+  await page.keyboard.down('Alt');
+  try {
+    await page.evaluate(() => window.dispatchEvent(new FocusEvent('blur')));
+    const result = await page.evaluate(() => window.X1PenAutomation.run());
+    assert.equal(result.ok, true);
+    await page.waitForFunction(({ address, bytes }) => {
+      const module = window.Module;
+      const ptr = module._malloc(bytes.length);
+      try {
+        if (module._js_debug_read_memory(address, ptr, bytes.length) !== bytes.length) return false;
+        const memory = new Uint8Array(module.wasmMemory.buffer, ptr, bytes.length);
+        return bytes.every((value, index) => memory[index] === value);
+      } finally {
+        module._free(ptr);
+      }
+    }, { address: markerAddress, bytes: marker });
+  } finally {
+    await page.keyboard.up('Alt');
+  }
+});
+
 test('Z80 debugger pauses, steps, resumes, and reads mapped memory', { timeout: 60_000 }, async () => {
   const programAddress = 0x0100;
   const expectedBytes = [0x00, 0x3C, 0xC3, 0x00, 0x01]; // NOP; INC A; JP 0100h

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -173,6 +173,33 @@ test('automation operations are serialized and stale source modes are cleared', 
   assert.ok(programs.final.revision > programs.results[0].revision);
 });
 
+test('automation program updates persist across page reloads', { timeout: 60_000 }, async () => {
+  const basic = '10 PRINT "PERSISTED BY MCP"';
+  const stored = await page.evaluate(async (source) => {
+    localStorage.setItem('x1pen_editor_asm', 'STALE ASM');
+    localStorage.setItem('x1pen_editor_slang', 'STALE SLANG');
+    await window.X1PenAutomation.setProgram({
+      sourceMode: 'basic+asm',
+      basic: source,
+      asm: '',
+    });
+    return {
+      basic: localStorage.getItem('x1pen_editor'),
+      asm: localStorage.getItem('x1pen_editor_asm'),
+      slang: localStorage.getItem('x1pen_editor_slang'),
+    };
+  }, basic);
+  assert.deepEqual(stored, { basic, asm: '', slang: '' });
+
+  await page.reload();
+  await page.evaluate(() => window.X1PenAutomation.ready());
+  const restored = await page.evaluate(() => window.X1PenAutomation.getProgram());
+  assert.equal(restored.basic, basic);
+  assert.equal(restored.asm, '');
+  assert.equal(restored.slang, '');
+  assert.equal(restored.sourceMode, 'basic+asm');
+});
+
 test('revision conflicts prevent stale AI updates', async () => {
   const result = await page.evaluate(async () => {
     const stale = window.X1PenAutomation.getProgram().revision;


### PR DESCRIPTION
## Summary

- release all emulator key state when the browser window loses focus or the document becomes hidden
- prevent Alt+Tab on Windows from leaving the X1 GRAPH key pressed
- persist normalized BASIC, ASM, and SLANG sources when `X1PenAutomation.setProgram()` updates editors silently
- clear stale source-mode storage entries by persisting empty normalized sections

## Regression coverage

- hold physical Alt, dispatch window blur, then verify automated `PROG` launches an ASM program and writes its RAM marker
- update FuzzyBASIC through the Automation API, reload the page, and verify the program is restored while stale ASM/SLANG are absent

## Verification

- `./build.sh`
- `npm run test:automation` (8/8)
- `npm run test:bridge` (4/4)
- `npm run test:mcp` (18/18)

## Merge order

This hotfix is based directly on `main`. Merge it before PR #61, then update PR #61 from `main` because both PRs touch `html/x1pen.js` and the Automation browser test.