### PR TITLE
Prepare x1pen-mcp 2.2.1 release

### DIFF
--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -98,7 +98,7 @@ The loopback WebSocket uses `ws://127.0.0.1`. Chrome Web Store policy explicitly
 No account or paid feature is required.
 
 1. Install Node.js 20 or later.
-2. Run `npx -y x1pen-mcp@2.2.0` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
+2. Run `npx -y x1pen-mcp@2.2.1` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
 3. Open `https://x1.onoda-pro.com/x1pen` in Chrome and wait for the editor to become ready.
 4. Open X1Pen Connector, enter the displayed port and pairing code, review and accept the disclosure, then click `Connect this tab`.
 5. Confirm the extension badge shows `1` and X1Pen shows `MCP Connected`.

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -22,7 +22,7 @@ CodexのMCP設定に以下を追加します。
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.2.0"]
+args = ["-y", "x1pen-mcp@2.2.1"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -35,7 +35,7 @@ userスコープへ登録すると、任意のプロジェクトからX1Penを�
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.2.0
+  npx -y x1pen-mcp@2.2.1
 claude mcp list
 ```
 
@@ -47,7 +47,7 @@ claude mcp list
     "x1pen": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "x1pen-mcp@2.2.0"]
+      "args": ["-y", "x1pen-mcp@2.2.1"]
     }
   }
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,7 +11,7 @@ Add the following server to your Codex MCP configuration. Pinning the version pr
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.2.0"]
+args = ["-y", "x1pen-mcp@2.2.1"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -22,7 +22,7 @@ Register the server at user scope to make it available from any project.
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.2.0
+  npx -y x1pen-mcp@2.2.1
 ```
 
 Use `claude mcp list` or `/mcp` to check the connection.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -60,7 +60,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.2.0');
+    assert.equal(manifest.version, '2.2.1');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');


### PR DESCRIPTION
## Summary
- bump x1pen-mcp to 2.2.1 after transferring npm ownership to the personal ho-ogino account
- update Codex, Claude Code, and Chrome Web Store reviewer instructions to pin 2.2.1
- update the standalone package test expectation

## Verification
- `npm run test:mcp` (18 passed)
- `npm run test:mcp-package` (1 passed)
- `npm pack ./mcp --dry-run --json`

## After merge
Publish `mcp/` as `x1pen-mcp@2.2.1` while authenticated as `ho-ogino`.