### PR TITLE
fix: apply connector updates while paired

### DIFF
--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -9,7 +9,7 @@ npm run test:extension-package
 npm run pack:extension
 ```
 
-Upload `dist/x1pen-connector-1.1.0.zip`. The ZIP has `manifest.json` at its root and excludes source artwork, README files, and Store-only images.
+Upload `dist/x1pen-connector-1.1.1.zip`. The ZIP has `manifest.json` at its root and excludes source artwork, README files, and Store-only images.
 
 ## Store listing
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "ja",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -1,4 +1,5 @@
 import { invokeX1PenInPage } from './page-automation.mjs';
+import { createUpdateCoordinator } from './update-coordinator.mjs';
 
 const connectedTabs = new Map();
 let bridgeConfig = null;
@@ -7,7 +8,14 @@ let paired = false;
 let connectPromise = null;
 let reconnectTimer = null;
 
-initialize();
+const updateCoordinator = createUpdateCoordinator({
+  prepare: prepareForUpdate,
+  reload: () => chrome.runtime.reload(),
+  onError: (error) => console.warn('Failed to cleanly disconnect before extension update:', error),
+});
+
+chrome.runtime.onUpdateAvailable.addListener(() => updateCoordinator.requestUpdate());
+updateCoordinator.run(initialize).catch(() => {});
 
 async function initialize() {
   const stored = await chrome.storage.local.get('bridgeConfig');
@@ -19,7 +27,7 @@ async function initialize() {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  handlePopupMessage(message).then(
+  updateCoordinator.run(() => handlePopupMessage(message)).then(
     (result) => sendResponse({ ok: true, result }),
     (error) => sendResponse({ ok: false, error: error.message || String(error) }),
   );
@@ -115,7 +123,7 @@ async function connectBridge() {
         sendSessions();
         resolve();
       } else if (message.type === 'command') {
-        handleCommand(message);
+        updateCoordinator.run(() => handleCommand(message)).catch(() => {});
       } else if (message.type === 'ping') {
         ws.send(JSON.stringify({ type: 'pong', timestamp: message.timestamp }));
       }
@@ -143,17 +151,33 @@ async function connectBridge() {
 }
 
 function scheduleReconnect() {
-  if (!bridgeConfig || connectedTabs.size === 0 || reconnectTimer) return;
+  if (updateCoordinator.isUpdatePending() || !bridgeConfig || connectedTabs.size === 0 || reconnectTimer) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    connectBridge().then(async () => {
+    updateCoordinator.run(async () => {
+      await connectBridge();
       for (const session of connectedTabs.values()) {
         await invokeX1Pen(session.tabId, 'connection', { connected: true }).catch(() => {});
       }
       await refreshSessions();
       sendSessions();
-    }).catch(scheduleReconnect);
+    }).catch(() => {
+      if (!updateCoordinator.isUpdatePending()) scheduleReconnect();
+    });
   }, 2_000);
+}
+
+async function prepareForUpdate() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  await Promise.allSettled(Array.from(connectedTabs.values(), (session) =>
+    invokeX1Pen(session.tabId, 'connection', { connected: false })));
+  const activeSocket = socket;
+  socket = null;
+  paired = false;
+  if (activeSocket) activeSocket.close(1012, 'Applying X1Pen Connector update');
 }
 
 async function handleCommand(message) {

--- a/extension/update-coordinator.mjs
+++ b/extension/update-coordinator.mjs
@@ -1,0 +1,44 @@
+export function createUpdateCoordinator({ prepare, reload, schedule, onError }) {
+  const scheduleTask = schedule || ((callback) => setTimeout(callback, 0));
+  const reportError = onError || (() => {});
+  let updatePending = false;
+  let activeOperations = 0;
+  let applyScheduled = false;
+  let applyingUpdate = false;
+
+  const applyWhenIdle = async () => {
+    applyScheduled = false;
+    if (!updatePending || activeOperations > 0 || applyingUpdate) return;
+    applyingUpdate = true;
+    try {
+      await prepare();
+    } catch (error) {
+      reportError(error);
+    } finally {
+      reload();
+    }
+  };
+
+  const scheduleApply = () => {
+    if (!updatePending || applyScheduled || applyingUpdate) return;
+    applyScheduled = true;
+    scheduleTask(applyWhenIdle);
+  };
+
+  return Object.freeze({
+    run: async (operation) => {
+      activeOperations++;
+      try {
+        return await operation();
+      } finally {
+        activeOperations--;
+        scheduleApply();
+      }
+    },
+    requestUpdate: () => {
+      updatePending = true;
+      scheduleApply();
+    },
+    isUpdatePending: () => updatePending,
+  });
+}

--- a/scripts/package-x1pen-connector.sh
+++ b/scripts/package-x1pen-connector.sh
@@ -15,7 +15,7 @@ staging=$(mktemp -d "${TMPDIR:-/tmp}/x1pen-connector.XXXXXX")
 trap 'rm -rf "$staging"' EXIT HUP INT TERM
 
 mkdir -p "$staging/icons" "$(dirname -- "$output")"
-for file in manifest.json popup.html popup.css popup.js service-worker.js page-automation.mjs; do
+for file in manifest.json popup.html popup.css popup.js service-worker.js page-automation.mjs update-coordinator.mjs; do
   cp "$repo_root/extension/$file" "$staging/$file"
 done
 for size in 16 32 48 128; do

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 import { invokeX1PenInPage } from '../extension/page-automation.mjs';
+import { createUpdateCoordinator } from '../extension/update-coordinator.mjs';
 
 afterEach(() => {
   delete globalThis.window;
@@ -105,4 +106,52 @@ test('page bridge rejects debugger calls when capability is unavailable', async 
   api.getStatus = () => ({ capabilities: { debugger: { available: false, runPending: false } } });
   globalThis.window = { X1PenAutomation: api };
   await assert.rejects(invokeX1PenInPage('debuggerGetState', {}), /does not provide the debugger API/);
+});
+
+test('extension update waits for active operations before disconnecting and reloading', async () => {
+  const scheduled = [];
+  const timeline = [];
+  let finishOperation;
+  const operationGate = new Promise((resolve) => { finishOperation = resolve; });
+  const coordinator = createUpdateCoordinator({
+    prepare: async () => { timeline.push('prepare'); },
+    reload: () => { timeline.push('reload'); },
+    schedule: (callback) => scheduled.push(callback),
+  });
+
+  const operation = coordinator.run(async () => {
+    timeline.push('operation:start');
+    await operationGate;
+    timeline.push('operation:end');
+  });
+  coordinator.requestUpdate();
+  coordinator.requestUpdate();
+  assert.equal(coordinator.isUpdatePending(), true);
+  assert.equal(scheduled.length, 1);
+
+  await scheduled.shift()();
+  assert.deepEqual(timeline, ['operation:start']);
+
+  finishOperation();
+  await operation;
+  assert.equal(scheduled.length, 1);
+  await scheduled.shift()();
+  assert.deepEqual(timeline, ['operation:start', 'operation:end', 'prepare', 'reload']);
+});
+
+test('extension update reloads even when disconnect cleanup fails', async () => {
+  const scheduled = [];
+  const errors = [];
+  let reloads = 0;
+  const coordinator = createUpdateCoordinator({
+    prepare: async () => { throw new Error('disconnect failed'); },
+    reload: () => { reloads++; },
+    schedule: (callback) => scheduled.push(callback),
+    onError: (error) => errors.push(error.message),
+  });
+
+  coordinator.requestUpdate();
+  await scheduled.shift()();
+  assert.deepEqual(errors, ['disconnect failed']);
+  assert.equal(reloads, 1);
 });

--- a/tests/x1pen_extension_package_test.mjs
+++ b/tests/x1pen_extension_package_test.mjs
@@ -44,11 +44,12 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
       'popup.html',
       'popup.js',
       'service-worker.js',
+      'update-coordinator.mjs',
     ]);
 
     const manifest = JSON.parse(run('unzip', ['-p', zipPath, 'manifest.json']));
     assert.equal(manifest.manifest_version, 3);
-    assert.equal(manifest.version, '1.1.0');
+    assert.equal(manifest.version, '1.1.1');
     assert.equal(manifest.default_locale, 'ja');
     assert.equal(manifest.name, '__MSG_extensionName__');
     assert.equal(manifest.description, '__MSG_extensionDescription__');
@@ -56,6 +57,10 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
     assert.equal(manifest.host_permissions, undefined);
     assert.match(manifest.content_security_policy.extension_pages, /ws:\/\/127\.0\.0\.1:\*/);
     assert.doesNotMatch(manifest.content_security_policy.extension_pages, /https?:\/\//);
+
+    const serviceWorker = run('unzip', ['-p', zipPath, 'service-worker.js']);
+    assert.match(serviceWorker, /chrome\.runtime\.onUpdateAvailable\.addListener/);
+    assert.match(serviceWorker, /updateCoordinator\.run/);
 
     const jaMessages = JSON.parse(run('unzip', ['-p', zipPath, '_locales/ja/messages.json']));
     const enMessages = JSON.parse(run('unzip', ['-p', zipPath, '_locales/en/messages.json']));


### PR DESCRIPTION
## Summary
- listen for `chrome.runtime.onUpdateAvailable` so a persistent MCP WebSocket cannot indefinitely defer an installed Connector update
- wait for active popup or MCP operations to finish before disconnecting tabs, closing the bridge, and reloading the extension
- suppress reconnect attempts once an update is pending
- bump X1Pen Connector to 1.1.1 and include the update coordinator in the Store ZIP

## Context
Connector 1.0.1 remained installed after 1.1.0 was published because the paired Manifest V3 service worker receives WebSocket traffic continuously and may not become idle. This produced a misleading state where the current X1Pen advertised debugger capability but the old Connector could not route debugger RPCs.

## Verification
- `npm run test:extension-package` (5/5)
- `node --check extension/service-worker.js`
- `node --check extension/update-coordinator.mjs`
- `git diff --check`

The extension permissions and data handling are unchanged.