### PR TITLE
docs: follow latest x1pen-mcp release

### DIFF
--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -98,7 +98,7 @@ The loopback WebSocket uses `ws://127.0.0.1`. Chrome Web Store policy explicitly
 No account or paid feature is required.
 
 1. Install Node.js 20 or later.
-2. Run `npx -y x1pen-mcp@2.5.0` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
+2. Run `npx -y x1pen-mcp@latest` in a terminal. Keep it running and note the bridge port and six-digit pairing code printed to standard error.
 3. Open `https://x1.onoda-pro.com/x1pen` in Chrome and wait for the editor to become ready.
 4. Open X1Pen Connector, enter the displayed port and pairing code, review and accept the disclosure, then click `Connect this tab`.
 5. Confirm the extension badge shows `1` and X1Pen shows `MCP Connected`.

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -13,7 +13,7 @@ Node.js 20以降が必要です。通信はstdioと`127.0.0.1`だけを使用し
 
 ## セットアップ
 
-MCPサーバーはnpmパッケージとしてX1Pen本体から独立して配布します。MCPサーバーを動かすために、このリポジトリをcloneする必要はありません。予期しない自動更新を避けるため、設定ではバージョンを固定します。
+MCPサーバーはnpmパッケージとしてX1Pen本体から独立して配布します。MCPサーバーを動かすために、このリポジトリをcloneする必要はありません。最新版へ追従するため、設定ではnpmの`latest`タグを指定します。更新を反映するにはCodexまたはClaude Codeを再起動してください。
 
 ### Codex
 
@@ -22,7 +22,7 @@ CodexのMCP設定に以下を追加します。
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.5.0"]
+args = ["-y", "x1pen-mcp@latest"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -35,7 +35,7 @@ userスコープへ登録すると、任意のプロジェクトからX1Penを�
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.5.0
+  npx -y x1pen-mcp@latest
 claude mcp list
 ```
 
@@ -47,7 +47,7 @@ claude mcp list
     "x1pen": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "x1pen-mcp@2.5.0"]
+      "args": ["-y", "x1pen-mcp@latest"]
     }
   }
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,12 +6,12 @@ The server communicates only through stdio and `127.0.0.1`. It requires Node.js 
 
 ## Codex
 
-Add the following server to your Codex MCP configuration. Pinning the version prevents an unexpected update during startup.
+Add the following server to your Codex MCP configuration. The `latest` tag keeps newly started MCP processes on the current release. Restart Codex after an `x1pen-mcp` update to use it.
 
 ```toml
 [mcp_servers.x1pen]
 command = "npx"
-args = ["-y", "x1pen-mcp@2.5.0"]
+args = ["-y", "x1pen-mcp@latest"]
 startup_timeout_sec = 30
 tool_timeout_sec = 60
 ```
@@ -22,7 +22,7 @@ Register the server at user scope to make it available from any project.
 
 ```bash
 claude mcp add --transport stdio --scope user x1pen -- \
-  npx -y x1pen-mcp@2.5.0
+  npx -y x1pen-mcp@latest
 ```
 
 Use `claude mcp list` or `/mcp` to check the connection.


### PR DESCRIPTION
## Summary
- use `x1pen-mcp@latest` in Codex, Claude Code, and project MCP examples
- document that restarting the MCP client picks up a newly published server release
- align Chrome Web Store reviewer instructions with the latest-tag setup

## Verification
- `npm run test:mcp-package`
- `git diff --check`