### PR TITLE
feat: expand X1Pen SLANG MCP reference

### DIFF
--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -98,7 +98,7 @@ The loopback WebSocket uses `ws://127.0.0.1`. Chrome Web Store policy explicitly
 No account or paid feature is required.
 
 1. Install Node.js 20 or later.
-2. Run `npx -y x1pen-mcp@2.4.0` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
+2. Run `npx -y x1pen-mcp@2.5.0` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
 3. Open `https://x1.onoda-pro.com/x1pen` in Chrome and wait for the editor to become ready.
 4. Open X1Pen Connector, enter the displayed port and pairing code, review and accept the disclosure, then click `Connect this tab`.
 5. Confirm the extension badge shows `1` and X1Pen shows `MCP Connected`.

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -22,7 +22,7 @@ CodexのMCP設定に以下を追加します。
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.4.0"]
+args = ["-y", "x1pen-mcp@2.5.0"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -35,7 +35,7 @@ userスコープへ登録すると、任意のプロジェクトからX1Penを�
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.4.0
+  npx -y x1pen-mcp@2.5.0
 claude mcp list
 ```
 
@@ -47,7 +47,7 @@ claude mcp list
     "x1pen": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "x1pen-mcp@2.4.0"]
+      "args": ["-y", "x1pen-mcp@2.5.0"]
     }
   }
 }
@@ -108,7 +108,7 @@ AIによる更新、検証、実行、停止中はエディターとツールバ
 
 MCPパッケージには、X1Pen FuzzyBASIC 1.2L（X1 / LSX-Dodgers版）とX1Pen内蔵SLANGコンパイラに対応する構造化リファレンスが同梱されています。ブラウザー未接続でも検索できるため、プログラム作成前に仕様を確認できます。MCP初期化時にも「一般的なBASIC、C、別バージョンのSLANGから仕様を推測しない」ことと、生成前のリファレンス検索、生成後の検証をクライアントへ通知します。
 
-schema v2の`symbols`と`relatedIds`による詳細な索引は、現時点ではFuzzyBASICへ適用しています。SLANG側はIssue #65の次PRで同じ形式へ移行します。
+schema v2の`symbols`と`relatedIds`による索引はFuzzyBASICとSLANGの両方へ適用しています。SLANGは内蔵コンパイラの予約語表と、`x1pen.js`が実際に読み込むruntime/includeファイルから公開シンボルを検査し、更新時に未収録項目が生じるとテストで検出します。
 
 最初に`x1pen_get_language_profile`を呼ぶと、同梱profileを確認できます。X1Penへ接続済みなら、ブラウザーが報告したprofile IDとの互換性も返します。
 
@@ -142,7 +142,7 @@ FuzzyBASICの固有構文は記号や日本語でも検索できます。
 
 FuzzyBASICについては、メモリ／I/O配列、16bit値と変数制約、PROC/FUNC、スタック、機械語連携、LSX-Dodgersファイル処理、X1のグラフィック・PCG・PSG・JOYまで収録しています。一般言語構文は原典を参照しますが、OS、ファイル、コンソール、メモリ配置、X1拡張の挙動はLSX-Dodgers移植ソースを優先しています。全トークナイザ予約語がリファレンスの`symbols`でカバーされることと、代表サンプルが現在のX1Pen tokenizerで処理できることを自動検証しています。
 
-SLANGについては、正確なコンパイラrevision、`ENV_TYPE=1`のLSX-Dodgers環境、X1Pen同梱runtime/include APIを収録しています。ゲーム開発で利用するPCGについては、FuzzyBASICの`PCGDEF` / `TCOLOR`、SLANGの`PCGDEF` / `PCGDEFS`、24-byte BRGパターン形式、TILELIBとの初期化順序まで独立項目として収録しています。未知のAPIや複雑な引数規約については、リファレンス確認後も`x1pen_validate`で検証してください。
+SLANGについては、正確なコンパイラrevision、`ENV_TYPE=1`のLSX-Dodgers環境、予約語と文字列関数、native FLOAT、LSXファイル、X1の画面／描画／PCG／PSG／VSYNC／SGL、圧縮・画像ローダ、同梱される8本のinclude APIを収録しています。網羅catalogには内部実装シンボルも含まれるため、通常は検索結果の専用項目を優先してください。ゲーム開発で利用するPCGについては、FuzzyBASICの`PCGDEF` / `TCOLOR`、SLANGの`PCGDEF` / `PCGDEFS`、24-byte BRGパターン形式、TILELIBとの初期化順序まで独立項目として収録しています。未知のAPIや複雑な引数規約については、リファレンス確認後も`x1pen_validate`で検証してください。
 
 ### 大きなプログラムの扱い
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,7 +11,7 @@ Add the following server to your Codex MCP configuration. Pinning the version pr
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.4.0"]
+args = ["-y", "x1pen-mcp@2.5.0"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -22,7 +22,7 @@ Register the server at user scope to make it available from any project.
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.4.0
+  npx -y x1pen-mcp@2.5.0
 ```
 
 Use `claude mcp list` or `/mcp` to check the connection.
@@ -50,6 +50,6 @@ The reference tools work before browser pairing because the data is bundled in t
 
 Search first and fetch only the entries needed for the current program. This avoids putting a complete language manual into the model context.
 
-The server initialization instructions tell MCP clients not to infer these nonstandard languages from ordinary BASIC, C, or another SLANG release. FuzzyBASIC coverage includes direct indexed memory/I/O arrays, LSX-Dodgers-specific file limitations, machine-code integration, PCG, PSG sound, and joystick input. Exact keywords and syntax symbols are searchable in English or Japanese, and an unsuccessful all-term search falls back to partial matches explicitly marked with `matchMode: "partial"`.
+The server initialization instructions tell MCP clients not to infer these nonstandard languages from ordinary BASIC, C, or another SLANG release. FuzzyBASIC coverage includes direct indexed memory/I/O arrays, LSX-Dodgers-specific file limitations, machine-code integration, PCG, PSG sound, and joystick input. SLANG coverage is tied to the exact browser compiler and VFS, including compiler vocabulary, native FLOAT, LSX file I/O, X1 graphics/PCG/PSG/timing/SGL, compression and all bundled include APIs. Exact symbols are searchable in English or Japanese, and an unsuccessful all-term search falls back to partial matches explicitly marked with `matchMode: "partial"`.
 
 See the [complete setup and tool documentation](https://github.com/ho-ogino/xmil-web/blob/main/docs/X1PEN_MCP.md) for details.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {

--- a/mcp/reference/manifest.json
+++ b/mcp/reference/manifest.json
@@ -28,7 +28,7 @@
         "defaultOrg": 256,
         "runtime": "lsx-dodgers"
       },
-      "notes": "The exact browser compiler snapshot and X1Pen-provided runtime/include library set.",
+      "notes": "The exact browser compiler snapshot and the runtime/include files loaded by the X1Pen VFS. Schema v2 indexes compiler vocabulary, runtime metadata symbols and bundled include APIs, with dedicated entries for supported application-facing contracts.",
       "sourceUrls": [
         "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"
       ]

--- a/mcp/reference/slang-catalogs.json
+++ b/mcp/reference/slang-catalogs.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "slang.compiler.catalog",
+    "language": "slang",
+    "kind": "catalog",
+    "title": "Accepted X1Pen SLANG compiler vocabulary",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": [
+      "AND", "ARRAY", "ASM", "BEGIN", "BYTE", "CASE", "CHR$", "CODE", "CONST", "CONTINUE", "CPL", "CR$", "DECI$", "DO", "DOWNTO", "EF", "ELIF", "ELSE", "ELSEIF", "END", "ENDIF", "EXIT", "FL$", "FLOAT", "FOR", "FORM$", "GOTO", "HEX2$", "HEX4$", "HIGH", "IF", "LOOP", "LOW", "MACHINE", "MOD", "MSG$", "MSX$", "NEXT", "NOT", "OF", "OFFSET", "OR", "ORG", "OTHERS", "PN$", "PRINT", "REPEAT", "RETURN", "SPC$", "STR$", "TAB$", "THEN", "TO", "UNTIL", "VAR", "WEND", "WHILE", "WORD", "WORK", "XOR", "MAIN", "#INCLUDE", "#IF", "#ELSE", "#END", "#ENDIF", "#ASM", "#MODULE"
+    ],
+    "aliases": ["reserved words", "compiler keywords", "string functions", "予約語", "言語要素", "文字列関数"],
+    "summary": "This catalog records the keywords, string-format functions and preprocessor directives accepted by the exact X1Pen browser compiler snapshot.",
+    "syntax": ["Search an exact compiler word, then fetch the related dedicated entry for its contract."],
+    "notes": [
+      "The catalog is generated from concepts represented in html/x1pen_slang_compiler.js and checked against its KEYWORDS and STRING_FUNCS tables.",
+      "Prefer dedicated syntax entries; this exhaustive index is intentionally low-detail."
+    ],
+    "relatedIds": ["slang.program.structure", "slang.data.types-declarations", "slang.control.flow", "slang.preprocessor.includes"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_slang_compiler.js"]
+  },
+  {
+    "id": "slang.runtime.catalog",
+    "language": "slang",
+    "kind": "catalog",
+    "title": "Bundled X1Pen SLANG runtime symbol catalog",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": [
+      "ABS", "ADECI", "ANDHLDE", "AT_VRCALC", "BEEP", "BFILL", "BIT", "CALL", "CALLMAGIC", "CPLHL", "CRDISP", "CSR", "CTRL0B", "CTRL0C", "CTRL0D", "DIVHLDE", "DIVHLDE8", "FABS", "FACOS", "FACOSH", "FASIN", "FASINH", "FATAN", "FATANH", "FCLOSE", "FCOS", "FCOSH", "FEXP", "FGETC", "FLOG", "FLOG10", "FLOG2", "FLOGY", "FOPEN", "FPOW", "FPOW10", "FPOW2", "FPUTC", "FRAND", "FREAD", "FREADWRITE", "FSEEK", "FSIN", "FSINH", "FSQRT", "FTAN", "FTANH", "FTOI", "FWORK", "FWRITE", "GETKY_DOINIT", "GETL", "GETLIN", "GETREG", "GRCLS", "GRDISP", "GRPSETUP", "INKEY", "INPUT", "ITOF", "LINE", "LINECOMMON", "LINPUT", "LOCATE", "LSHIFTHLDE", "LSXCALLS", "LSXFILE", "LZEEE_DECODE", "LZEE_DECODE", "LZE_DECODE", "M8ALOAD", "MAGBASE", "MAGICBASE", "MAGLOAD", "MAX", "MEMCPY", "MEMSET", "MIN", "MODHLDE", "MPRNT", "MSGET", "MSINIT", "MULHLDE", "NEGHL", "NOTHL", "OPEQHL", "OPGEHLDE", "OPGTHLDE", "OPLEHLDE", "OPLTHLDE", "OPNEQHL", "OPSGEHLDE", "OPSGTHLDE", "OPSLEHLDE", "OPSLTHLDE", "ORHLDE", "P10", "P10to5", "P10toN", "PAINT", "PAINT1", "PAINT2", "PCGDEF", "PCGDEFS", "PCHR", "PCR", "PCR1", "PCRONE", "PFLOAT", "PHEX", "PHEX2", "PHEX4", "PMSG", "PMSX", "PMSX1", "PRMODE", "PRT", "PSG_BASE", "PSG_END", "PSG_INIT", "PSG_PAUSE", "PSG_PLAY", "PSG_PROC", "PSG_RESUME", "PSG_SFX", "PSG_STOP", "PSIGN", "PSPC", "PSTR", "PSTR2", "PTAB", "RBIT", "RCALL", "RESET", "RND", "RSET", "RSHIFTHLDE", "SASC", "SCREEN", "SDIVHLDE", "SET", "SETUPCTC", "SET_PAINTBUF", "SEX", "SGL_DEFPAT", "SGL_FPSMODE", "SGL_INIT", "SGL_PRINT", "SGL_PRINT2", "SGL_SPRCREATE", "SGL_SPRDESTROY", "SGL_SPRDISP", "SGL_SPRMOVE", "SGL_SPRPAT", "SGL_SPRSET", "SGL_VSYNC", "SGN", "SLANGINIT", "SLSHIFTHLDE", "SMODHLDE", "SOROBAN", "SOROBANWORK", "SRAND", "SRSHIFTHLDE", "STOP", "STRLEN", "UTOF", "VSYNC", "VSYNC1", "VSYNC_CHECK", "VTOS", "WIDTH", "X1SGLBASE", "X1SGLINCLUDE", "X1WORK", "XLINE", "XORHLDE", "ZX0_DECODE", "f24_common_str", "f24add", "f24amean", "f24bg", "f24cmp", "f24div", "f24div2", "f24div_pow2", "f24geomean", "f24inv", "f24mod1", "f24mul", "f24mul2", "f24mul3", "f24neg", "f24pow10_LUT", "f24sqr", "f24sub", "f24toa", "formatstr", "i16tof24", "lLOC1", "mul16", "sASC", "sBOOT", "sBRKEY", "sCAP", "sCSR", "sCTRL", "sFGETL", "sFLGET", "sGETKY", "sGETL", "sHEX", "sHLHEX", "sINKBF", "sINKEY", "sKYBFC", "sLOC", "sLPRNT", "sLPTOF", "sLPTON", "sLTNL", "sMPRNT", "sMSG", "sMSX", "sNL", "sPAUSE", "sPCLR", "sPRINT", "sPRINTS", "sPRNT0", "sSCRN", "sSYSTEM", "sWIDCH", "sWORK", "sZPRINT", "sqrt16", "u16tof24", "z80rand"
+    ],
+    "aliases": ["runtime functions", "runtime metadata", "internal helpers", "ランタイム関数", "内部関数", "実行時ライブラリ"],
+    "summary": "This catalog mirrors every @name and @alias loaded from the runtime ASM files in the X1Pen VFS, including implementation helpers and user-facing calls.",
+    "syntax": ["Search an exact runtime symbol, then prefer a related user-facing entry when one exists."],
+    "notes": [
+      "Presence here means the compiler can resolve the symbol; it does not mean the function is a stable or recommended application API.",
+      "Names such as f24*, s* and support bases are usually implementation dependencies. Generate calls from the dedicated entries instead."
+    ],
+    "relatedIds": ["slang.machine.system-access", "slang.runtime.float", "slang.runtime.lsx-io-files", "slang.x1.display-graphics", "slang.x1.psg", "slang.x1.sgl"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/tree/main/assets/slang_runtime"]
+  },
+  {
+    "id": "slang.includes.catalog",
+    "language": "slang",
+    "kind": "catalog",
+    "title": "Bundled X1Pen SLANG include API catalog",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": [
+      "@ABS", "@ADD", "@ATN", "@BOX", "@BOXC", "@CBOX", "@CFULL", "@CINT", "@CIRCLE", "@CIRCLEC", "@CLINE", "@CLS", "@CMP", "@COLDRAW", "@COLDRAWT", "@COS", "@CPOLY", "@CRTKN", "@CVDBL", "@CVFTI", "@CVFTS", "@CVFTU", "@CVITF", "@CVSNG", "@CVSTF", "@CVUTF", "@DIV", "@DOUBLE", "@EXP", "@FIX", "@FLASH", "@FRAC", "@FUKUGEN", "@FULL", "@FULLC", "@GRAD", "@IATN", "@ICOS", "@IDIV", "@INIT", "@INT", "@ISIN", "@KYU", "@LINE", "@LINEC", "@LOG", "@MAGIC", "@MASK", "@MOD", "@MODE", "@MOVE", "@MUL", "@NEG", "@PAI", "@PALET", "@PLINE", "@PLINIT", "@PLOT", "@POW", "@RAD", "@ROAD", "@SCTL", "@SETOD", "@SETWD", "@SGN", "@SIN", "@SINGLE", "@SPLINE", "@SPLINEC", "@SQR", "@SUB", "@SWAP", "@TAN", "@TLINE", "@TRIANGLE", "@TRIANGLEC", "@WAVE", "@WINDOW", "CHIP_ANIM_TICK", "CHIP_DRAW", "CHIP_DRAW_VVRAM", "CHIP_FILL_MAP", "CHIP_INIT", "CHIP_MASK_DRAW", "CHIP_SET_ANIM", "CHIP_SET_ANIM_RATE", "CHIP_SET_MAP", "CHIP_SET_MAPSIZE", "CHIP_SET_OFS", "CHIP_SET_SCROLL", "CHIP_SET_SIZE", "CHIP_SET_VVRAMSIZE", "CHIP_SPR_ADD", "CHIP_SPR_FLASH", "CHIP_SPR_POS", "CHIP_SPR_START", "SPR_INIT", "SPR_IS_ACTIVE", "SPR_SET_PATTERN", "SPR_SET_POS", "SPR_SET_SHOW", "SPR_UPDATE", "TILE_ANIM_TICK", "TILE_FILL_MAP", "TILE_INIT", "TILE_INVALIDATE", "TILE_SET_ANIM", "TILE_SET_ANIM_RATE", "TILE_SET_MAP", "TILE_SET_MAPSIZE", "TILE_SET_OFS", "TILE_SET_PAGE", "TILE_SET_SCROLL", "TILE_SET_SIZE", "TILE_SYNC_SPR_PAGE", "UI_AT", "UI_BOX", "UI_FILL", "UI_FONT_ADDR", "UI_PUTC", "UI_PUTS", "UI_SET_COLOR", "_LSXCLS"
+    ],
+    "aliases": ["include APIs", "library functions", "public MACHINE declarations", "同梱ライブラリ", "インクルードAPI", "公開関数"],
+    "summary": "This catalog records function definitions and MACHINE declarations exposed by all eight include files bundled in the X1Pen browser VFS.",
+    "syntax": ["#INCLUDE filename.LIB"],
+    "notes": [
+      "Compile-time switches can remove some GRAPH, GRAPHF or SOROBAN functions from a particular build.",
+      "Prefer the dedicated library entries for setup order, argument meaning and lifetime constraints."
+    ],
+    "relatedIds": ["slang.include.tile-sprite", "slang.include.chiplib", "slang.include.ui", "slang.include.graph-soroban", "slang.include.soroban"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/tree/main/assets/slang_include"]
+  }
+]

--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -36,7 +36,7 @@
     "title": "BYTE, WORD, FLOAT, VAR, ARRAY and CONST",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
     "symbols": ["BYTE", "WORD", "FLOAT", "VAR", "ARRAY", "CONST"],
-    "aliases": ["types", "variables", "arrays", "constants", "indirect variable", "24-bit float", "データ型", "変数", "配列", "定数", "間接変数", "浮動小数点"],
+    "aliases": ["types", "variables", "arrays", "constants", "indirect variable", "24-bit float", "multidimensional array", "データ型", "変数", "配列", "2次元配列", "多次元配列", "定数", "間接変数", "浮動小数点"],
     "summary": "WORD is the default 16-bit type, BYTE is 8-bit, and the X1Pen compiler adds 24-bit FLOAT. VAR declares variables, ARRAY allocates indexed storage, and CONST defines compile-time values.",
     "syntax": [
       "VAR A, BYTE B, FLOAT F;",
@@ -61,7 +61,7 @@
     "title": "Functions, arguments and return types",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
     "symbols": ["MAIN", "RETURN", "BYTE", "WORD", "FLOAT", "END"],
-    "aliases": ["function", "RETURN", "typed arguments", "FLOAT return", "local variables", "関数", "サブルーチン", "引数", "戻り値", "ローカル変数"],
+    "aliases": ["function", "RETURN", "typed arguments", "FLOAT return", "local variables", "recursion", "recursive function", "関数", "サブルーチン", "再帰", "再帰関数", "引数", "戻り値", "ローカル変数"],
     "summary": "Functions can declare BYTE, WORD or FLOAT parameters and return types. WORD is the default; FLOAT functions return a 24-bit value and require explicit FTOI conversion when consumed as an integer.",
     "syntax": [
       "SQUARE(X) BEGIN RETURN(X*X); END;",
@@ -428,7 +428,7 @@
     "title": "Native 24-bit FLOAT runtime",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
     "symbols": ["FLOAT", "ITOF", "UTOF", "FTOI", "FABS", "FACOS", "FACOSH", "FASIN", "FASINH", "FATAN", "FATANH", "FCOS", "FCOSH", "FEXP", "FLOG", "FLOG2", "FLOG10", "FLOGY", "FPOW", "FPOW2", "FPOW10", "FRAND", "FSIN", "FSINH", "FSQRT", "FTAN", "FTANH", "FL$"],
-    "aliases": ["floating point", "24-bit float", "math functions", "trigonometry", "square root", "浮動小数点", "浮動小数点関数", "実数", "三角関数", "平方根", "対数", "べき乗"],
+    "aliases": ["floating point", "24-bit float", "math functions", "type conversion", "trigonometry", "square root", "浮動小数点", "浮動小数点関数", "型変換", "実数", "三角関数", "平方根", "対数", "べき乗"],
     "summary": "X1Pen SLANG has a native 24-bit FLOAT type and bundled conversion, trigonometric, logarithmic, power and random-number functions.",
     "syntax": [
       "VAR FLOAT VALUE;",

--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -5,7 +5,8 @@
     "kind": "syntax",
     "title": "Program structure, blocks and comments",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["MAIN", "BEGIN END", "free format", "comments", "braces"],
+    "symbols": ["MAIN", "BEGIN", "END", "{", "}", "[", "]", "(", ")", "//", "/*", "*/", "(*", "*)"],
+    "aliases": ["MAIN", "BEGIN END", "free format", "comments", "braces", "プログラム構造", "メイン関数", "ブロック", "コメント", "注釈"],
     "summary": "SLANG is free-format and requires MAIN(). Blocks may use braces, brackets, parentheses, Japanese corner brackets, or BEGIN ... END;.",
     "syntax": [
       "MAIN() BEGIN ... END;",
@@ -25,6 +26,7 @@
         "source": "MAIN() BEGIN\n  PRINT(\"HELLO FROM X1PEN\", /);\nEND;"
       }
     ],
+    "relatedIds": ["slang.functions.typed", "slang.control.flow", "slang.compiler.catalog", "slang.x1pen.build-profile"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -33,7 +35,8 @@
     "kind": "syntax",
     "title": "BYTE, WORD, FLOAT, VAR, ARRAY and CONST",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["types", "variables", "arrays", "constants", "indirect variable", "24-bit float"],
+    "symbols": ["BYTE", "WORD", "FLOAT", "VAR", "ARRAY", "CONST"],
+    "aliases": ["types", "variables", "arrays", "constants", "indirect variable", "24-bit float", "データ型", "変数", "配列", "定数", "間接変数", "浮動小数点"],
     "summary": "WORD is the default 16-bit type, BYTE is 8-bit, and the X1Pen compiler adds 24-bit FLOAT. VAR declares variables, ARRAY allocates indexed storage, and CONST defines compile-time values.",
     "syntax": [
       "VAR A, BYTE B, FLOAT F;",
@@ -48,6 +51,7 @@
       "Integer values convert to FLOAT automatically. Convert FLOAT to an integer explicitly with FTOI.",
       "A VAR declared with [] is indirect: its value is treated as the base address for indexed memory access."
     ],
+    "relatedIds": ["slang.functions.typed", "slang.machine.system-access", "slang.runtime.float", "slang.compiler.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -56,7 +60,8 @@
     "kind": "syntax",
     "title": "Functions, arguments and return types",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["function", "RETURN", "typed arguments", "FLOAT return", "local variables"],
+    "symbols": ["MAIN", "RETURN", "BYTE", "WORD", "FLOAT", "END"],
+    "aliases": ["function", "RETURN", "typed arguments", "FLOAT return", "local variables", "関数", "サブルーチン", "引数", "戻り値", "ローカル変数"],
     "summary": "Functions can declare BYTE, WORD or FLOAT parameters and return types. WORD is the default; FLOAT functions return a 24-bit value and require explicit FTOI conversion when consumed as an integer.",
     "syntax": [
       "SQUARE(X) BEGIN RETURN(X*X); END;",
@@ -76,6 +81,7 @@
         "source": "DOUBLE(WORD X) BEGIN\n  RETURN(X*2);\nEND;\n\nMAIN() BEGIN\n  PRINT(DOUBLE(21), /);\nEND;"
       }
     ],
+    "relatedIds": ["slang.program.structure", "slang.data.types-declarations", "slang.machine.calling-convention", "slang.runtime.float"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -84,7 +90,8 @@
     "kind": "runtime",
     "title": "MACHINE declarations and calling convention",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["external routine", "register arguments", "Z80", "HL DE BC", "machine function"],
+    "symbols": ["MACHINE", "CODE", "CALL", "GETREG", "^AF", "^BC", "^DE", "^HL", "^IX", "^IY", "^SP", "^CARRY", "^ZERO"],
+    "aliases": ["external routine", "register arguments", "Z80", "HL DE BC", "machine function", "マシン語", "機械語", "アセンブラ", "外部ルーチン", "レジスタ", "呼出規約"],
     "summary": "MACHINE binds a SLANG function name to an external Z80 routine. Argument count controls whether values are passed in registers or on the stack.",
     "syntax": [
       "MACHINE MON(0):$1F8E;",
@@ -96,6 +103,7 @@
       "If the argument count is omitted, arguments go on the stack and HL receives the argument count.",
       "MACHINE functions return WORD only in this compiler snapshot; a FLOAT return annotation is rejected."
     ],
+    "relatedIds": ["slang.functions.typed", "slang.machine.system-access", "slang.preprocessor.includes", "slang.runtime.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -104,7 +112,8 @@
     "kind": "syntax",
     "title": "IF, loops, CASE, EXIT and CONTINUE",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["IF ELSE", "FOR NEXT", "WHILE WEND", "REPEAT UNTIL", "LOOP", "CASE", "break"],
+    "symbols": ["IF", "THEN", "ELSE", "ELSEIF", "ELIF", "EF", "ENDIF", "FOR", "TO", "DOWNTO", "DO", "NEXT", "WHILE", "WEND", "REPEAT", "UNTIL", "LOOP", "CASE", "OF", "OTHERS", "EXIT", "CONTINUE", "GOTO"],
+    "aliases": ["IF ELSE", "FOR NEXT", "WHILE WEND", "REPEAT UNTIL", "LOOP", "CASE", "break", "条件分岐", "繰り返し", "ループ", "場合分け", "脱出", "継続"],
     "summary": "SLANG supports structured conditionals and loops, CASE selection, EXIT, multi-level EXIT(n), and CONTINUE.",
     "syntax": [
       "IF expression [THEN] statement [ELSE statement] [ENDIF;]",
@@ -120,6 +129,7 @@
       "CASE tests clauses from top to bottom and exits after the first match. Clauses may contain a value, a range with TO, or comma-separated values.",
       "ELSE IF may also be written ELSEIF or EF."
     ],
+    "relatedIds": ["slang.program.structure", "slang.expressions.operators", "slang.limits.gotchas", "slang.compiler.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -128,7 +138,8 @@
     "kind": "syntax",
     "title": "Operators and signed arithmetic",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["operator precedence", "signed operators", "dot operators", "compound assignment", "logical and or"],
+    "symbols": ["AND", "OR", "XOR", "NOT", "CPL", "MOD", "HIGH", "LOW", "+", "-", "*", "/", "<<", ">>", "==", "<>", "!=", "<", "<=", ">", ">=", "&&", "||", "+=", "-=", "*=", "/=", "?", ":", "&"],
+    "aliases": ["operator precedence", "signed operators", "dot operators", "compound assignment", "logical and or", "演算子", "符号付き演算", "比較", "論理演算", "ビット演算", "優先順位"],
     "summary": "Ordinary integer arithmetic and comparisons are unsigned where relevant. Dot operators provide signed multiply, divide, shifts and comparisons; the X1Pen compiler also supports logical &&/|| and compound assignments.",
     "syntax": [
       "+ - * / MOD << >> AND OR XOR",
@@ -143,6 +154,7 @@
       "Relation results use TRUE=1 and FALSE=0.",
       "The ampersand address operator returns the address of a variable or array element."
     ],
+    "relatedIds": ["slang.control.flow", "slang.data.types-declarations", "slang.machine.system-access", "slang.compiler.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -151,7 +163,8 @@
     "kind": "syntax",
     "title": "Preprocessor, includes and environment constants",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["#INCLUDE", "#IF", "#ELSE", "#ENDIF", "#MODULE", "ENV_TYPE", "OS_TYPE"],
+    "symbols": ["#INCLUDE", "#IF", "#ELSE", "#END", "#ENDIF", "#ASM", "#MODULE", "ASM", "ORG", "WORK", "OFFSET", "ENV_TYPE", "OS_TYPE"],
+    "aliases": ["#INCLUDE", "#IF", "#ELSE", "#ENDIF", "#MODULE", "ENV_TYPE", "OS_TYPE", "プリプロセッサ", "インクルード", "条件コンパイル", "埋め込みアセンブラ", "環境定数"],
     "summary": "Use #INCLUDE for bundled libraries and #IF for environment-dependent code. X1Pen compiles for ENV_TYPE=1, the LSX-Dodgers environment.",
     "syntax": [
       "#INCLUDE GRAPHF.LIB",
@@ -166,6 +179,7 @@
       "The compiler supports include nesting up to 8 levels.",
       "X1Pen bundles GRAPH.LIB, GRAPHF.LIB, SOROBAN.LIB, CHIPLIB.LIB, SPRLIB.LIB, TILELIB.LIB, TILESPR.LIB and UILIB.LIB. Other local files are not available through the browser VFS."
     ],
+    "relatedIds": ["slang.x1pen.build-profile", "slang.includes.catalog", "slang.machine.calling-convention", "slang.compiler.catalog"],
     "sourceUrls": [
       "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
       "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen.js"
@@ -177,8 +191,9 @@
     "kind": "runtime",
     "title": "PRINT formatting, strings and escapes",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["PRINT", "FORM$", "HEX2$", "HEX4$", "MSX$", "newline", "string escape"],
-    "summary": "PRINT accepts strings, numbers and formatting items. A slash emits a newline; string literals are zero-terminated addresses and support X1/S-OS control escapes.",
+    "symbols": ["PRINT", "FORM$", "DECI$", "PN$", "HEX2$", "HEX4$", "MSG$", "MSX$", "STR$", "CHR$", "SPC$", "CR$", "TAB$", "FL$"],
+    "aliases": ["PRINT", "FORM$", "HEX2$", "HEX4$", "MSX$", "newline", "string escape", "文字列", "文字列操作", "表示", "数値書式", "改行", "エスケープ"],
+    "summary": "PRINT accepts strings, numbers and formatting items. A slash emits a newline; string literals are zero-terminated addresses and support the compiler's X1 control escapes.",
     "syntax": [
       "PRINT(\"VALUE=\", VALUE, /);",
       "PRINT(HEX4$(ADDRESS), /);",
@@ -189,6 +204,7 @@
       "Common formatters include FORM$, DECI$, PN$, HEX2$, HEX4$, MSG$, MSX$, STR$, CHR$, SPC$, CR$ and TAB$.",
       "The newline escape is backslash-N or backslash-slash and has value $0D. Backslash-C is clear-screen control $0C."
     ],
+    "relatedIds": ["slang.x1.display-graphics", "slang.include.ui", "slang.data.types-declarations", "slang.compiler.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   },
   {
@@ -197,8 +213,9 @@
     "kind": "runtime",
     "title": "System arrays, registers and core runtime functions",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["MEM", "MEMW", "PORT", "PORTW", "SOS", "registers", "BIT SET RESET", "MEMCPY MEMSET"],
-    "summary": "SLANG exposes byte/word memory and port arrays, S-OS work arrays, Z80 register variables, and core helper routines supplied by the X1Pen runtime.",
+    "symbols": ["MEM", "MEMW", "PORT", "PORTW", "SOS", "SOSW", "^AF", "^BC", "^DE", "^HL", "^IX", "^IY", "^SP", "^CARRY", "^ZERO", "@KBUFF", "BIT", "SET", "RESET", "ABS", "SGN", "SEX", "RND", "CALL", "GETREG", "MEMCPY", "MEMSET", "STRLEN", "MIN", "MAX"],
+    "aliases": ["MEM", "MEMW", "PORT", "PORTW", "SOS", "registers", "BIT SET RESET", "MEMCPY MEMSET", "メモリ配列", "マシン語", "機械語", "ポート入出力", "レジスタ", "乱数", "ビット操作"],
+    "summary": "SLANG exposes byte/word memory and port arrays, LSX compatibility work arrays, Z80 register variables, and core helper routines supplied by the X1Pen runtime.",
     "syntax": [
       "MEM[address]  MEMW[address]",
       "PORT[port]  PORTW[port]",
@@ -210,8 +227,10 @@
     ],
     "notes": [
       "CALL and GETREG exchange values through registered Z80 register variables.",
-      "@KBUFF is the address of the keyboard input buffer."
+      "@KBUFF is the address of the keyboard input buffer.",
+      "SOS and SOSW are compatibility work arrays provided by this compiler/runtime profile. Do not infer historical S-OS fixed-address layouts that are not documented by the X1Pen implementation."
     ],
+    "relatedIds": ["slang.machine.calling-convention", "slang.data.types-declarations", "slang.runtime.lsx-io-files", "slang.runtime.catalog"],
     "sourceUrls": [
       "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/core.asm"
@@ -223,7 +242,8 @@
     "kind": "x1-extension",
     "title": "X1Pen LSX input and file runtime",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE"],
+    "symbols": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE"],
+    "aliases": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE", "キー入力", "キーボード", "行入力", "ファイル", "ファイルを開く", "ファイルを読む", "ファイルに書く", "ファイル入出力"],
     "summary": "The X1Pen LSX runtime provides keyboard/line input and LSX file operations in addition to the core SLANG functions.",
     "syntax": [
       "INKEY(mode)",
@@ -231,12 +251,24 @@
       "GETL(address)",
       "GETLIN(address,length)",
       "LINPUT(address,length)",
-      "FOPEN(...) FSEEK(...) FGETC(...) FPUTC(...) FCLOSE(...) FREAD(...) FWRITE(...)"
+      "FOPEN(fileNumber,filenameAddress,mode)",
+      "FSEEK(fileNumber,offset,origin)",
+      "FGETC(fileNumber) FPUTC(fileNumber,character) FCLOSE(fileNumber)",
+      "FREAD(fileNumber,address,size) FWRITE(fileNumber,address,size)"
     ],
     "notes": [
-      "File APIs are low-level LSX runtime bindings. Search for the exact function name, inspect compiler diagnostics, and validate against the bundled runtime before relying on an argument convention.",
+      "File numbers are 0 through 7. FOPEN returns 255 for an invalid file number; otherwise it returns the LSX operation result.",
+      "FOPEN masks mode to two bits. Values below 3 open an existing file; mode 3 creates a file.",
+      "FSEEK origin is 0 from the beginning, 1 from the current position, or 2 from the end.",
       "INKEY takes one mode argument; INPUT takes none; GETL takes one; GETLIN and LINPUT take two."
     ],
+    "examples": [
+      {
+        "title": "Open and close an LSX file",
+        "source": "MAIN() BEGIN\n  VAR RESULT;\n  RESULT=FOPEN(0, \"A:DATA.BIN\", 0);\n  IF RESULT==0 THEN FCLOSE(0);\n  PRINT(RESULT, /);\nEND;"
+      }
+    ],
+    "relatedIds": ["slang.machine.system-access", "slang.x1.assets-compression", "slang.x1.display-graphics", "slang.runtime.catalog"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_input.asm",
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_file.asm"
@@ -248,7 +280,8 @@
     "kind": "x1-extension",
     "title": "Defining X1 PCG characters with PCGDEF and PCGDEFS",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["PCGDEF", "PCGDEFS", "programmable character generator", "BRG", "24-byte tile", "game graphics", "glyph"],
+    "symbols": ["PCGDEF", "PCGDEFS", "WIDTH", "CHR$"],
+    "aliases": ["PCGDEF", "PCGDEFS", "programmable character generator", "BRG", "24-byte tile", "game graphics", "glyph", "PCG", "キャラクタ定義", "外字", "ゲームグラフィック", "タイル定義"],
     "summary": "The X1Pen runtime defines one PCG glyph with PCGDEF or a consecutive range with PCGDEFS. Each 8x8 glyph is a 24-byte Blue/Red/Green interleaved bitmap.",
     "syntax": [
       "WIDTH(40);",
@@ -270,6 +303,7 @@
         "source": "ARRAY BYTE GLYPH[] = {\n  $3C,0,0, $7E,0,0, $DB,0,0, $FF,0,0,\n  $A5,0,0, $FF,0,0, $66,0,0, $3C,0,0\n};\n\nMAIN() BEGIN\n  WIDTH(40);\n  PCGDEFS(128, GLYPH, 1);\n  PRINT(CHR$(128), /);\nEND;"
       }
     ],
+    "relatedIds": ["slang.include.tile-sprite", "slang.x1.display-graphics", "slang.x1.sgl", "slang.runtime.catalog"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_pcg.asm",
       "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/examples/tile/README.md"
@@ -281,7 +315,8 @@
     "kind": "library",
     "title": "TILELIB, SPRLIB and TILESPR APIs",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["tile map", "sprite", "scroll", "animation", "TILE_SYNC_SPR_PAGE"],
+    "symbols": ["TILE_INIT", "TILE_FILL_MAP", "TILE_SET_MAP", "TILE_SET_MAPSIZE", "TILE_SET_SCROLL", "TILE_SET_ANIM", "TILE_SET_ANIM_RATE", "TILE_ANIM_TICK", "TILE_SET_PAGE", "TILE_SET_OFS", "TILE_SET_SIZE", "TILE_INVALIDATE", "SPR_INIT", "SPR_SET_PATTERN", "SPR_SET_POS", "SPR_SET_SHOW", "SPR_IS_ACTIVE", "SPR_UPDATE", "TILE_SYNC_SPR_PAGE"],
+    "aliases": ["tile map", "sprite", "scroll", "animation", "TILE_SYNC_SPR_PAGE", "タイルマップ", "スプライト", "スクロール", "アニメーション", "ゲーム画面"],
     "summary": "X1Pen bundles a PCG tile-map library, a software-sprite library and a helper that synchronizes their double-buffer pages.",
     "syntax": [
       "#INCLUDE TILELIB.LIB",
@@ -302,6 +337,7 @@
       "For animation, reserve consecutive groups of up to four PCG indexes, set the threshold with TILE_SET_ANIM, call TILE_ANIM_TICK from VSYNC_PROC, and call TILE_FILL_MAP each frame.",
       "The signatures list parameter counts because the libraries bind their public calls with MACHINE declarations; consult the library source for argument meaning and memory layout."
     ],
+    "relatedIds": ["slang.x1.pcg-definition", "slang.include.chiplib", "slang.x1.timing", "slang.includes.catalog"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/TILELIB.LIB",
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/SPRLIB.LIB",
@@ -314,7 +350,8 @@
     "kind": "library",
     "title": "CHIPLIB tile-chip and sprite APIs",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["CHIP_INIT", "CHIP_DRAW", "CHIP_SET_MAP", "CHIP_SET_SCROLL", "CHIP_SPR"],
+    "symbols": ["CHIP_INIT", "CHIP_DRAW_VVRAM", "CHIP_FILL_MAP", "CHIP_DRAW", "CHIP_MASK_DRAW", "CHIP_SET_OFS", "CHIP_SET_SIZE", "CHIP_SET_MAP", "CHIP_SET_MAPSIZE", "CHIP_SET_SCROLL", "CHIP_SET_VVRAMSIZE", "CHIP_SET_ANIM", "CHIP_SET_ANIM_RATE", "CHIP_ANIM_TICK", "CHIP_SPR_START", "CHIP_SPR_POS", "CHIP_SPR_ADD", "CHIP_SPR_FLASH"],
+    "aliases": ["CHIP_INIT", "CHIP_DRAW", "CHIP_SET_MAP", "CHIP_SET_SCROLL", "CHIP_SPR", "チップ", "タイル", "マップ描画", "スプライト合成", "ゲームグラフィック"],
     "summary": "CHIPLIB exposes a compact tile-chip renderer, animation controls and a small sprite composition interface.",
     "syntax": [
       "#INCLUDE CHIPLIB.LIB",
@@ -329,6 +366,7 @@
       "Call CHIP_INIT before drawing. Configure offsets, sizes, map and VVRAM dimensions before the main draw loop.",
       "The public declarations specify argument counts; use the bundled CHIPLIB.LIB comments and validation to confirm each argument's units."
     ],
+    "relatedIds": ["slang.include.tile-sprite", "slang.x1.pcg-definition", "slang.x1.timing", "slang.includes.catalog"],
     "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/CHIPLIB.LIB"]
   },
   {
@@ -337,7 +375,8 @@
     "kind": "library",
     "title": "UILIB text UI API",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["UI_AT", "UI_SET_COLOR", "UI_PUTC", "UI_PUTS", "UI_FILL", "UI_BOX", "UI_FONT_ADDR"],
+    "symbols": ["UI_AT", "UI_SET_COLOR", "UI_PUTC", "UI_PUTS", "UI_FILL", "UI_BOX", "UI_FONT_ADDR"],
+    "aliases": ["UI_AT", "UI_SET_COLOR", "UI_PUTC", "UI_PUTS", "UI_FILL", "UI_BOX", "UI_FONT_ADDR", "ユーザーインターフェース", "文字UI", "テキスト画面", "文字表示", "色を変える", "枠を描く"],
     "summary": "UILIB provides cursor positioning, color, character/string output, fill and box operations for compact text-oriented interfaces.",
     "syntax": [
       "#INCLUDE UILIB.LIB",
@@ -353,33 +392,214 @@
       "UI_PUTS receives an address, normally a zero-terminated SLANG string literal or buffer.",
       "The fill and box calls use compact packed arguments defined by UILIB; inspect its comments when constructing nontrivial layouts."
     ],
+    "relatedIds": ["slang.output.print-strings", "slang.x1.display-graphics", "slang.includes.catalog"],
     "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/UILIB.LIB"]
   },
   {
     "id": "slang.include.graph-soroban",
     "language": "slang",
     "kind": "library",
-    "title": "GRAPH, GRAPHF and SOROBAN libraries",
+    "title": "GRAPH and GRAPHF graphics libraries",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["3D graphics", "floating point", "LINEC", "CIRCLEC", "SOROBAN", "trigonometry"],
-    "summary": "GRAPH provides the historical geometry package, GRAPHF adds FLOAT/color variants, and SOROBAN provides the older software numeric package.",
+    "symbols": ["@INIT", "@CLS", "@MODE", "@PALET", "@WINDOW", "@LINE", "@SPLINE", "@BOX", "@TRIANGLE", "@FULL", "@CIRCLE", "@LINEC", "@SPLINEC", "@BOXC", "@TRIANGLEC", "@FULLC", "@CIRCLEC", "@PLOT", "@MOVE", "@PLINIT", "@PLINE", "@TLINE", "@CLINE", "@CBOX", "@CFULL", "@CPOLY", "@WAVE", "@ROAD", "@COLDRAW", "@COLDRAWT"],
+    "aliases": ["3D graphics", "floating point graphics", "LINEC", "CIRCLEC", "geometry", "グラフィック", "図形描画", "線を描く", "円を描く", "三角形", "座標変換"],
+    "summary": "GRAPH provides the historical geometry package and GRAPHF adds native FLOAT and color variants for X1 graphics.",
     "syntax": [
       "#INCLUDE GRAPH.LIB",
       "@INIT(...) @CLS(...) @MODE(...) @PALET(...) @WINDOW(...) @LINE(...) @SPLINE(...) @BOX(...) @TRIANGLE(...) @FULL(...) @CIRCLE(...) ",
       "#INCLUDE GRAPHF.LIB",
-      "@LINEC(...) @SPLINEC(...) @BOXC(...) @TRIANGLEC(...) @FULLC(...) @CIRCLEC(...) ",
-      "#INCLUDE SOROBAN.LIB"
+      "@LINEC(...) @SPLINEC(...) @BOXC(...) @TRIANGLEC(...) @FULLC(...) @CIRCLEC(...)"
     ],
     "notes": [
       "GRAPH and GRAPHF are substantial packages with shared global buffers and compile-time feature switches; start from their headers and initialization routines rather than mixing calls blindly.",
-      "Prefer GRAPHF and native FLOAT for new X1Pen programs that need floating-point calculations. SOROBAN remains useful for compatibility with older SLANG sources.",
-      "SOROBAN includes single/double numeric operations, conversion, comparison, arithmetic, square root, trigonometric, exponential and logarithmic routines."
+      "Prefer GRAPHF and native FLOAT for new X1Pen programs that need floating-point calculations.",
+      "Some functions are conditional on constants in the include file. Validate the exact set used by the program."
     ],
+    "relatedIds": ["slang.x1.display-graphics", "slang.runtime.float", "slang.include.soroban", "slang.includes.catalog"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/GRAPH.LIB",
-      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/GRAPHF.LIB",
-      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/SOROBAN.LIB"
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/GRAPHF.LIB"
     ]
+  },
+  {
+    "id": "slang.runtime.float",
+    "language": "slang",
+    "kind": "runtime",
+    "title": "Native 24-bit FLOAT runtime",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["FLOAT", "ITOF", "UTOF", "FTOI", "FABS", "FACOS", "FACOSH", "FASIN", "FASINH", "FATAN", "FATANH", "FCOS", "FCOSH", "FEXP", "FLOG", "FLOG2", "FLOG10", "FLOGY", "FPOW", "FPOW2", "FPOW10", "FRAND", "FSIN", "FSINH", "FSQRT", "FTAN", "FTANH", "FL$"],
+    "aliases": ["floating point", "24-bit float", "math functions", "trigonometry", "square root", "浮動小数点", "浮動小数点関数", "実数", "三角関数", "平方根", "対数", "べき乗"],
+    "summary": "X1Pen SLANG has a native 24-bit FLOAT type and bundled conversion, trigonometric, logarithmic, power and random-number functions.",
+    "syntax": [
+      "VAR FLOAT VALUE;",
+      "ITOF(integer) UTOF(unsignedInteger) FTOI(floatValue)",
+      "FSIN(x) FCOS(x) FTAN(x) FASIN(x) FACOS(x) FATAN(x)",
+      "FEXP(x) FLOG(x) FLOG2(x) FLOG10(x) FSQRT(x)",
+      "FPOW(x,y) FPOW2(x) FPOW10(x) FRAND()"
+    ],
+    "notes": [
+      "FLOAT values occupy three bytes. FLOAT functions return values in AHL.",
+      "Integers convert to FLOAT automatically where a typed FLOAT argument is expected. FLOAT-to-integer conversion is explicit through FTOI.",
+      "Use the native FLOAT runtime for new X1Pen code. SOROBAN is primarily for compatibility with older sources."
+    ],
+    "examples": [
+      {
+        "title": "Calculate a square root with native FLOAT",
+        "source": "MAIN() BEGIN\n  VAR FLOAT VALUE;\n  VALUE=FSQRT(81.0);\n  PRINT(FL$(VALUE), /);\nEND;"
+      }
+    ],
+    "relatedIds": ["slang.data.types-declarations", "slang.functions.typed", "slang.include.graph-soroban", "slang.include.soroban", "slang.runtime.catalog"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libfloat.asm"]
+  },
+  {
+    "id": "slang.x1.display-graphics",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "X1 display and low-level graphics runtime",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["WIDTH", "PRMODE", "SCREEN", "LOCATE", "GRPSETUP", "GRDISP", "GRCLS", "LINE", "XLINE", "PAINT", "SET_PAINTBUF", "BFILL"],
+    "aliases": ["screen mode", "text screen", "graphics screen", "draw line", "paint", "画面", "画面クリア", "テキスト画面", "グラフィック画面", "線を描く", "塗りつぶし", "座標"],
+    "summary": "The bundled X1 runtime controls text width and cursor state, reads text-screen characters, and provides low-level line, XOR-line, paint and box-fill primitives.",
+    "syntax": [
+      "WIDTH(columns) PRMODE(mode) SCREEN(x,y) LOCATE(x,y)",
+      "GRPSETUP() GRDISP(enabled) GRCLS()",
+      "LINE(...) XLINE(...) PAINT(x,y,color) BFILL(...) SET_PAINTBUF(address)"
+    ],
+    "notes": [
+      "Call WIDTH before PCG setup and call GRPSETUP after selecting the intended 40/80-column mode; the line routines patch themselves for 320- or 640-dot width.",
+      "SCREEN(x,y) returns the character at the text-screen position. PRMODE is retained for source compatibility but is not supported by the LSX-Dodgers runtime and currently returns without changing mode.",
+      "SET_PAINTBUF receives the start of a 1KB work buffer. BFILL requires x2>x1 and y2>y1.",
+      "For higher-level geometry use GRAPH or GRAPHF; for game-oriented sprite rendering consider SGL or the tile libraries."
+    ],
+    "relatedIds": ["slang.output.print-strings", "slang.x1.pcg-definition", "slang.include.graph-soroban", "slang.x1.sgl", "slang.runtime.catalog"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_print.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_grp.asm"
+    ]
+  },
+  {
+    "id": "slang.x1.psg",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "X1 PSG music and sound-effects runtime",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["PSG_INIT", "PSG_PLAY", "PSG_SFX", "PSG_STOP", "PSG_PAUSE", "PSG_RESUME", "PSG_PROC", "PSG_END"],
+    "aliases": ["PSG", "AY-3-8910", "BGM", "sound effect", "play sound", "music", "音を鳴らす", "音楽", "効果音", "サウンド", "音量", "再生", "一時停止"],
+    "summary": "The X1 PSG driver plays three-channel BGM and priority-controlled sound effects, using either CTC-driven updates or explicit polling.",
+    "syntax": [
+      "PSG_INIT(mode);",
+      "PSG_PLAY(bgmAddress); PSG_SFX(sfxAddress);",
+      "PSG_STOP(); PSG_PAUSE(); PSG_RESUME(); PSG_END();",
+      "PSG_PROC();  // call periodically only in polling mode"
+    ],
+    "notes": [
+      "PSG_INIT(0) selects polling mode and requires regular PSG_PROC calls. A nonzero mode requests CTC operation and falls back to polling if CTC is unavailable.",
+      "BGM and SFX headers contain one tempo byte followed by three little-endian track addresses. Zero track addresses are allowed for SFX.",
+      "SFX playback compares the incoming priority byte with active BGM/SFX priorities before replacing channels.",
+      "Call PSG_END before abandoning an interrupt-driven driver so its CTC handler is restored."
+    ],
+    "examples": [
+      {
+        "title": "Initialize and stop the PSG polling driver",
+        "source": "MAIN() BEGIN\n  PSG_INIT(0);\n  PSG_PROC();\n  PSG_STOP();\n  PSG_END();\nEND;"
+      }
+    ],
+    "relatedIds": ["slang.x1.timing", "slang.machine.system-access", "slang.x1pen.build-profile", "slang.runtime.catalog"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_psg.asm"]
+  },
+  {
+    "id": "slang.x1.timing",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "Vertical blank and CTC timing",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["VSYNC_CHECK", "VSYNC", "VSYNC1", "SETUPCTC"],
+    "aliases": ["vertical blank", "frame timing", "CTC", "game loop", "垂直同期", "VBLANK", "フレーム待ち", "タイミング", "ゲームループ", "割り込み"],
+    "summary": "The X1 runtime exposes vertical-blank polling/wait helpers and CTC setup used by frame loops and time-based subsystems.",
+    "syntax": ["VSYNC(count);", "VSYNC1();", "VSYNC_CHECK();", "SETUPCTC();"],
+    "notes": [
+      "VSYNC waits for the requested number of counted vertical blanks and clears its internal counter afterward.",
+      "VSYNC1 waits directly for one vertical-blank transition.",
+      "Libraries can install work in the compiler's !VSYNC_PROC hook; use their documented update calls and setup order."
+    ],
+    "relatedIds": ["slang.x1.psg", "slang.include.tile-sprite", "slang.include.chiplib", "slang.x1.sgl", "slang.runtime.catalog"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_base.asm"]
+  },
+  {
+    "id": "slang.x1.assets-compression",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "Compressed data and X1 image loaders",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["LZE_DECODE", "LZEE_DECODE", "LZEEE_DECODE", "ZX0_DECODE", "MAGLOAD", "M8ALOAD"],
+    "aliases": ["decompress", "compressed data", "ZX0", "LZE", "MAG image", "M8A image", "圧縮", "圧縮データ", "展開", "画像読込", "画像ファイル", "MAG", "M8A"],
+    "summary": "X1Pen bundles LZE-family and ZX0 decompressors plus MAG and M8A image loaders for compact program assets.",
+    "syntax": [
+      "LZE_DECODE(sourceAddress,destinationAddress)",
+      "LZEE_DECODE(sourceAddress,destinationAddress)",
+      "LZEEE_DECODE(sourceAddress,destinationAddress)",
+      "ZX0_DECODE(sourceAddress,destinationAddress)",
+      "MAGLOAD(filenameAddress,x,y)",
+      "M8ALOAD(...)"
+    ],
+    "notes": [
+      "The decompressors operate on encoded byte streams and write directly to the destination address; allocate enough writable memory for the decoded result.",
+      "MAGLOAD uses LSX file operations and receives a filename, X and Y. It is intended for 200-line X1 images and reserves substantial work buffers.",
+      "M8ALOAD is a low-level format-specific loader; validate memory use and display mode with a small test before combining it with other large libraries."
+    ],
+    "relatedIds": ["slang.runtime.lsx-io-files", "slang.machine.system-access", "slang.x1.display-graphics", "slang.runtime.catalog"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libcompress.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libmag.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libm8a.asm"
+    ]
+  },
+  {
+    "id": "slang.x1.sgl",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "LSX-Dodgers X1 SGL sprite runtime",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["SGL_INIT", "SGL_DEFPAT", "SGL_SPRCREATE", "SGL_SPRDESTROY", "SGL_SPRSET", "SGL_SPRPAT", "SGL_SPRMOVE", "SGL_SPRDISP", "SGL_FPSMODE", "SGL_VSYNC", "SGL_PRINT", "SGL_PRINT2"],
+    "aliases": ["SGL", "sprite engine", "double buffering", "game library", "スプライト", "ゲームライブラリ", "ダブルバッファ", "キャラクタ移動", "ゲーム画面", "文字描画"],
+    "summary": "The loaded libx1_sgl_lsx runtime provides pattern registration, sprite lifecycle and movement, page-flipped frame synchronization, and text rendering for LSX-Dodgers games.",
+    "syntax": [
+      "SGL_INIT(); SGL_DEFPAT(patternNumber,address);",
+      "handle=SGL_SPRCREATE(patternNumber,kind); SGL_SPRDESTROY(handle);",
+      "SGL_SPRSET(handle,dataAddress); SGL_SPRPAT(handle,patternNumber);",
+      "SGL_SPRMOVE(handle,x,y); SGL_SPRDISP(handle,visible);",
+      "SGL_FPSMODE(mode); SGL_VSYNC(); SGL_PRINT(x,y,stringAddress); SGL_PRINT2(x,y,stringAddress);"
+    ],
+    "notes": [
+      "SGL_SPRCREATE returns zero on failure. Preserve nonzero handles and destroy sprites when they are no longer needed.",
+      "SGL_SPRDISP uses 0 for hidden and 1 for visible.",
+      "SGL_PRINT draws on the current render page; SGL_PRINT2 draws on both pages. SGL_VSYNC processes characters and flips the screen.",
+      "This profile loads libx1_sgl_lsx.asm, not the separate non-LSX libx1_sgl.asm file also present in the repository."
+    ],
+    "relatedIds": ["slang.x1.pcg-definition", "slang.x1.display-graphics", "slang.x1.timing", "slang.runtime.catalog"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_sgl_lsx.asm"]
+  },
+  {
+    "id": "slang.include.soroban",
+    "language": "slang",
+    "kind": "library",
+    "title": "SOROBAN compatibility numeric library",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["@SINGLE", "@DOUBLE", "@CVITF", "@CVUTF", "@CVFTI", "@CVFTU", "@CVFTS", "@CVSTF", "@CVSNG", "@CVDBL", "@SWAP", "@SETWD", "@SETOD", "@CMP", "@ADD", "@SUB", "@MUL", "@DIV", "@MOD", "@NEG", "@ABS", "@SGN", "@INT", "@FIX", "@FRAC", "@SQR", "@SIN", "@COS", "@TAN", "@ATN", "@EXP", "@LOG", "@POW", "@RAD", "@GRAD", "@PAI", "@CINT", "@ISIN", "@ICOS", "@IATN", "@IDIV", "@FUKUGEN", "@KYU"],
+    "aliases": ["SOROBAN", "legacy floating point", "numeric compatibility", "trigonometry", "そろばん", "旧浮動小数点", "数値演算", "互換ライブラリ", "三角関数"],
+    "summary": "SOROBAN.LIB supplies the older single/double numeric representation, conversion, comparison, arithmetic and transcendental routines used by historical SLANG sources.",
+    "syntax": [
+      "#INCLUDE SOROBAN.LIB",
+      "@SINGLE(...) @DOUBLE(...) @CVITF(...) @CVFTI(...)",
+      "@ADD(...) @SUB(...) @MUL(...) @DIV(...) @SQR(...)",
+      "@SIN(...) @COS(...) @TAN(...) @ATN(...) @EXP(...) @LOG(...) @POW(...)"
+    ],
+    "notes": [
+      "Prefer the compiler's native FLOAT type and libfloat functions for new X1Pen programs.",
+      "SOROBAN maintains its own numeric work representation and exposes many conditional routines. Read the include's switches before selecting functions."
+    ],
+    "relatedIds": ["slang.runtime.float", "slang.include.graph-soroban", "slang.preprocessor.includes", "slang.includes.catalog"],
+    "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_include/SOROBAN.LIB"]
   },
   {
     "id": "slang.x1pen.build-profile",
@@ -387,7 +607,8 @@
     "kind": "profile",
     "title": "X1Pen compiler and LSX-Dodgers build profile",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["compiler revision", "c9e8f53", "ENV_TYPE 1", "ORG 0100", "generated ASM", "LSX"],
+    "symbols": ["ENV_TYPE", "OS_TYPE", "ORG", "PROGRAM.BIN"],
+    "aliases": ["compiler revision", "c9e8f53", "ENV_TYPE 1", "ORG 0100", "generated ASM", "LSX", "LSX-Dodgers", "ビルド環境", "コンパイラ版", "生成ASM", "実行環境"],
     "summary": "X1Pen uses SLANG compiler snapshot c9e8f53, compiles with ENV_TYPE=1 and default ORG=$0100, assembles the generated Z80 source, then runs it under LSX-Dodgers.",
     "syntax": [
       "ENV_TYPE = 1",
@@ -399,6 +620,7 @@
       "x1pen_validate compiles SLANG and assembles its generated output without running it.",
       "The MCP reference profile is tied to the exact compiler commit c9e8f5315d8d44a413368045d78439a4ec8da3fc."
     ],
+    "relatedIds": ["slang.preprocessor.includes", "slang.program.structure", "slang.compiler.catalog", "slang.runtime.catalog", "slang.includes.catalog"],
     "sourceUrls": [
       "https://github.com/h-o-soft/SLANG-compiler/tree/c9e8f5315d8d44a413368045d78439a4ec8da3fc",
       "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen.js"
@@ -410,7 +632,8 @@
     "kind": "limits",
     "title": "Compiler limits and common mistakes",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "aliases": ["limitations", "errors", "gotchas", "array size", "whitespace", "FOR executes once"],
+    "symbols": ["CALL", "ARRAY", "FTOI", "FOR", "#INCLUDE"],
+    "aliases": ["limitations", "errors", "gotchas", "array size", "whitespace", "FOR executes once", "制限", "エラー", "よくある間違い", "配列サイズ", "空白", "メモリ不足"],
     "summary": "Keep function names attached to '(', array names attached to '[', remember that array bounds are inclusive, and stay within compiler nesting and storage limits.",
     "syntax": [
       "CALL()     // valid",
@@ -424,6 +647,7 @@
       "FLOAT-to-integer conversion is not implicit; use FTOI.",
       "Validate frequently because included libraries consume memory and may impose initialization or buffer-address requirements not expressed by the language type system."
     ],
+    "relatedIds": ["slang.program.structure", "slang.data.types-declarations", "slang.control.flow", "slang.x1pen.build-profile"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
   }
 ]

--- a/mcp/x1pen-reference.mjs
+++ b/mcp/x1pen-reference.mjs
@@ -5,6 +5,7 @@ const MANIFEST = readJson('manifest.json');
 const ENTRIES = Object.freeze([
   ...readJson('fuzzybasic.json'),
   ...readJson('slang.json'),
+  ...readJson('slang-catalogs.json'),
 ]);
 const ENTRY_BY_ID = new Map(ENTRIES.map((entry) => [entry.id, entry]));
 
@@ -147,8 +148,8 @@ export function validateReferenceData() {
         if (!profileIds.has(profile)) errors.push(`${entry.id}: unknown profile ${profile}`);
       }
     }
-    if (entry.language === 'fuzzybasic' && (!Array.isArray(entry.symbols) || entry.symbols.length === 0)) {
-      errors.push(`${entry.id}: FuzzyBASIC entries must declare symbols`);
+    if (!Array.isArray(entry.symbols) || entry.symbols.length === 0) {
+      errors.push(`${entry.id}: schema v2 entries must declare symbols`);
     }
     for (const field of ['symbols', 'aliases', 'relatedIds', 'sourceUrls']) {
       if (entry[field] !== undefined && (!Array.isArray(entry[field])

--- a/mcp/x1pen-reference.mjs
+++ b/mcp/x1pen-reference.mjs
@@ -72,13 +72,40 @@ export function getReferenceManifest() {
 export function searchReference({ language, query, profile, kinds, maxResults = 8 }) {
   const normalizedQuery = normalize(query);
   const queryTokens = [...new Set(normalizedQuery.split(/\s+/).filter(Boolean))];
-  if (queryTokens.length === 0) throw new Error('query must contain searchable characters');
-
   const allowedKinds = kinds ? new Set(kinds) : null;
   const candidates = ENTRIES
     .filter((entry) => (!language || entry.language === language)
       && matchesProfile(entry, profile)
       && (!allowedKinds || allowedKinds.has(entry.kind)));
+
+  // Punctuation-only operators are intentionally removed by normalize() so
+  // they cannot change ordinary token boundaries. Match those symbols exactly
+  // against the raw query instead, preferring a dedicated entry to a catalog.
+  if (queryTokens.length === 0) {
+    const rawQuery = String(query || '').trim();
+    const symbolMatches = candidates
+      .filter((entry) => (entry.symbols || []).includes(rawQuery))
+      .sort((left, right) => Number(left.kind === 'catalog') - Number(right.kind === 'catalog')
+        || left.id.localeCompare(right.id));
+    if (symbolMatches.length === 0) throw new Error('query must contain searchable characters');
+    return {
+      query,
+      matchMode: 'symbol',
+      ...(language ? { language } : {}),
+      ...(profile ? { profile } : {}),
+      totalMatches: symbolMatches.length,
+      matches: symbolMatches.slice(0, maxResults).map((entry) => ({
+        id: entry.id,
+        language: entry.language,
+        kind: entry.kind,
+        title: entry.title,
+        summary: entry.summary,
+        score: entry.kind === 'catalog' ? 119 : 120,
+      })),
+      truncated: symbolMatches.length > maxResults,
+    };
+  }
+
   const score = (requireAllTokens) => candidates
     .map((entry) => ({ entry, score: scoreEntry(entry, normalizedQuery, queryTokens, requireAllTokens) }))
     .filter(({ score }) => score > 0)

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -43,6 +43,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'package.json',
       'reference/fuzzybasic.json',
       'reference/manifest.json',
+      'reference/slang-catalogs.json',
       'reference/slang.json',
       'x1pen-bridge.mjs',
       'x1pen-reference.mjs',
@@ -60,7 +61,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.4.0');
+    assert.equal(manifest.version, '2.5.0');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -182,7 +182,7 @@ test('language reference tools search compact results and fetch selected details
     arguments: { language: 'slang', query: 'TILE_SET_SCROLL' },
   });
   const search = jsonContent(searchResult);
-  assert.equal(search.totalMatches, 1);
+  assert.ok(search.totalMatches >= 1);
   assert.equal(search.matches[0].id, 'slang.include.tile-sprite');
   assert.equal(search.matches[0].syntax, undefined);
 

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -194,6 +194,14 @@ test('language reference tools search compact results and fetch selected details
   assert.equal(detail.entries[0].id, 'slang.include.tile-sprite');
   assert.ok(detail.entries[0].syntax.some((line) => line.includes('TILE_SET_SCROLL')));
   assert.equal(detail.truncated, false);
+
+  const symbolResult = await client.callTool({
+    name: 'x1pen_search_reference',
+    arguments: { language: 'slang', query: '!=' },
+  });
+  const symbolSearch = jsonContent(symbolResult);
+  assert.equal(symbolSearch.matchMode, 'symbol');
+  assert.equal(symbolSearch.matches[0].id, 'slang.expressions.operators');
 });
 
 test('language profile reports bundled data and connected X1Pen compatibility', async () => {

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
@@ -19,22 +19,43 @@ function loadBrowserGlobal(filename, exportName) {
 }
 
 function loadSlangVfs() {
+  const x1penSource = readFileSync(join(repoRoot, 'html/x1pen.js'), 'utf8');
   const vfs = {};
-  for (const directory of ['assets/slang_runtime', 'assets/slang_include']) {
-    for (const filename of readdirSync(join(repoRoot, directory))) {
-      if (/\.(?:asm|lib)$/i.test(filename)) {
-        vfs[filename] = readFileSync(join(repoRoot, directory, filename), 'utf8');
-      }
+  for (const [variable, directory] of [
+    ['runtimeFiles', 'assets/slang_runtime'],
+    ['includeFiles', 'assets/slang_include'],
+  ]) {
+    for (const filename of extractVfsFiles(x1penSource, variable)) {
+      vfs[filename] = readFileSync(join(repoRoot, directory, filename), 'utf8');
     }
   }
   return vfs;
+}
+
+function extractVfsFiles(source, variable) {
+  const block = source.match(new RegExp(`var ${variable} = \\[([\\s\\S]*?)\\n\\s*\\];`));
+  assert.ok(block, `${variable} must be present in x1pen.js`);
+  return [...block[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+function extractSlangIncludeSymbols(source) {
+  const symbols = new Set();
+  for (const block of source.matchAll(/^MACHINE\b([\s\S]*?);/gmi)) {
+    for (const match of block[1].matchAll(/([@A-Za-z_][@A-Za-z0-9_$^]*)\s*\(/g)) {
+      symbols.add(match[1]);
+    }
+  }
+  for (const match of source.matchAll(/^([@A-Za-z_][@A-Za-z0-9_$^]*)\s*(?::(?:BYTE|WORD|FLOAT))?\s*\([^;\n]*\)/gmi)) {
+    symbols.add(match[1]);
+  }
+  return symbols;
 }
 
 test('reference data has unique IDs and known profiles', () => {
   const validation = validateReferenceData();
   assert.deepEqual(validation.errors, []);
   assert.equal(validation.manifest.schemaVersion, 2);
-  assert.ok(validation.entries.length >= 40);
+  assert.ok(validation.entries.length >= 50);
 });
 
 test('reference search is deterministic, filtered and summary-only', () => {
@@ -86,12 +107,38 @@ test('representative Japanese and English queries reach dedicated FuzzyBASIC ent
   }
 });
 
+test('representative Japanese and English queries reach dedicated SLANG entries', () => {
+  const cases = new Map([
+    ['浮動小数点関数', 'slang.runtime.float'],
+    ['square root', 'slang.runtime.float'],
+    ['マシン語', 'slang.machine.calling-convention'],
+    ['メモリ配列', 'slang.machine.system-access'],
+    ['ファイルを読む', 'slang.runtime.lsx-io-files'],
+    ['open file', 'slang.runtime.lsx-io-files'],
+    ['音を鳴らす', 'slang.x1.psg'],
+    ['play sound', 'slang.x1.psg'],
+    ['タイルマップ', 'slang.include.tile-sprite'],
+    ['線を描く', 'slang.include.graph-soroban'],
+    ['圧縮データ', 'slang.x1.assets-compression'],
+    ['垂直同期', 'slang.x1.timing'],
+    ['ゲームライブラリ', 'slang.x1.sgl'],
+  ]);
+
+  for (const [query, expectedId] of cases) {
+    const result = searchReference({ language: 'slang', query, maxResults: 3 });
+    assert.equal(result.matches[0]?.id, expectedId, query);
+  }
+});
+
 test('dedicated entries rank above the exhaustive keyword catalog', () => {
-  for (const [query, expectedId] of [
-    ['CIRCLE', 'fuzzybasic.x1.graphics-magic'],
-    ['PEEK POKE', 'fuzzybasic.machine.memory-io'],
+  for (const [language, query, expectedId] of [
+    ['fuzzybasic', 'CIRCLE', 'fuzzybasic.x1.graphics-magic'],
+    ['fuzzybasic', 'PEEK POKE', 'fuzzybasic.machine.memory-io'],
+    ['slang', 'PSG_INIT', 'slang.x1.psg'],
+    ['slang', 'TILE_SET_SCROLL', 'slang.include.tile-sprite'],
+    ['slang', 'FSQRT', 'slang.runtime.float'],
   ]) {
-    const result = searchReference({ language: 'fuzzybasic', query, maxResults: 3 });
+    const result = searchReference({ language, query, maxResults: 3 });
     assert.equal(result.matches[0]?.id, expectedId, query);
   }
 });
@@ -134,6 +181,21 @@ test('every FuzzyBASIC reference entry is reachable through relatedIds', () => {
   );
 });
 
+test('every SLANG reference entry is reachable through relatedIds', () => {
+  const entries = validateReferenceData().entries
+    .filter((entry) => entry.language === 'slang');
+  const incoming = new Map(entries.map((entry) => [entry.id, 0]));
+  for (const entry of entries) {
+    for (const relatedId of entry.relatedIds || []) {
+      if (incoming.has(relatedId)) incoming.set(relatedId, incoming.get(relatedId) + 1);
+    }
+  }
+  assert.deepEqual(
+    [...incoming].filter(([, count]) => count === 0).map(([id]) => id),
+    [],
+  );
+});
+
 test('every X1Pen FuzzyBASIC tokenizer keyword is covered by symbols', () => {
   const tokenizerSource = readFileSync(join(repoRoot, 'html/x1pen_tokenizer.js'), 'utf8');
   const table = tokenizerSource.match(/var RSVTBL = \[([\s\S]*?)\n\s*\];/);
@@ -149,6 +211,47 @@ test('every X1Pen FuzzyBASIC tokenizer keyword is covered by symbols', () => {
     .flatMap((entry) => entry.symbols));
   for (const keyword of new Set(keywords)) {
     assert.ok(documented.has(keyword), `${keyword} must be covered by a dedicated FuzzyBASIC entry`);
+  }
+});
+
+test('every X1Pen SLANG compiler keyword is covered by a dedicated entry', () => {
+  const compilerSource = readFileSync(join(repoRoot, 'html/x1pen_slang_compiler.js'), 'utf8');
+  const keywordBlock = compilerSource.match(/var kw = \{([\s\S]*?)\n\s*\};/);
+  const stringBlock = compilerSource.match(/var STRING_FUNCS = new Set\(\[([\s\S]*?)\]\);/);
+  assert.ok(keywordBlock, 'SLANG keyword table must be present');
+  assert.ok(stringBlock, 'SLANG string function table must be present');
+  const keywords = [...keywordBlock[1].matchAll(/\b([A-Z][A-Z0-9]*)\s*:/g)]
+    .map((match) => match[1]);
+  const stringFunctions = [...stringBlock[1].matchAll(/'([^']+)'/g)]
+    .map((match) => match[1]);
+  assert.ok(keywords.length >= 45);
+
+  const documented = new Set(validateReferenceData().entries
+    .filter((entry) => entry.language === 'slang' && entry.kind !== 'catalog')
+    .flatMap((entry) => entry.symbols));
+  for (const symbol of new Set([...keywords, ...stringFunctions])) {
+    assert.ok(documented.has(symbol), `${symbol} must be covered by a dedicated SLANG entry`);
+  }
+});
+
+test('SLANG catalogs cover the exact runtime and include files loaded by X1Pen', () => {
+  const x1penSource = readFileSync(join(repoRoot, 'html/x1pen.js'), 'utf8');
+  const entries = validateReferenceData().entries;
+  const runtimeCatalog = new Set(entries.find((entry) => entry.id === 'slang.runtime.catalog').symbols);
+  const includeCatalog = new Set(entries.find((entry) => entry.id === 'slang.includes.catalog').symbols);
+
+  for (const filename of extractVfsFiles(x1penSource, 'runtimeFiles')) {
+    const source = readFileSync(join(repoRoot, 'assets/slang_runtime', filename), 'utf8');
+    for (const match of source.matchAll(/^; @(?:name|alias) (\S+)/gm)) {
+      assert.ok(runtimeCatalog.has(match[1]), `${match[1]} from ${filename} must be in the runtime catalog`);
+    }
+  }
+
+  for (const filename of extractVfsFiles(x1penSource, 'includeFiles')) {
+    const source = readFileSync(join(repoRoot, 'assets/slang_include', filename), 'utf8');
+    for (const symbol of extractSlangIncludeSymbols(source)) {
+      assert.ok(includeCatalog.has(symbol), `${symbol} from ${filename} must be in the include catalog`);
+    }
   }
 });
 
@@ -181,7 +284,7 @@ test('bundled SLANG examples compile with the exact X1Pen compiler and VFS', () 
   const examples = entries
     .filter((entry) => entry.language === 'slang')
     .flatMap((entry) => entry.examples || []);
-  assert.ok(examples.length >= 2);
+  assert.ok(examples.length >= 6);
   for (const example of examples) {
     const result = compiler.compile(example.source, vfs, {
       defaultOrg: 0x100,
@@ -200,16 +303,25 @@ test('documented include API names exist in the bundled libraries', () => {
     'TILELIB.LIB': ['TILE_INIT', 'TILE_SET_SCROLL', 'TILE_INVALIDATE'],
     'TILESPR.LIB': ['TILE_SYNC_SPR_PAGE'],
     'UILIB.LIB': ['UI_AT', 'UI_PUTS', 'UI_BOX'],
+    'GRAPH.LIB': ['@INIT', '@LINE', '@CIRCLE'],
+    'GRAPHF.LIB': ['@LINEC', '@TRIANGLEC', '@CIRCLEC'],
+    'SOROBAN.LIB': ['@SINGLE', '@ADD', '@SQR'],
   };
   const documented = JSON.stringify(getReferenceEntries({
-    ids: ['slang.include.tile-sprite', 'slang.include.chiplib', 'slang.include.ui'],
+    ids: [
+      'slang.include.tile-sprite',
+      'slang.include.chiplib',
+      'slang.include.ui',
+      'slang.include.graph-soroban',
+      'slang.include.soroban',
+    ],
     maxCharacters: 32 * 1024,
   }).entries);
 
   for (const [filename, names] of Object.entries(selectedApis)) {
     const source = readFileSync(join(repoRoot, 'assets/slang_include', filename), 'utf8');
     for (const name of names) {
-      assert.match(source, new RegExp(`\\b${name}\\b`), `${name} must exist in ${filename}`);
+      assert.ok(source.includes(name), `${name} must exist in ${filename}`);
       assert.ok(documented.includes(name), `${name} must be covered by the reference`);
     }
   }

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -84,6 +84,21 @@ test('reference search finds exact symbols and falls back to partial terms', () 
   assert.equal(partial.matches[0].id, 'fuzzybasic.memory.arrays');
 });
 
+test('reference search matches punctuation-only symbols without changing token normalization', () => {
+  for (const [language, query, expectedId] of [
+    ['slang', '!=', 'slang.expressions.operators'],
+    ['slang', '<<', 'slang.expressions.operators'],
+    ['slang', '<>', 'slang.expressions.operators'],
+    ['fuzzybasic', '<=', 'fuzzybasic.values.operators'],
+    ['fuzzybasic', '>=', 'fuzzybasic.values.operators'],
+  ]) {
+    const result = searchReference({ language, query, maxResults: 3 });
+    assert.equal(result.matchMode, 'symbol', query);
+    assert.equal(result.matches[0]?.id, expectedId, query);
+  }
+  assert.throws(() => searchReference({ query: '   ' }), /searchable characters/);
+});
+
 test('representative Japanese and English queries reach dedicated FuzzyBASIC entries', () => {
   const cases = new Map([
     ['PSG 音を鳴らす', 'fuzzybasic.x1.sound'],
@@ -239,10 +254,13 @@ test('SLANG catalogs cover the exact runtime and include files loaded by X1Pen',
   const entries = validateReferenceData().entries;
   const runtimeCatalog = new Set(entries.find((entry) => entry.id === 'slang.runtime.catalog').symbols);
   const includeCatalog = new Set(entries.find((entry) => entry.id === 'slang.includes.catalog').symbols);
+  const runtimeImplementation = new Set();
+  const includeImplementation = new Set();
 
   for (const filename of extractVfsFiles(x1penSource, 'runtimeFiles')) {
     const source = readFileSync(join(repoRoot, 'assets/slang_runtime', filename), 'utf8');
     for (const match of source.matchAll(/^; @(?:name|alias) (\S+)/gm)) {
+      runtimeImplementation.add(match[1]);
       assert.ok(runtimeCatalog.has(match[1]), `${match[1]} from ${filename} must be in the runtime catalog`);
     }
   }
@@ -250,9 +268,21 @@ test('SLANG catalogs cover the exact runtime and include files loaded by X1Pen',
   for (const filename of extractVfsFiles(x1penSource, 'includeFiles')) {
     const source = readFileSync(join(repoRoot, 'assets/slang_include', filename), 'utf8');
     for (const symbol of extractSlangIncludeSymbols(source)) {
+      includeImplementation.add(symbol);
       assert.ok(includeCatalog.has(symbol), `${symbol} from ${filename} must be in the include catalog`);
     }
   }
+
+  assert.deepEqual(
+    [...runtimeCatalog].filter((symbol) => !runtimeImplementation.has(symbol)),
+    [],
+    'runtime catalog must not include symbols outside the loaded VFS files',
+  );
+  assert.deepEqual(
+    [...includeCatalog].filter((symbol) => !includeImplementation.has(symbol)),
+    [],
+    'include catalog must not include symbols outside the loaded VFS files',
+  );
 });
 
 test('LSX-Dodgers-specific file limitations are documented', () => {


### PR DESCRIPTION
## Summary
- expand the SLANG reference with schema v2 symbols, Japanese/English aliases, related-entry navigation, and dedicated runtime/library topics
- add exhaustive compiler, runtime, and include catalogs derived from the exact browser compiler and X1Pen VFS inputs
- support punctuation-only symbol searches such as !=, <<, <=, and >= without changing ordinary token normalization
- validate compiler vocabulary, bidirectional loaded runtime/include catalog coverage, search ranking, graph reachability, and bundled examples against the current implementation
- bump the independently published MCP package to 2.5.0 and update setup documentation

## Verification
- npm run test:mcp (32/32)
- npm run test:mcp-package (1/1)
- git diff --check

Closes #65