### PR TITLE
Expose X1 VRAM debugger through MCP

### DIFF
--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -9,7 +9,7 @@ npm run test:extension-package
 npm run pack:extension
 ```
 
-Upload `dist/x1pen-connector-1.1.1.zip`. The ZIP has `manifest.json` at its root and excludes source artwork, README files, and Store-only images.
+Upload `dist/x1pen-connector-1.2.0.zip`. The ZIP has `manifest.json` at its root and excludes source artwork, README files, and Store-only images.
 
 ## Store listing
 
@@ -28,7 +28,7 @@ Connect the active X1Pen tab to a local MCP server for AI-assisted FuzzyBASIC an
 
 X1Pen Connector links the X1Pen tab you explicitly select to an x1pen-mcp server running on the same computer. A configured MCP client such as Codex or Claude Code can then assist with FuzzyBASIC and SLANG development in the X1Pen editor you can see and edit yourself.
 
-The connection handles the selected tab's title and URL, requested source, validation results, execution and debugger state, requested emulator memory ranges, and emulator screen captures. Supported operations include reading and editing source, validating programs, running and stopping programs, and controlling the Z80 debugger. Access starts only after you open the extension popup, review the data-access disclosure, enter the local bridge port and pairing code, and choose "Connect this tab." The port and pairing code are stored locally so the requested connection can be restored.
+The connection handles the selected tab's title and URL, requested source, validation results, execution, debugger and video state, requested CPU and video memory ranges, paused video-memory changes, and emulator screen captures. Supported operations include reading and editing source, validating programs, running and stopping programs, and controlling the Z80 debugger. Access starts only after you open the extension popup, review the data-access disclosure, enter the local bridge port and pairing code, and choose "Connect this tab." The port and pairing code are stored locally so the requested connection can be restored.
 
 The extension communicates with the paired local bridge at 127.0.0.1. It does not contain advertising, analytics, or tracking, and it does not send data to a server operated by the extension developer. Your configured MCP client may send requested X1Pen data to its AI provider under that provider's terms and privacy policy.
 
@@ -49,7 +49,7 @@ X1PenのタブをローカルMCPサーバーへ接続し、AIによるFuzzyBASIC
 
 X1Pen Connectorは、明示的に選択したX1Penタブを、同じコンピューターで動作するx1pen-mcpサーバーへ接続します。CodexやClaude CodeなどのMCPクライアントが、人間も操作できるX1Penエディター上でFuzzyBASIC・SLANGプログラムの作成を支援できます。
 
-選択したタブのタイトルとURL、要求されたソース、検証結果、実行・デバッガ状態、要求されたエミュレータメモリ範囲、エミュレーター画面を取り扱い、ソースの読み書き、検証、実行・停止、Z80デバッガ操作に対応します。拡張機能のポップアップでデータ取扱いの説明を確認し、ローカル接続情報を入力して「Connect this tab」を押したタブだけにアクセスします。ポートとペアリングコードは、要求された接続を復元するためローカルへ保存します。
+選択したタブのタイトルとURL、要求されたソース、検証結果、実行・デバッガ・ビデオ状態、要求されたCPU／ビデオメモリ範囲、停止中のビデオメモリ変更、エミュレーター画面を取り扱い、ソースの読み書き、検証、実行・停止、Z80デバッガ操作に対応します。拡張機能のポップアップでデータ取扱いの説明を確認し、ローカル接続情報を入力して「Connect this tab」を押したタブだけにアクセスします。ポートとペアリングコードは、要求された接続を復元するためローカルへ保存します。
 
 通信先は127.0.0.1のペアリング済みローカルブリッジです。広告、アクセス解析、追跡はなく、拡張機能の開発者が運用するサーバーへデータを送信しません。設定したMCPクライアントは、各AIプロバイダーの規約とプライバシーポリシーに基づき、要求したX1Penデータを送信する場合があります。
 
@@ -77,7 +77,7 @@ Stores the user-entered local bridge port and pairing code in local extension st
 
 The extension handles the following user data only after prominent disclosure and affirmative consent in the popup:
 
-- Website content: X1Pen source, validation results, execution and debugger state, requested emulator memory ranges, and requested emulator screenshots.
+- Website content: X1Pen source, validation results, execution, debugger and video state, requested CPU/video memory ranges and paused video-memory changes, and requested emulator screenshots.
 - Web browsing activity: title and URL of the explicitly connected X1Pen tab only.
 - Authentication information: the six-digit pairing code for the user-selected local bridge.
 

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -100,6 +100,9 @@ MCPサーバーのnpm配布とブラウザー拡張の配布は独立してお�
 | `x1pen_debug_step` | 停止位置から1〜100命令をステップ実行 |
 | `x1pen_debug_set_breakpoints` | PCブレークポイントを一括置換・解除 |
 | `x1pen_debug_read_memory` | 現在の64KBアドレス空間を範囲指定して16進取得 |
+| `x1pen_debug_get_video_state` | 現在機種、画面寸法、表示／アクセスbankを取得 |
+| `x1pen_debug_read_vram` | テキスト／属性／漢字／グラフィックVRAMを副作用なしで16進取得 |
+| `x1pen_debug_write_vram` | 停止中にVRAMへ連続16進データを書き込み |
 | `x1pen_debug_wait_for_pause` | 条件に一致する停止まで待機 |
 
 AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
@@ -196,7 +199,9 @@ SLANG編集中のASMは生成物として読み取り・編集とも既定で保
 4. `x1pen_debug_get_state`と`x1pen_debug_read_memory`で状態を調査
 5. `x1pen_debug_step`で必要な命令数だけ進める
 
-`x1pen_debug_resume`後の新しい停止を待つ場合、`afterSequence`には停止前の値ではなく、`x1pen_debug_resume`が返した`sequence`を指定します。`x1pen_debug_read_memory`は既定64 byte、最大4096 byteで、モデルのコンテキスト消費を抑えるためバイト配列ではなく連続した大文字16進文字列を返します。
+`x1pen_debug_resume`後の新しい停止を待つ場合、`afterSequence`には停止前の値ではなく、`x1pen_debug_resume`が返した`sequence`を指定します。`x1pen_debug_read_memory`と`x1pen_debug_read_vram`は既定64 byte、最大4096 byteで、モデルのコンテキスト消費を抑えるためバイト配列ではなく連続した大文字16進文字列を返します。
+
+VRAMはCPUの64KBメモリ空間とは別です。`x1pen_debug_get_video_state`で現在の機種とbankを確認し、グラフィックVRAMではbank（`0`、`1`、`display`、`access`）とplane（`blue`、`red`、`green`）を指定します。実行中の読出しは複数バイトの一貫したスナップショットにならない場合があるため、厳密な調査では先にpauseしてください。書込みは停止中のみ許可され、空白なしの偶数桁hex文字列を指定します。
 
 ```json
 {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "ja",
   "permissions": ["activeTab", "scripting", "storage"],

--- a/extension/page-automation.mjs
+++ b/extension/page-automation.mjs
@@ -13,6 +13,15 @@ export async function invokeX1PenInPage(requestedMethod, requestedParams) {
     }
     return api.debugger;
   };
+  const requireVramDebugger = () => {
+    const debuggerApi = requireDebugger();
+    const capability = api.getStatus().capabilities?.debugger?.vram;
+    if (!capability?.available || !debuggerApi.getVideoState ||
+        !debuggerApi.readVram || !debuggerApi.writeVram) {
+      throw new Error('The connected X1Pen does not provide the VRAM debugger API');
+    }
+    return debuggerApi;
+  };
   const runDebuggerControl = async (operation) => {
     const deadline = Date.now() + 10_000;
     while (true) {
@@ -41,6 +50,7 @@ export async function invokeX1PenInPage(requestedMethod, requestedParams) {
     debuggerResume: 'AI is resuming the debugger...',
     debuggerStep: 'AI is stepping the debugger...',
     debuggerSetBreakpoints: 'AI is updating breakpoints...',
+    debuggerWriteVram: 'AI is updating video memory...',
   };
   const shouldLock = Object.prototype.hasOwnProperty.call(lockLabels, requestedMethod);
   if (shouldLock) api.setInteractionLocked(true, lockLabels[requestedMethod]);
@@ -79,6 +89,15 @@ export async function invokeX1PenInPage(requestedMethod, requestedParams) {
     }
     if (requestedMethod === 'debuggerReadMemory') {
       return requireDebugger().readMemory(requestedParams.address, requestedParams.length);
+    }
+    if (requestedMethod === 'debuggerGetVideoState') {
+      return requireVramDebugger().getVideoState();
+    }
+    if (requestedMethod === 'debuggerReadVram') {
+      return requireVramDebugger().readVram(requestedParams);
+    }
+    if (requestedMethod === 'debuggerWriteVram') {
+      return await requireVramDebugger().writeVram(requestedParams);
     }
     if (requestedMethod === 'debuggerWaitForPause') {
       return requireDebugger().waitForPause(requestedParams);

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -13,7 +13,7 @@
   <label for="code">Pairing code</label>
   <input id="code" type="text" inputmode="numeric" maxlength="6" autocomplete="one-time-code">
   <div class="disclosure">
-    <p>Connecting lets your local MCP server access this tab's title and URL; read and edit X1Pen source; validate, run, and debug programs; read requested emulator memory; and capture status and screen images. The port and pairing code are saved locally. Your selected AI client may send requested X1Pen data to its configured AI provider.</p>
+    <p>Connecting lets your local MCP server access this tab's title and URL; read and edit X1Pen source; validate, run, and debug programs; read requested CPU and video memory; modify requested video memory while paused; and capture status and screen images. The port and pairing code are saved locally. Your selected AI client may send requested X1Pen data to its configured AI provider.</p>
     <label class="consent" for="consent">
       <input id="consent" type="checkbox">
       <span>Allow access to this X1Pen tab</span>

--- a/html/x1pen-connector-privacy.html
+++ b/html/x1pen-connector-privacy.html
@@ -33,7 +33,7 @@
     <header>
         <h1>X1Pen Connector Privacy Policy</h1>
         <p class="subtitle">Privacy policy for the X1Pen Connector browser extension</p>
-        <p class="updated">Effective: August 5, 2026</p>
+        <p class="updated">Effective: August 7, 2026</p>
     </header>
 
     <section>
@@ -49,10 +49,10 @@
             <li>The selected X1Pen tab's title, URL, connection status, and program revision.</li>
             <li>X1Pen FuzzyBASIC, SLANG, and assembly source requested by the MCP client.</li>
             <li>Validation results, execution status, and emulator screen captures requested by the MCP client.</li>
-            <li>Debugger state, CPU registers, breakpoint settings, and emulator memory ranges requested by the MCP client.</li>
+            <li>Debugger state, video state, CPU registers, breakpoint settings, requested CPU and video memory ranges, and requested video-memory changes made while paused.</li>
             <li>The local bridge port and six-digit pairing code entered by the user.</li>
         </ul>
-        <p class="ja" lang="ja">接続への同意後、選択したX1Penタブのタイトル・URL・接続状態・リビジョン、MCPクライアントが要求したプログラムソース・検証結果・実行状態・画面キャプチャ・デバッガ状態・CPUレジスタ・ブレークポイント設定・エミュレータメモリ範囲、およびユーザーが入力したローカル接続情報を取り扱います。</p>
+        <p class="ja" lang="ja">接続への同意後、選択したX1Penタブのタイトル・URL・接続状態・リビジョン、MCPクライアントが要求したプログラムソース・検証結果・実行状態・画面キャプチャ・デバッガ／ビデオ状態・CPUレジスタ・ブレークポイント設定・CPU／ビデオメモリ範囲・停止中のビデオメモリ変更、およびユーザーが入力したローカル接続情報を取り扱います。</p>
     </section>
 
     <section>
@@ -64,9 +64,9 @@
 
     <section>
         <h2>Storage and deletion</h2>
-        <p>The bridge port and pairing code are stored in Chrome local extension storage so the local connection can be restored. Connected-tab metadata is stored in Chrome session storage. Program source, debugger data, memory reads, and screen captures are not retained by the extension.</p>
+        <p>The bridge port and pairing code are stored in Chrome local extension storage so the local connection can be restored. Connected-tab metadata is stored in Chrome session storage. Program source, debugger data, memory reads or writes, and screen captures are not retained by the extension.</p>
         <p>Users can disconnect a tab from the popup. Removing the extension or clearing its extension data deletes its saved local configuration.</p>
-        <p class="ja" lang="ja">ポートとペアリングコードはChromeの拡張機能用ローカルストレージへ、接続タブ情報はセッションストレージへ保存します。プログラムソース、デバッガデータ、メモリ読み取り結果、画面キャプチャを拡張機能内へ保持しません。切断、拡張機能の削除、または拡張データの消去により保存情報を削除できます。</p>
+        <p class="ja" lang="ja">ポートとペアリングコードはChromeの拡張機能用ローカルストレージへ、接続タブ情報はセッションストレージへ保存します。プログラムソース、デバッガデータ、メモリ読み書き結果、画面キャプチャを拡張機能内へ保持しません。切断、拡張機能の削除、または拡張データの消去により保存情報を削除できます。</p>
     </section>
 
     <section>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -38,7 +38,7 @@ The pairing code changes whenever the MCP server process restarts. One browser e
 
 ## Z80 debugger
 
-The debugger tools expose named CPU state, pause/resume, bounded multi-step execution, atomic PC breakpoint replacement, compact hexadecimal memory reads, and filtered pause waiting. They operate only through the allowlisted X1Pen Automation API; arbitrary JavaScript and raw WASM access are not exposed.
+The debugger tools expose named CPU/video state, pause/resume, bounded multi-step execution, atomic PC breakpoint replacement, compact hexadecimal CPU/VRAM reads, paused VRAM writes, and filtered pause waiting. They operate only through the allowlisted X1Pen Automation API; arbitrary JavaScript, raw I/O, and raw WASM access are not exposed.
 
 ## Language reference
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -349,7 +349,7 @@ function compactDebuggerVramWrite(value) {
   if (!value || !DEBUGGER_VRAM_REGIONS.includes(value.region) ||
       !Number.isInteger(value.offset) || !Number.isInteger(value.length) ||
       !Number.isInteger(value.bytesWritten) || value.bytesWritten !== value.length ||
-      value.redrawPending !== true) {
+      typeof value.redrawPending !== 'boolean') {
     throw new Error('X1Pen returned an invalid debugger VRAM write response');
   }
   const result = {
@@ -357,7 +357,7 @@ function compactDebuggerVramWrite(value) {
     offset: value.offset,
     endOffset: value.offset + value.length - 1,
     bytesWritten: value.bytesWritten,
-    redrawPending: true,
+    redrawPending: value.redrawPending,
   };
   if (value.region === 'graphics') {
     if (!Number.isInteger(value.bank) || !DEBUGGER_VRAM_PLANES.includes(value.plane)) {

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -23,6 +23,14 @@ const REFERENCE_KINDS = ['syntax', 'runtime', 'x1-extension', 'catalog', 'librar
 const DEBUGGER_STOP_REASONS = ['none', 'manual', 'breakpoint', 'step'];
 const DEBUGGER_MAX_READ_LENGTH = 4096;
 const DEBUGGER_MAX_BREAKPOINTS = 1024;
+const DEBUGGER_VRAM_REGIONS = ['text', 'attribute', 'kanji', 'graphics'];
+const DEBUGGER_VRAM_PLANES = ['blue', 'red', 'green'];
+const DEBUGGER_VRAM_REGION_SIZES = {
+  text: 0x0800,
+  attribute: 0x0800,
+  kanji: 0x0800,
+  graphics: 0x4000,
+};
 const SERVER_INSTRUCTIONS = [
   'X1Pen FuzzyBASIC and X1Pen SLANG are nonstandard languages. Do not infer syntax or APIs from ordinary BASIC, C, or another SLANG release.',
   'Before writing or substantially editing a program, call x1pen_get_language_profile, search the bundled reference with x1pen_search_reference, and fetch only the needed IDs with x1pen_get_reference.',
@@ -299,6 +307,69 @@ function compactDebuggerMemory(value) {
   };
 }
 
+function validateDebuggerVramRange({ region, bank, plane, offset, length }) {
+  const size = DEBUGGER_VRAM_REGION_SIZES[region];
+  if (offset + length > size) {
+    throw new Error(`VRAM range exceeds the ${region} region (${size} bytes)`);
+  }
+  if (region === 'graphics') {
+    if (bank === undefined) throw new Error('graphics VRAM requires bank 0, 1, display or access');
+    if (plane === undefined) throw new Error('graphics VRAM requires plane blue, red or green');
+  } else if (bank !== undefined || plane !== undefined) {
+    throw new Error('bank and plane are only valid for graphics VRAM');
+  }
+}
+
+function compactDebuggerVram(value) {
+  if (!value || !DEBUGGER_VRAM_REGIONS.includes(value.region) ||
+      !Number.isInteger(value.offset) || !Number.isInteger(value.length) ||
+      !Array.isArray(value.bytes) || value.bytes.length !== value.length ||
+      value.bytes.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 0xFF)) {
+    throw new Error('X1Pen returned an invalid debugger VRAM response');
+  }
+  const result = {
+    region: value.region,
+    offset: value.offset,
+    endOffset: value.offset + value.length - 1,
+    length: value.length,
+    hex: value.bytes.map((byte) => byte.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+  if (value.region === 'graphics') {
+    if (!Number.isInteger(value.bank) || !DEBUGGER_VRAM_PLANES.includes(value.plane)) {
+      throw new Error('X1Pen returned an invalid graphics VRAM response');
+    }
+    result.bankSelector = value.bankSelector;
+    result.bank = value.bank;
+    result.plane = value.plane;
+  }
+  return result;
+}
+
+function compactDebuggerVramWrite(value) {
+  if (!value || !DEBUGGER_VRAM_REGIONS.includes(value.region) ||
+      !Number.isInteger(value.offset) || !Number.isInteger(value.length) ||
+      !Number.isInteger(value.bytesWritten) || value.bytesWritten !== value.length ||
+      value.redrawPending !== true) {
+    throw new Error('X1Pen returned an invalid debugger VRAM write response');
+  }
+  const result = {
+    region: value.region,
+    offset: value.offset,
+    endOffset: value.offset + value.length - 1,
+    bytesWritten: value.bytesWritten,
+    redrawPending: true,
+  };
+  if (value.region === 'graphics') {
+    if (!Number.isInteger(value.bank) || !DEBUGGER_VRAM_PLANES.includes(value.plane)) {
+      throw new Error('X1Pen returned an invalid graphics VRAM write response');
+    }
+    result.bankSelector = value.bankSelector;
+    result.bank = value.bank;
+    result.plane = value.plane;
+  }
+  return result;
+}
+
 export function createX1PenMcpServer(options = {}) {
   const bridge = options.bridge || new X1PenBridge(options.bridgeOptions);
   const server = new McpServer(
@@ -569,6 +640,52 @@ export function createX1PenMcpServer(options = {}) {
     if (address + length > 0x10000) throw new Error('Memory range exceeds the 64KB address space');
     const memory = await bridge.sendCommand('debuggerReadMemory', { address, length }, sessionId);
     return textResult(compactDebuggerMemory(memory));
+  }));
+
+  server.registerTool('x1pen_debug_get_video_state', {
+    description: 'Get the current X1 model, screen dimensions, display/access graphics banks and VRAM availability.',
+    inputSchema: sessionInput,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId }) => textResult(
+    await bridge.sendCommand('debuggerGetVideoState', {}, sessionId),
+  )));
+
+  const vramSelectionSchema = {
+    sessionId: sessionInput.sessionId,
+    region: z.enum(DEBUGGER_VRAM_REGIONS),
+    bank: z.union([z.literal(0), z.literal(1), z.enum(['display', 'access'])]).optional()
+      .describe('Required for graphics VRAM; display/access are resolved atomically by X1Pen'),
+    plane: z.enum(DEBUGGER_VRAM_PLANES).optional().describe('Required for graphics VRAM'),
+    offset: z.number().int().min(0).max(0x3FFF),
+  };
+
+  server.registerTool('x1pen_debug_read_vram', {
+    description: 'Read logical X1 video memory without I/O side effects and return compact uppercase hex. Running reads may not be a consistent multi-byte snapshot; pause first when consistency matters.',
+    inputSchema: {
+      ...vramSelectionSchema,
+      length: z.number().int().min(1).max(DEBUGGER_MAX_READ_LENGTH).default(64),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, ...request }) => {
+    validateDebuggerVramRange(request);
+    const value = await bridge.sendCommand('debuggerReadVram', request, sessionId);
+    return textResult(compactDebuggerVram(value));
+  }));
+
+  server.registerTool('x1pen_debug_write_vram', {
+    description: 'Write logical X1 video memory while the Z80 debugger is paused. hex must contain 1-4096 bytes as contiguous even-length hexadecimal.',
+    inputSchema: {
+      ...vramSelectionSchema,
+      hex: z.string().min(2).max(DEBUGGER_MAX_READ_LENGTH * 2)
+        .regex(/^(?:[0-9A-Fa-f]{2})+$/, 'hex must contain contiguous pairs of hexadecimal digits'),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, hex, ...selection }) => {
+    const bytes = Array.from(Buffer.from(hex, 'hex'));
+    const request = { ...selection, length: bytes.length };
+    validateDebuggerVramRange(request);
+    const value = await bridge.sendCommand('debuggerWriteVram', { ...selection, bytes }, sessionId);
+    return textResult(compactDebuggerVramWrite(value));
   }));
 
   server.registerTool('x1pen_debug_wait_for_pause', {

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -27,7 +27,7 @@ function createAutomationApi() {
     ready: async () => ({ ready: true }),
     getStatus: () => ({
       capabilities: {
-        debugger: { available: true, runPending: pendingReads-- > 0 },
+        debugger: { available: true, runPending: pendingReads-- > 0, vram: { available: true } },
       },
     }),
     getProgram: () => ({ revision: 1 }),
@@ -55,6 +55,12 @@ function createAutomationApi() {
       },
       setBreakpoints: async (addresses) => state({ breakpointCount: new Set(addresses).size }),
       readMemory: (address, length) => ({ address, length, bytes: Array(length).fill(0xAA) }),
+      getVideoState: () => ({ model: 'x1', displayBank: 0, accessBank: 0 }),
+      readVram: (options) => ({ ...options, bank: 0, bytes: [0x12, 0x34] }),
+      writeVram: async (options) => {
+        timeline.push('vram-write:done');
+        return { ...options, bank: 0, bytesWritten: options.bytes.length, redrawPending: true };
+      },
       waitForPause: async (options) => ({ ...state(), options }),
     },
   };
@@ -94,6 +100,17 @@ test('page bridge allowlists debugger operations and retries Run setup races', a
   assert.equal(breakpoints.breakpointCount, 2);
   const memory = await invokeX1PenInPage('debuggerReadMemory', { address: 0x200, length: 4 });
   assert.deepEqual(memory.bytes, [0xAA, 0xAA, 0xAA, 0xAA]);
+  const video = await invokeX1PenInPage('debuggerGetVideoState', {});
+  assert.equal(video.model, 'x1');
+  const vram = await invokeX1PenInPage('debuggerReadVram', {
+    region: 'graphics', bank: 'access', plane: 'blue', offset: 0, length: 2,
+  });
+  assert.deepEqual(vram.bytes, [0x12, 0x34]);
+  const written = await invokeX1PenInPage('debuggerWriteVram', {
+    region: 'graphics', bank: 'access', plane: 'blue', offset: 0, bytes: [0x56],
+  });
+  assert.equal(written.bytesWritten, 1);
+  assert.deepEqual(timeline.slice(-3), ['lock:on', 'vram-write:done', 'lock:off']);
   const waited = await invokeX1PenInPage('debuggerWaitForPause', { stopReason: 'breakpoint' });
   assert.deepEqual(waited.options, { stopReason: 'breakpoint' });
 
@@ -106,6 +123,18 @@ test('page bridge rejects debugger calls when capability is unavailable', async 
   api.getStatus = () => ({ capabilities: { debugger: { available: false, runPending: false } } });
   globalThis.window = { X1PenAutomation: api };
   await assert.rejects(invokeX1PenInPage('debuggerGetState', {}), /does not provide the debugger API/);
+});
+
+test('page bridge rejects VRAM calls when its capability is unavailable', async () => {
+  const { api } = createAutomationApi();
+  api.getStatus = () => ({
+    capabilities: { debugger: { available: true, runPending: false, vram: { available: false } } },
+  });
+  globalThis.window = { X1PenAutomation: api };
+  await assert.rejects(
+    invokeX1PenInPage('debuggerReadVram', { region: 'text', offset: 0, length: 1 }),
+    /does not provide the VRAM debugger API/,
+  );
 });
 
 test('extension update waits for active operations before disconnecting and reloading', async () => {

--- a/tests/x1pen_extension_package_test.mjs
+++ b/tests/x1pen_extension_package_test.mjs
@@ -49,7 +49,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
 
     const manifest = JSON.parse(run('unzip', ['-p', zipPath, 'manifest.json']));
     assert.equal(manifest.manifest_version, 3);
-    assert.equal(manifest.version, '1.1.1');
+    assert.equal(manifest.version, '1.2.0');
     assert.equal(manifest.default_locale, 'ja');
     assert.equal(manifest.name, '__MSG_extensionName__');
     assert.equal(manifest.description, '__MSG_extensionDescription__');
@@ -86,6 +86,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
     assert.match(privacy, /127\.0\.0\.1/);
     assert.match(privacy, /program source/i);
     assert.match(privacy, /debugger state/i);
+    assert.match(privacy, /video memory/i);
     assert.match(privacy, /AI provider/i);
     const buildScript = await readFile(join(repoRoot, 'build.sh'), 'utf8');
     assert.match(buildScript, /html\/x1pen-connector-privacy\.html.*DIST_DIR/);
@@ -93,6 +94,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
     const popup = await readFile(join(repoRoot, 'extension/popup.html'), 'utf8');
     assert.match(popup, /id="consent" type="checkbox"/);
     assert.match(popup, /debug programs/);
+    assert.match(popup, /video memory/);
     assert.match(popup, /x1pen-connector-privacy\.html/);
     assert.match(popup, /id="connect" disabled/);
   } finally {

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -65,7 +65,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.5.0');
+    assert.equal(manifest.version, '2.6.0');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');
@@ -83,9 +83,10 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(client.getInstructions(), /x1pen_search_reference/);
 
     const tools = await client.listTools();
-    assert.equal(tools.tools.length, 23);
+    assert.equal(tools.tools.length, 26);
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_get_state'));
+    assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_read_vram'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_search_reference'));
     const connection = await client.callTool({ name: 'x1pen_connection_info', arguments: {} });
     const info = JSON.parse(connection.content[0].text);

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -136,7 +136,7 @@ const fakeBridge = {
         bank: params.bank === 'access' || params.bank === 'display' ? 0 : params.bank,
         length: params.bytes.length,
         bytesWritten: params.bytes.length,
-        redrawPending: true,
+        redrawPending: params.bytes.some((byte) => byte !== 0),
       };
     }
     if (method === 'debuggerWaitForPause') return clone(debuggerState);
@@ -512,6 +512,12 @@ test('debugger VRAM tools validate regions and return compact responses', async 
   assert.deepEqual(written, {
     region: 'attribute', offset: 2, endOffset: 3, bytesWritten: 2, redrawPending: true,
   });
+
+  const unchanged = jsonContent(await client.callTool({
+    name: 'x1pen_debug_write_vram',
+    arguments: { region: 'attribute', offset: 3, hex: '00' },
+  }));
+  assert.equal(unchanged.redrawPending, false);
 
   const missingPlane = await client.callTool({
     name: 'x1pen_debug_read_vram',

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -114,6 +114,31 @@ const fakeBridge = {
         bytes: Array.from({ length: params.length }, (_, index) => (params.address + index) & 0xFF),
       };
     }
+    if (method === 'debuggerGetVideoState') {
+      return {
+        version: 1, model: 'x1', romType: 1, displayBank: 0, accessBank: 0,
+        text: { columns: 80, rows: 25, regionSize: 0x0800, kanjiAvailable: false },
+        graphics: { width: 640, height: 200, banks: 1, planes: ['blue', 'red', 'green'], planeSize: 0x4000 },
+      };
+    }
+    if (method === 'debuggerReadVram') {
+      return {
+        ...params,
+        bankSelector: params.bank,
+        bank: params.bank === 'access' || params.bank === 'display' ? 0 : params.bank,
+        bytes: Array.from({ length: params.length }, (_, index) => (params.offset + 0xAB + index) & 0xFF),
+      };
+    }
+    if (method === 'debuggerWriteVram') {
+      return {
+        ...params,
+        bankSelector: params.bank,
+        bank: params.bank === 'access' || params.bank === 'display' ? 0 : params.bank,
+        length: params.bytes.length,
+        bytesWritten: params.bytes.length,
+        redrawPending: true,
+      };
+    }
     if (method === 'debuggerWaitForPause') return clone(debuggerState);
     return { ok: true };
   },
@@ -154,12 +179,15 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_capture_screen',
     'x1pen_connection_info',
     'x1pen_debug_get_state',
+    'x1pen_debug_get_video_state',
     'x1pen_debug_pause',
     'x1pen_debug_read_memory',
+    'x1pen_debug_read_vram',
     'x1pen_debug_resume',
     'x1pen_debug_set_breakpoints',
     'x1pen_debug_step',
     'x1pen_debug_wait_for_pause',
+    'x1pen_debug_write_vram',
     'x1pen_get_language_profile',
     'x1pen_get_program',
     'x1pen_get_reference',
@@ -457,4 +485,45 @@ test('debugger memory reads are bounded and compact', async () => {
   });
   assert.equal(invalid.isError, true);
   assert.match(invalid.content[0].text, /64KB address space/);
+});
+
+test('debugger VRAM tools validate regions and return compact responses', async () => {
+  const video = jsonContent(await client.callTool({
+    name: 'x1pen_debug_get_video_state', arguments: {},
+  }));
+  assert.equal(video.model, 'x1');
+  assert.equal(calls.at(-1).method, 'debuggerGetVideoState');
+
+  const read = jsonContent(await client.callTool({
+    name: 'x1pen_debug_read_vram',
+    arguments: { region: 'graphics', bank: 'access', plane: 'blue', offset: 0, length: 4 },
+  }));
+  assert.deepEqual(read, {
+    region: 'graphics', bankSelector: 'access', bank: 0, plane: 'blue',
+    offset: 0, endOffset: 3, length: 4, hex: 'ABACADAE',
+  });
+  assert.equal(read.bytes, undefined);
+
+  const written = jsonContent(await client.callTool({
+    name: 'x1pen_debug_write_vram',
+    arguments: { region: 'attribute', offset: 2, hex: '0aFF' },
+  }));
+  assert.deepEqual(calls.at(-1).params.bytes, [0x0A, 0xFF]);
+  assert.deepEqual(written, {
+    region: 'attribute', offset: 2, endOffset: 3, bytesWritten: 2, redrawPending: true,
+  });
+
+  const missingPlane = await client.callTool({
+    name: 'x1pen_debug_read_vram',
+    arguments: { region: 'graphics', bank: 0, offset: 0, length: 1 },
+  });
+  assert.equal(missingPlane.isError, true);
+  assert.match(missingPlane.content[0].text, /requires plane/);
+
+  const oversizedText = await client.callTool({
+    name: 'x1pen_debug_read_vram',
+    arguments: { region: 'text', offset: 0x07FF, length: 2 },
+  });
+  assert.equal(oversizedText.isError, true);
+  assert.match(oversizedText.content[0].text, /2048 bytes/);
 });


### PR DESCRIPTION
## Summary
- route the VRAM debugger APIs from PR #73 through the allowlisted Chrome extension bridge
- add MCP tools for video state, compact VRAM reads, and paused VRAM writes
- update Connector 1.2.0 / x1pen-mcp 2.6.0 documentation and privacy disclosures

## MCP tools
- `x1pen_debug_get_video_state`
- `x1pen_debug_read_vram`
- `x1pen_debug_write_vram`

Graphics access accepts bank `0`, `1`, `display`, or `access` plus plane `blue`, `red`, or `green`. Reads return compact uppercase hexadecimal. Writes accept contiguous hexadecimal and are restricted to a paused debugger.

## Verification
- `npm run test:extension-package` (6/6)
- `npm run test:mcp` (33/33)
- `npm run test:bridge` (4/4)
- `npm run test:mcp-package` (1/1)
- `./build.sh`

This is PR 2 of Issue #72. The broader X1 hardware/I/O reference remains a separate npm-only follow-up.
