### PR TITLE
Add X1 hardware MCP reference

### DIFF
--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -81,8 +81,8 @@ MCPサーバーのnpm配布とブラウザー拡張の配布は独立してお�
 | `x1pen_connection_info` | 拡張機能の接続情報を取得 |
 | `x1pen_list_sessions` | 接続済みX1Penタブを一覧表示 |
 | `x1pen_select_session` | 操作対象タブを選択 |
-| `x1pen_get_language_profile` | 同梱リファレンスと接続中X1Penの言語profileを確認 |
-| `x1pen_search_reference` | FuzzyBASIC / SLANGリファレンスを要約検索 |
+| `x1pen_get_language_profile` | 同梱言語／X1ハードウェアprofileと接続中X1Penの言語profileを確認 |
+| `x1pen_search_reference` | FuzzyBASIC / SLANG / X1ハードウェアリファレンスを要約検索 |
 | `x1pen_get_reference` | 検索結果のIDを指定して詳細を上限付きで取得 |
 | `x1pen_get_program` | メタデータと明示指定した完全ソースを取得 |
 | `x1pen_get_source` | 1セクションを行範囲・文字数上限付きで取得 |
@@ -107,11 +107,11 @@ MCPサーバーのnpm配布とブラウザー拡張の配布は独立してお�
 
 AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
 
-### 言語リファレンス
+### 言語・X1ハードウェアリファレンス
 
-MCPパッケージには、X1Pen FuzzyBASIC 1.2L（X1 / LSX-Dodgers版）とX1Pen内蔵SLANGコンパイラに対応する構造化リファレンスが同梱されています。ブラウザー未接続でも検索できるため、プログラム作成前に仕様を確認できます。MCP初期化時にも「一般的なBASIC、C、別バージョンのSLANGから仕様を推測しない」ことと、生成前のリファレンス検索、生成後の検証をクライアントへ通知します。
+MCPパッケージには、X1Pen FuzzyBASIC 1.2L（X1 / LSX-Dodgers版）、X1Pen内蔵SLANGコンパイラ、X millennium Webが実装するX1ハードウェアに対応する構造化リファレンスが同梱されています。ブラウザー未接続でも検索できるため、プログラム作成前に仕様を確認できます。MCP初期化時にも「一般的なBASIC、C、別バージョンのSLANGから仕様を推測しない」こと、X1のCPUメモリ／I/O空間／VRAMを混同しないこと、生成前のリファレンス検索、生成後の検証をクライアントへ通知します。
 
-schema v2の`symbols`と`relatedIds`による索引はFuzzyBASICとSLANGの両方へ適用しています。SLANGは内蔵コンパイラの予約語表と、`x1pen.js`が実際に読み込むruntime/includeファイルから公開シンボルを検査し、更新時に未収録項目が生じるとテストで検出します。
+schema v2の`symbols`と`relatedIds`による索引はFuzzyBASIC、SLANG、X1ハードウェアの全profileへ適用しています。SLANGは内蔵コンパイラの予約語表と、`x1pen.js`が実際に読み込むruntime/includeファイルから公開シンボルを検査し、更新時に未収録項目が生じるとテストで検出します。
 
 最初に`x1pen_get_language_profile`を呼ぶと、同梱profileを確認できます。X1Penへ接続済みなら、ブラウザーが報告したprofile IDとの互換性も返します。
 
@@ -146,6 +146,8 @@ FuzzyBASICの固有構文は記号や日本語でも検索できます。
 FuzzyBASICについては、メモリ／I/O配列、16bit値と変数制約、PROC/FUNC、スタック、機械語連携、LSX-Dodgersファイル処理、X1のグラフィック・PCG・PSG・JOYまで収録しています。一般言語構文は原典を参照しますが、OS、ファイル、コンソール、メモリ配置、X1拡張の挙動はLSX-Dodgers移植ソースを優先しています。全トークナイザ予約語がリファレンスの`symbols`でカバーされることと、代表サンプルが現在のX1Pen tokenizerで処理できることを自動検証しています。
 
 SLANGについては、正確なコンパイラrevision、`ENV_TYPE=1`のLSX-Dodgers環境、予約語と文字列関数、native FLOAT、LSXファイル、X1の画面／描画／PCG／PSG／VSYNC／SGL、圧縮・画像ローダ、同梱される8本のinclude APIを収録しています。網羅catalogには内部実装シンボルも含まれるため、通常は検索結果の専用項目を優先してください。ゲーム開発で利用するPCGについては、FuzzyBASICの`PCGDEF` / `TCOLOR`、SLANGの`PCGDEF` / `PCGDEFS`、24-byte BRGパターン形式、TILELIBとの初期化順序まで独立項目として収録しています。未知のAPIや複雑な引数規約については、リファレンス確認後も`x1pen_validate`で検証してください。
+
+X1ハードウェアについては、Z80のCPUメモリと16bit I/O空間の分離、X1turbo/Zの低位バンクRAM、テキスト／属性／漢字VRAM、グラフィックVRAMのbankとB/R/G plane、PPIによる同時アクセス、画面制御、PCG／基本パレットを収録しています。VRAMをCPUバンク切替で参照できるとは推測せず、デバッガでは`x1pen_debug_read_memory`と`x1pen_debug_read_vram`を目的に応じて使い分けてください。PSG、サブCPU、CTC、DMA、FDC、SASI、EMM等の詳細I/Oは後続で段階的に追加します。
 
 ### 大きなプログラムの扱い
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # x1pen-mcp
 
-`x1pen-mcp` is a local MCP server that lets Codex and Claude Code edit, validate, run, inspect, and Z80-debug programs in the X1Pen tab already open in Chrome or Edge. It also includes bounded, offline-searchable references for X1Pen FuzzyBASIC and SLANG.
+`x1pen-mcp` is a local MCP server that lets Codex and Claude Code edit, validate, run, inspect, and Z80-debug programs in the X1Pen tab already open in Chrome or Edge. It also includes bounded, offline-searchable references for X1Pen FuzzyBASIC, SLANG, and the X1 hardware implemented by the emulator.
 
 The server communicates only through stdio and `127.0.0.1`. It requires Node.js 20 or later. Browser-control tools require the X1Pen Connector extension; the bundled reference tools do not.
 
@@ -40,7 +40,7 @@ The pairing code changes whenever the MCP server process restarts. One browser e
 
 The debugger tools expose named CPU/video state, pause/resume, bounded multi-step execution, atomic PC breakpoint replacement, compact hexadecimal CPU/VRAM reads, paused VRAM writes, and filtered pause waiting. They operate only through the allowlisted X1Pen Automation API; arbitrary JavaScript, raw I/O, and raw WASM access are not exposed.
 
-## Language reference
+## Language and X1 hardware reference
 
 The reference tools work before browser pairing because the data is bundled in this package:
 
@@ -50,6 +50,6 @@ The reference tools work before browser pairing because the data is bundled in t
 
 Search first and fetch only the entries needed for the current program. This avoids putting a complete language manual into the model context.
 
-The server initialization instructions tell MCP clients not to infer these nonstandard languages from ordinary BASIC, C, or another SLANG release. FuzzyBASIC coverage includes direct indexed memory/I/O arrays, LSX-Dodgers-specific file limitations, machine-code integration, PCG, PSG sound, and joystick input. SLANG coverage is tied to the exact browser compiler and VFS, including compiler vocabulary, native FLOAT, LSX file I/O, X1 graphics/PCG/PSG/timing/SGL, compression and all bundled include APIs. Exact symbols are searchable in English or Japanese, and an unsuccessful all-term search falls back to partial matches explicitly marked with `matchMode: "partial"`.
+The server initialization instructions tell MCP clients not to infer these nonstandard languages from ordinary BASIC, C, or another SLANG release, and not to confuse X1 CPU memory, I/O ports, VRAM, or their independent banks. FuzzyBASIC coverage includes direct indexed memory/I/O arrays, LSX-Dodgers-specific file limitations, machine-code integration, PCG, PSG sound, and joystick input. SLANG coverage is tied to the exact browser compiler and VFS, including compiler vocabulary, native FLOAT, LSX file I/O, X1 graphics/PCG/PSG/timing/SGL, compression and all bundled include APIs. The X1 hardware profile initially covers address spaces, turbo low-memory banking, text/attribute/kanji VRAM, graphics banks and color planes, simultaneous access, screen control, PCG, and the base palette. Exact symbols are searchable in English or Japanese, and an unsuccessful all-term search falls back to partial matches explicitly marked with `matchMode: "partial"`.
 
 See the [complete setup and tool documentation](https://github.com/ho-ogino/xmil-web/blob/main/docs/X1PEN_MCP.md) for details.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.7.0",
+  "version": "2.6.0",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x1pen-mcp",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Local MCP server for controlling X1Pen in a user-visible Chromium tab",
   "type": "module",
   "bin": {

--- a/mcp/reference/manifest.json
+++ b/mcp/reference/manifest.json
@@ -3,7 +3,8 @@
   "referenceVersion": "2026-08-07",
   "defaultProfiles": {
     "fuzzybasic": "x1pen-fuzzybasic-1.2L",
-    "slang": "x1pen-slang-c9e8f53-lsx"
+    "slang": "x1pen-slang-c9e8f53-lsx",
+    "x1": "x1-hardware-xmillennium-web"
   },
   "profiles": [
     {
@@ -31,6 +32,19 @@
       "notes": "The exact browser compiler snapshot and the runtime/include files loaded by the X1Pen VFS. Schema v2 indexes compiler vocabulary, runtime metadata symbols and bundled include APIs, with dedicated entries for supported application-facing contracts.",
       "sourceUrls": [
         "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"
+      ]
+    },
+    {
+      "id": "x1-hardware-xmillennium-web",
+      "language": "x1",
+      "displayName": "X1 hardware implemented by X millennium Web",
+      "environment": "SHARP X1 / X1turbo / X1turboZ",
+      "notes": "A focused hardware profile derived from the emulator implementation and cross-checked against X1 technical documentation. It distinguishes CPU memory, I/O ports and logical VRAM debugger regions; broader peripheral I/O coverage is intentionally incremental.",
+      "sourceUrls": [
+        "https://github.com/ho-ogino/xmil-web/tree/main/src",
+        "https://github.com/ho-ogino/xmil-web/tree/main/platform",
+        "https://github.com/mamedev/mame/blob/master/src/mame/sharp/x1.cpp",
+        "http://x1center.org/sdx1/sdx1_0.html"
       ]
     }
   ]

--- a/mcp/reference/x1-hardware.json
+++ b/mcp/reference/x1-hardware.json
@@ -1,0 +1,198 @@
+[
+  {
+    "id": "x1.architecture.address-spaces",
+    "language": "x1",
+    "kind": "architecture",
+    "title": "Z80 CPU memory, I/O ports and video memory",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["0000H-FFFFH", "IN", "OUT", "MEM", "PORT", "x1pen_debug_read_memory", "x1pen_debug_read_vram"],
+    "aliases": ["address space", "CPU memory", "I/O space", "port space", "video memory", "VRAM", "アドレス空間", "CPUメモリ", "I/O空間", "ポート空間", "ビデオメモリ"],
+    "summary": "The X1 uses separate 16-bit Z80 CPU-memory and I/O-port spaces. Text and graphics VRAM are reached through I/O ports, not by changing the CPU-memory bank.",
+    "syntax": [
+      "LD A,(address) / LD (address),A       CPU memory",
+      "IN A,(C) / OUT (C),A                 16-bit I/O port in BC",
+      "x1pen_debug_read_memory              current mapped CPU memory",
+      "x1pen_debug_read_vram                logical video-memory region"
+    ],
+    "notes": [
+      "CPU addresses and I/O ports both range from 0000H through FFFFH, but they are independent namespaces. The same numeric value does not identify the same storage.",
+      "X1 text VRAM is decoded at I/O ports 2000H through 3FFFH and graphics VRAM at 4000H through FFFFH. These are not CPU-memory addresses.",
+      "x1pen_debug_read_memory observes the Z80's currently mapped 64KB CPU view. Use x1pen_debug_read_vram for text, attribute, kanji or graphics video memory.",
+      "Do not invent a CPU bank switch to reach VRAM. X1turbo low-memory banks and graphics VRAM banks are separate mechanisms.",
+      "A general debugger IN/OUT API is intentionally not exposed: device reads can acknowledge interrupts, consume data or change modes. VRAM debugger reads use a side-effect-free physical view.",
+      "On this X1 implementation, every ordinary IN clears graphics simultaneous-access mode. A debugger VRAM read does not call Z80_In and therefore does not clear it."
+    ],
+    "relatedIds": ["x1.memory.cpu-banking", "x1.video.text-vram", "x1.video.graphics-vram", "x1.video.screen-control"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_IO.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/platform/x1_mem_port.cpp",
+      "http://x1center.org/sdx1/sdx1_0.html"
+    ]
+  },
+  {
+    "id": "x1.memory.cpu-banking",
+    "language": "x1",
+    "kind": "memory",
+    "title": "CPU memory map and X1turbo low-memory banks",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["0000H-7FFFH", "8000H-FFFFH", "0B00H-0BFFH", "1D00H-1DFFH", "1E00H-1EFFH", "lastmem", "ROM_TYPE"],
+    "aliases": ["memory map", "bank memory", "banked RAM", "ROM switch", "low memory", "X1turbo bank", "メモリマップ", "バンクメモリ", "バンクRAM", "ROM切替", "低位メモリ"],
+    "summary": "CPU addresses 8000H-FFFFH always use main RAM. The 0000H-7FFFH view can select IPL ROM/main RAM, and X1turbo/Z can instead map one of sixteen 32KB bank-RAM pages.",
+    "syntax": [
+      "OUT (0B00H),A   turbo/Z low-memory selector",
+      "A bit 4 = 0     map bank RAM page A bits 3..0 to 0000H-7FFFH",
+      "A bit 4 = 1     use normal IPL-ROM/main-RAM low-memory mapping",
+      "OUT (1D00H),A   enable IPL ROM reads in normal mapping",
+      "OUT (1E00H),A   enable main RAM reads in normal mapping"
+    ],
+    "notes": [
+      "The 0Bxx selector and sixteen 32KB bank pages are available only on X1turbo and X1turboZ. Original X1 does not provide this bank-RAM mapping.",
+      "In normal low-memory mapping, writes go to main RAM. Reads select IPL ROM or main RAM according to the ROM switch controlled by 1Dxx and 1Exx output ports.",
+      "The debugger state reports lowMemory.mapping as bios, main or bank and reports the selected bank when applicable. x1pen_debug_read_memory follows that active view.",
+      "Graphics bank 0/1 is unrelated to these CPU-memory pages. Select graphics banks only through screen control or the VRAM debugger bank parameter.",
+      "EMM is a separate I/O peripheral and is not the X1turbo low-memory bank mechanism. This initial hardware profile does not document EMM ports."
+    ],
+    "relatedIds": ["x1.architecture.address-spaces", "x1.video.graphics-vram", "x1.video.screen-control"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_IO.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1.cpp",
+      "https://github.com/ho-ogino/xmil-web/blob/main/platform/platform_main.cpp"
+    ]
+  },
+  {
+    "id": "x1.video.text-vram",
+    "language": "x1",
+    "kind": "video",
+    "title": "Text, attribute and kanji VRAM",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["2000H-27FFH", "2800H-2FFFH", "3000H-37FFH", "3800H-3FFFH", "TEXT_ATR", "TEXT_ANK", "TEXT_KNJ", "X1ATR_PCG"],
+    "aliases": ["text VRAM", "attribute VRAM", "kanji VRAM", "ANK", "text color", "blink", "double width", "テキストVRAM", "属性VRAM", "漢字VRAM", "文字色", "点滅", "倍角"],
+    "summary": "Text display uses three logical 2048-byte regions in I/O space: attributes at canonical 2000H-27FFH, ANK character codes at 3000H-37FFH, and turbo/Z kanji codes at 3800H-3FFFH.",
+    "syntax": [
+      "2000H-27FFH   attribute VRAM (canonical)",
+      "2800H-2FFFH   mirror of attribute VRAM",
+      "3000H-37FFH   ANK character-code VRAM",
+      "3800H-3FFFH   kanji-code VRAM on turbo/Z; ANK mirror on X1",
+      "attribute bits: 7=X2, 6=Y2, 5=PCG, 4=blink, 3=reverse, 2..0=color"
+    ],
+    "notes": [
+      "Each debugger region uses logical offsets 0000H-07FFH. Use region text, attribute or kanji instead of passing an I/O port as the offset.",
+      "The canonical attribute range is 2000H-27FFH. 2800H-2FFFH is a mirror alias of the same 2048 bytes.",
+      "On original X1, hardware reads and writes at 3800H-3FFFH mirror ANK text VRAM. Software can use this behavior to distinguish X1 from turbo models.",
+      "The debugger deliberately rejects region kanji on original X1 so clients do not mistake the mirror for an independent region. Read region text to observe the underlying ANK data.",
+      "Writing through the debugger applies the emulator's normal text dirty, blink and double-size handling and is allowed only while paused."
+    ],
+    "relatedIds": ["x1.architecture.address-spaces", "x1.video.pcg-palette", "x1.video.screen-control", "x1.video.graphics-vram"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/platform/x1_vram_port.cpp",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_VRAM.H",
+      "https://github.com/mamedev/mame/blob/master/src/mame/sharp/x1.cpp",
+      "http://x1center.org/sdx1/sdx1_0.html"
+    ]
+  },
+  {
+    "id": "x1.video.graphics-vram",
+    "language": "x1",
+    "kind": "video",
+    "title": "Graphics VRAM banks, color planes and simultaneous access",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["4000H-7FFFH", "8000H-BFFFH", "C000H-FFFFH", "BLUE", "RED", "GREEN", "IO_MODE", "1A02H"],
+    "aliases": ["graphics VRAM", "VRAM plane", "color plane", "display bank", "access bank", "simultaneous access", "GRAM", "グラフィックVRAM", "色プレーン", "表示バンク", "アクセスバンク", "同時アクセス", "同時書き込み"],
+    "summary": "Graphics VRAM has independent blue, red and green 16KB planes. X1turbo/Z provides banks 0 and 1, while original X1 supports bank 0 only.",
+    "syntax": [
+      "4000H-7FFFH   BLUE plane in normal single-plane mode",
+      "8000H-BFFFH   RED plane in normal single-plane mode",
+      "C000H-FFFFH   GREEN plane in normal single-plane mode",
+      "simultaneous 0000H-3FFFH -> B+R+G",
+      "simultaneous 4000H-7FFFH -> R+G",
+      "simultaneous 8000H-BFFFH -> B+G",
+      "simultaneous C000H-FFFFH -> B+R"
+    ],
+    "notes": [
+      "Normal plane accesses use the low 14 port bits as a logical offset 0000H-3FFFH. The debugger exposes this contiguous offset and hides GRP_RAM's internal interleaving.",
+      "Bank 1 is available only on X1turbo and X1turboZ. Original X1 rejects debugger requests for bank 1.",
+      "The current display bank and CPU access bank are separate. MCP accepts numeric bank 0/1 or the selectors display/access and returns the resolved numeric bank.",
+      "PPI port C at 1A02H controls the simultaneous-access trigger. A bit-5 falling edge enters the mode; subsequent OUT instructions write the plane combinations shown above instead of ordinary I/O devices.",
+      "Any ordinary IN clears simultaneous-access mode. x1pen_debug_read_vram does not perform IN and therefore does not disturb the mode.",
+      "Pause before a multi-byte dump when a consistent snapshot matters. Debugger writes are paused-only and mark changed graphics bytes for a later display frame."
+    ],
+    "relatedIds": ["x1.architecture.address-spaces", "x1.video.screen-control", "x1.video.text-vram", "x1.video.pcg-palette"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/platform/x1_vram_port.cpp",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_IO.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_8255.cpp",
+      "https://github.com/mamedev/mame/blob/master/src/mame/sharp/x1.cpp",
+      "http://x1center.org/sdx1/sdx1_0.html"
+    ]
+  },
+  {
+    "id": "x1.video.screen-control",
+    "language": "x1",
+    "kind": "video",
+    "title": "Screen control, CRTC and graphics bank selection",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["1800H-18FFH", "1A02H", "1FD0H", "SCRN_BITS", "SCRN_DISPVRAM", "SCRN_ACCESSVRAM", "SCRN_PCGMODE"],
+    "aliases": ["screen mode", "screen control", "CRTC", "display bank", "access bank", "display bank access bank", "resolution", "40 columns", "80 columns", "画面モード", "画面制御", "表示バンク", "アクセスバンク", "表示バンク アクセスバンク", "解像度", "CRTC"],
+    "summary": "The CRTC and PPI determine text and graphics dimensions. X1turbo/Z screen-control port 1FD0H also selects the displayed and CPU-access graphics banks independently.",
+    "syntax": [
+      "1800H-18FFH   CRTC writes",
+      "1A02H         PPI port C; bit 6 reflects/selects 40 versus 80 columns",
+      "1FD0H bit 0   0=15kHz, 1=24kHz",
+      "1FD0H bit 1   0=400-line family, 1=200-line family",
+      "1FD0H bit 2   text vertical double",
+      "1FD0H bit 3   displayed graphics VRAM bank",
+      "1FD0H bit 4   CPU-access graphics VRAM bank",
+      "1FD0H bit 5   high-speed PCG mode",
+      "1FD0H bit 6   CPU font height selection",
+      "1FD0H bit 7   underline enable"
+    ],
+    "notes": [
+      "Port 1FD0H and graphics bank 1 require X1turbo or X1turboZ. Original X1 has one graphics bank.",
+      "Display bank controls what the video hardware shows. Access bank controls which graphics bank ordinary I/O reads and writes reach. They may intentionally differ for page flipping.",
+      "x1pen_debug_get_video_state returns the raw screenBits plus resolved displayBank/accessBank and dimensions derived by the emulator's current CRTC state.",
+      "Do not recompute the current dimensions from screenBits alone; CRTC registers and the 40/80-column PPI state also contribute.",
+      "The MCP VRAM display/access selectors are resolved inside the same WASM call as the copy, avoiding a bank-change race within the single-threaded emulator call."
+    ],
+    "relatedIds": ["x1.video.graphics-vram", "x1.video.text-vram", "x1.video.pcg-palette", "x1.architecture.address-spaces"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_CRTC.H",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_CRTC.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_8255.cpp",
+      "http://www.x1center.org/sdx1/sdx1_1.html"
+    ]
+  },
+  {
+    "id": "x1.video.pcg-palette",
+    "language": "x1",
+    "kind": "video",
+    "title": "PCG character patterns and base graphics palette",
+    "profiles": ["x1-hardware-xmillennium-web"],
+    "symbols": ["1000H-12FFH", "1400H-14FFH", "1500H-15FFH", "1600H-16FFH", "1700H-17FFH", "X1ATR_PCG", "SCRN_PCGMODE"],
+    "aliases": ["PCG", "programmable character", "character generator", "palette", "blue palette", "red palette", "green palette", "キャラクタジェネレータ", "キャラクター定義", "パレット", "色設定"],
+    "summary": "PCG provides blue, red and green pattern bytes for programmable text characters. Base graphics palette components are controlled through the 1000H, 1100H and 1200H port groups.",
+    "syntax": [
+      "1000H-10FFH   blue graphics palette component",
+      "1100H-11FFH   red graphics palette component",
+      "1200H-12FFH   green graphics palette component",
+      "1400H-14FFH   character/font pattern read path",
+      "1500H-15FFH   PCG blue pattern write",
+      "1600H-16FFH   PCG red pattern write",
+      "1700H-17FFH   PCG green pattern write",
+      "attribute bit 5 (20H) selects PCG for a text cell"
+    ],
+    "notes": [
+      "A PCG glyph is color-planar: each raster row has separate blue, red and green pattern bytes. The text attribute PCG bit selects programmable rather than ROM character data.",
+      "Original-compatible PCG access is synchronized with the currently scanned text cell. X1turbo/Z high-speed PCG mode changes addressing behavior and is selected by screen-control bit 5.",
+      "Direct PCG port programming is timing- and mode-sensitive. For FuzzyBASIC or SLANG, prefer the bundled PCG helpers documented by those language profiles unless hardware-level control is required.",
+      "The 1000H/1100H/1200H groups are base blue/red/green palette controls. X1turboZ extended palettes add further modes and ports not covered by this initial reference.",
+      "PCG RAM is not exposed by the current VRAM debugger regions. text and attribute regions let a debugger inspect which character and PCG attribute a cell uses."
+    ],
+    "relatedIds": ["x1.video.text-vram", "x1.video.screen-control", "x1.video.graphics-vram", "x1.architecture.address-spaces"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_PCG.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_CRTC.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_VRAM.H",
+      "http://x1center.org/sdx1/sdx1_0.html"
+    ]
+  }
+]

--- a/mcp/reference/x1-hardware.json
+++ b/mcp/reference/x1-hardware.json
@@ -22,6 +22,12 @@
       "A general debugger IN/OUT API is intentionally not exposed: device reads can acknowledge interrupts, consume data or change modes. VRAM debugger reads use a side-effect-free physical view.",
       "On this X1 implementation, every ordinary IN clears graphics simultaneous-access mode. A debugger VRAM read does not call Z80_In and therefore does not clear it."
     ],
+    "examples": [
+      {
+        "title": "Read and write a 16-bit X1 I/O port through BC",
+        "source": "ORG 0100H\nLD BC,04000H\nIN A,(C)\nOUT (C),A\nRET"
+      }
+    ],
     "relatedIds": ["x1.memory.cpu-banking", "x1.video.text-vram", "x1.video.graphics-vram", "x1.video.screen-control"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_IO.CPP",
@@ -52,6 +58,12 @@
       "Graphics bank 0/1 is unrelated to these CPU-memory pages. Select graphics banks only through screen control or the VRAM debugger bank parameter.",
       "EMM is a separate I/O peripheral and is not the X1turbo low-memory bank mechanism. This initial hardware profile does not document EMM ports."
     ],
+    "examples": [
+      {
+        "title": "Write turbo bank-RAM page 2 from stable high memory",
+        "source": "ORG 8000H\nLD BC,00B00H\nLD A,02H\nOUT (C),A\nLD HL,0000H\nLD (HL),05AH\nLD A,010H\nOUT (C),A\nRET"
+      }
+    ],
     "relatedIds": ["x1.architecture.address-spaces", "x1.video.graphics-vram", "x1.video.screen-control"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_IO.CPP",
@@ -81,6 +93,12 @@
       "On original X1, hardware reads and writes at 3800H-3FFFH mirror ANK text VRAM. Software can use this behavior to distinguish X1 from turbo models.",
       "The debugger deliberately rejects region kanji on original X1 so clients do not mistake the mirror for an independent region. Read region text to observe the underlying ANK data.",
       "Writing through the debugger applies the emulator's normal text dirty, blink and double-size handling and is allowed only while paused."
+    ],
+    "examples": [
+      {
+        "title": "Put a white A in the first text cell",
+        "source": "ORG 0100H\nLD BC,01A02H\nIN A,(C)\nLD BC,03000H\nLD A,041H\nOUT (C),A\nLD BC,02000H\nLD A,07H\nOUT (C),A\nRET"
+      }
     ],
     "relatedIds": ["x1.architecture.address-spaces", "x1.video.pcg-palette", "x1.video.screen-control", "x1.video.graphics-vram"],
     "sourceUrls": [
@@ -115,6 +133,12 @@
       "PPI port C at 1A02H controls the simultaneous-access trigger. A bit-5 falling edge enters the mode; subsequent OUT instructions write the plane combinations shown above instead of ordinary I/O devices.",
       "Any ordinary IN clears simultaneous-access mode. x1pen_debug_read_vram does not perform IN and therefore does not disturb the mode.",
       "Pause before a multi-byte dump when a consistent snapshot matters. Debugger writes are paused-only and mark changed graphics bytes for a later display frame."
+    ],
+    "examples": [
+      {
+        "title": "Write one byte to the blue graphics plane",
+        "source": "ORG 0100H\nLD BC,01A02H\nIN A,(C)\nLD BC,04000H\nLD A,080H\nOUT (C),A\nRET"
+      }
     ],
     "relatedIds": ["x1.architecture.address-spaces", "x1.video.screen-control", "x1.video.text-vram", "x1.video.pcg-palette"],
     "sourceUrls": [
@@ -153,6 +177,12 @@
       "Do not recompute the current dimensions from screenBits alone; CRTC registers and the 40/80-column PPI state also contribute.",
       "The MCP VRAM display/access selectors are resolved inside the same WASM call as the copy, avoiding a bank-change race within the single-threaded emulator call."
     ],
+    "examples": [
+      {
+        "title": "Toggle the displayed graphics bank on X1turbo/Z",
+        "source": "ORG 0100H\nLD BC,01FD0H\nIN A,(C)\nXOR 08H\nOUT (C),A\nRET"
+      }
+    ],
     "relatedIds": ["x1.video.graphics-vram", "x1.video.text-vram", "x1.video.pcg-palette", "x1.architecture.address-spaces"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_CRTC.H",
@@ -186,6 +216,12 @@
       "Direct PCG port programming is timing- and mode-sensitive. For FuzzyBASIC or SLANG, prefer the bundled PCG helpers documented by those language profiles unless hardware-level control is required.",
       "The 1000H/1100H/1200H groups are base blue/red/green palette controls. X1turboZ extended palettes add further modes and ports not covered by this initial reference.",
       "PCG RAM is not exposed by the current VRAM debugger regions. text and attribute regions let a debugger inspect which character and PCG attribute a cell uses."
+    ],
+    "examples": [
+      {
+        "title": "Set the base blue palette component",
+        "source": "ORG 0100H\nLD BC,01000H\nLD A,0FFH\nOUT (C),A\nRET"
+      }
     ],
     "relatedIds": ["x1.video.text-vram", "x1.video.screen-control", "x1.video.graphics-vram", "x1.architecture.address-spaces"],
     "sourceUrls": [

--- a/mcp/x1pen-reference.mjs
+++ b/mcp/x1pen-reference.mjs
@@ -6,6 +6,7 @@ const ENTRIES = Object.freeze([
   ...readJson('fuzzybasic.json'),
   ...readJson('slang.json'),
   ...readJson('slang-catalogs.json'),
+  ...readJson('x1-hardware.json'),
 ]);
 const ENTRY_BY_ID = new Map(ENTRIES.map((entry) => [entry.id, entry]));
 

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -18,8 +18,11 @@ const MAX_SOURCE_LENGTH = 512 * 1024;
 const DEFAULT_RANGE_CHARACTERS = 32 * 1024;
 const MAX_RANGE_CHARACTERS = 128 * 1024;
 const SOURCE_SECTIONS = ['basic', 'asm', 'slang'];
-const REFERENCE_LANGUAGES = ['fuzzybasic', 'slang'];
-const REFERENCE_KINDS = ['syntax', 'runtime', 'x1-extension', 'catalog', 'library', 'profile', 'limits'];
+const REFERENCE_LANGUAGES = ['fuzzybasic', 'slang', 'x1'];
+const REFERENCE_KINDS = [
+  'syntax', 'runtime', 'x1-extension', 'catalog', 'library', 'profile', 'limits',
+  'architecture', 'memory', 'video', 'io',
+];
 const DEBUGGER_STOP_REASONS = ['none', 'manual', 'breakpoint', 'step'];
 const DEBUGGER_MAX_READ_LENGTH = 4096;
 const DEBUGGER_MAX_BREAKPOINTS = 1024;
@@ -33,6 +36,7 @@ const DEBUGGER_VRAM_REGION_SIZES = {
 };
 const SERVER_INSTRUCTIONS = [
   'X1Pen FuzzyBASIC and X1Pen SLANG are nonstandard languages. Do not infer syntax or APIs from ordinary BASIC, C, or another SLANG release.',
+  'The X1 has separate CPU-memory, I/O-port and video-memory spaces. Before direct memory, port, bank or VRAM work, search the bundled x1 hardware reference instead of inferring another machine architecture.',
   'Before writing or substantially editing a program, call x1pen_get_language_profile, search the bundled reference with x1pen_search_reference, and fetch only the needed IDs with x1pen_get_reference.',
   'After editing, call x1pen_validate. Run and inspect the visible emulator when behavior must be confirmed.',
   'Prefer bounded source and reference tools so generated ASM and unrelated manual sections do not consume context.',
@@ -395,7 +399,7 @@ export function createX1PenMcpServer(options = {}) {
   }, handleTool(async ({ sessionId }) => textResult(bridge.selectSession(sessionId))));
 
   server.registerTool('x1pen_get_language_profile', {
-    description: 'Call before generating nontrivial code. Lists the bundled nonstandard FuzzyBASIC and SLANG profiles and, when connected, compares them with the exact profiles reported by X1Pen.',
+    description: 'Call before generating nontrivial code. Lists the bundled FuzzyBASIC, SLANG and X1 hardware profiles and, when connected, compares language profiles with those reported by X1Pen.',
     inputSchema: {
       sessionId: sessionInput.sessionId,
       includeActive: z.boolean().default(true)
@@ -429,7 +433,7 @@ export function createX1PenMcpServer(options = {}) {
   }));
 
   server.registerTool('x1pen_search_reference', {
-    description: 'Search the bundled X1Pen-specific FuzzyBASIC and SLANG reference before assuming syntax or APIs. Returns compact summaries and stable IDs; use x1pen_get_reference for selected details.',
+    description: 'Search the bundled X1Pen-specific FuzzyBASIC, SLANG and X1 hardware reference before assuming syntax, APIs, memory maps or I/O behavior. Returns compact summaries and stable IDs; use x1pen_get_reference for selected details.',
     inputSchema: {
       query: z.string().min(1).max(1_024),
       language: z.enum(REFERENCE_LANGUAGES).optional(),

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -49,6 +49,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'reference/manifest.json',
       'reference/slang-catalogs.json',
       'reference/slang.json',
+      'reference/x1-hardware.json',
       'x1pen-bridge.mjs',
       'x1pen-reference.mjs',
       'x1pen-server.mjs',
@@ -65,7 +66,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.6.0');
+    assert.equal(manifest.version, '2.7.0');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');
@@ -80,6 +81,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     client = new Client({ name: 'x1pen-package-test', version: '1.0.0' });
     await client.connect(transport);
     assert.match(client.getInstructions(), /FuzzyBASIC and X1Pen SLANG are nonstandard/);
+    assert.match(client.getInstructions(), /separate CPU-memory, I\/O-port and video-memory spaces/);
     assert.match(client.getInstructions(), /x1pen_search_reference/);
 
     const tools = await client.listTools();
@@ -100,6 +102,13 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     });
     const matches = JSON.parse(reference.content[0].text);
     assert.equal(matches.matches[0].id, 'fuzzybasic.subroutines.proc');
+
+    const hardwareReference = await client.callTool({
+      name: 'x1pen_search_reference',
+      arguments: { language: 'x1', query: 'バンクメモリ VRAM' },
+    });
+    const hardwareMatches = JSON.parse(hardwareReference.content[0].text);
+    assert.ok(hardwareMatches.matches.some((match) => match.language === 'x1'));
   } finally {
     if (client) await client.close();
     await rm(tempRoot, { recursive: true, force: true });

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -66,7 +66,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     const packageRoot = join(installRoot, 'node_modules', 'x1pen-mcp');
     const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
     assert.equal(manifest.name, 'x1pen-mcp');
-    assert.equal(manifest.version, '2.7.0');
+    assert.equal(manifest.version, '2.6.0');
     assert.deepEqual(manifest.bin, { 'x1pen-mcp': 'x1pen-server.mjs' });
 
     const serverPath = join(packageRoot, 'x1pen-server.mjs');

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -230,16 +230,23 @@ test('language reference tools search compact results and fetch selected details
   const symbolSearch = jsonContent(symbolResult);
   assert.equal(symbolSearch.matchMode, 'symbol');
   assert.equal(symbolSearch.matches[0].id, 'slang.expressions.operators');
+
+  const hardwareResult = await client.callTool({
+    name: 'x1pen_search_reference',
+    arguments: { language: 'x1', query: 'I/O空間 VRAM' },
+  });
+  assert.equal(jsonContent(hardwareResult).matches[0].id, 'x1.architecture.address-spaces');
 });
 
 test('language profile reports bundled data and connected X1Pen compatibility', async () => {
   const result = await client.callTool({ name: 'x1pen_get_language_profile', arguments: {} });
   const profile = jsonContent(result);
   assert.equal(profile.schemaVersion, 2);
-  assert.equal(profile.profiles.length, 2);
+  assert.equal(profile.profiles.length, 3);
   assert.equal(profile.active.id, 'x1pen-fuzzybasic-1.2L');
   assert.equal(profile.profiles[0].environment, 'SHARP X1 / LSX-Dodgers');
   assert.equal(profile.reportedProfiles.slang.id, 'x1pen-slang-c9e8f53-lsx');
+  assert.equal(profile.defaultProfiles.x1, 'x1-hardware-xmillennium-web');
   assert.equal(profile.compatible, true);
   assert.equal(calls.at(-1).method, 'getStatus');
 });

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -145,6 +145,28 @@ test('representative Japanese and English queries reach dedicated SLANG entries'
   }
 });
 
+test('representative Japanese and English queries reach dedicated X1 hardware entries', () => {
+  const cases = new Map([
+    ['I/O空間 VRAM', 'x1.architecture.address-spaces'],
+    ['CPU memory versus video memory', 'x1.architecture.address-spaces'],
+    ['バンクメモリ', 'x1.memory.cpu-banking'],
+    ['turbo low memory bank', 'x1.memory.cpu-banking'],
+    ['属性VRAM', 'x1.video.text-vram'],
+    ['kanji VRAM mirror', 'x1.video.text-vram'],
+    ['色プレーン', 'x1.video.graphics-vram'],
+    ['simultaneous access', 'x1.video.graphics-vram'],
+    ['表示バンク アクセスバンク', 'x1.video.screen-control'],
+    ['screen control CRTC', 'x1.video.screen-control'],
+    ['PCG パレット', 'x1.video.pcg-palette'],
+    ['programmable character palette', 'x1.video.pcg-palette'],
+  ]);
+
+  for (const [query, expectedId] of cases) {
+    const result = searchReference({ language: 'x1', query, maxResults: 3 });
+    assert.equal(result.matches[0]?.id, expectedId, query);
+  }
+});
+
 test('dedicated entries rank above the exhaustive keyword catalog', () => {
   for (const [language, query, expectedId] of [
     ['fuzzybasic', 'CIRCLE', 'fuzzybasic.x1.graphics-magic'],
@@ -209,6 +231,60 @@ test('every SLANG reference entry is reachable through relatedIds', () => {
     [...incoming].filter(([, count]) => count === 0).map(([id]) => id),
     [],
   );
+});
+
+test('every X1 hardware reference entry is reachable through relatedIds', () => {
+  const entries = validateReferenceData().entries
+    .filter((entry) => entry.language === 'x1');
+  const incoming = new Map(entries.map((entry) => [entry.id, 0]));
+  for (const entry of entries) {
+    for (const relatedId of entry.relatedIds || []) {
+      if (incoming.has(relatedId)) incoming.set(relatedId, incoming.get(relatedId) + 1);
+    }
+  }
+  assert.deepEqual(
+    [...incoming].filter(([, count]) => count === 0).map(([id]) => id),
+    [],
+  );
+});
+
+test('X1 hardware reference matches emulator memory and VRAM constants', () => {
+  const x1Header = readFileSync(join(repoRoot, 'src/X1.H'), 'utf8');
+  const crtcHeader = readFileSync(join(repoRoot, 'src/X1_CRTC.H'), 'utf8');
+  const ioSource = readFileSync(join(repoRoot, 'src/X1_IO.CPP'), 'utf8');
+  const vramSource = readFileSync(join(repoRoot, 'platform/x1_vram_port.cpp'), 'utf8');
+  const details = JSON.stringify(getReferenceEntries({
+    ids: [
+      'x1.architecture.address-spaces',
+      'x1.memory.cpu-banking',
+      'x1.video.text-vram',
+      'x1.video.graphics-vram',
+      'x1.video.screen-control',
+    ],
+    maxCharacters: 64 * 1024,
+  }).entries);
+
+  assert.match(x1Header, /mBANK\[16\]\[0x8000\]/);
+  assert.match(x1Header, /GRAM_BANK1\s+0x10000/);
+  assert.match(ioSource, /ROM_TYPE >= 2.*hi == 0x0b/s);
+  assert.match(ioSource, /if \(s8255\.IO_MODE\).*x1_grp_w2/s);
+  assert.match(ioSource, /BYTE __fastcall Z80_In[\s\S]*?s8255\.IO_MODE = 0;/);
+  assert.match(vramSource, /text_ports\[\] = \{ 0x3000, 0x2000, 0x3800 \}/);
+  assert.match(vramSource, /plane_ports\[\] = \{ 0x4000, 0x8000, 0xC000 \}/);
+  for (const [name, value] of [
+    ['SCRN_DISPVRAM', '0x08'],
+    ['SCRN_ACCESSVRAM', '0x10'],
+    ['SCRN_PCGMODE', '0x20'],
+  ]) {
+    assert.match(crtcHeader, new RegExp(`#define\\s+${name}\\s+${value}`));
+  }
+  for (const fact of [
+    '2000H-27FFH', '2800H-2FFFH', '3000H-37FFH', '3800H-3FFFH',
+    '4000H-7FFFH', '8000H-BFFFH', 'C000H-FFFFH',
+    'B+R+G', 'R+G', 'B+G', 'B+R', '0B00H-0BFFH',
+  ]) {
+    assert.ok(details.includes(fact), `${fact} must remain documented`);
+  }
 });
 
 test('every X1Pen FuzzyBASIC tokenizer keyword is covered by symbols', () => {

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -287,6 +287,22 @@ test('X1 hardware reference matches emulator memory and VRAM constants', () => {
   }
 });
 
+test('every X1 hardware example assembles with the bundled Z80 assembler', () => {
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const entries = validateReferenceData().entries
+    .filter((entry) => entry.language === 'x1');
+  assert.ok(entries.length >= 6);
+  for (const entry of entries) {
+    assert.ok(entry.examples?.length > 0, `${entry.id} must include an example`);
+    for (const example of entry.examples) {
+      const result = assembler.assemble(example.source);
+      assert.equal(result.errors.length, 0,
+        `${entry.id}: ${example.title}: ${JSON.stringify(result.errors)}`);
+      assert.ok(result.bytes.length > 0, `${entry.id}: ${example.title} must produce bytes`);
+    }
+  }
+});
+
 test('every X1Pen FuzzyBASIC tokenizer keyword is covered by symbols', () => {
   const tokenizerSource = readFileSync(join(repoRoot, 'html/x1pen_tokenizer.js'), 'utf8');
   const table = tokenizerSource.match(/var RSVTBL = \[([\s\S]*?)\n\s*\];/);


### PR DESCRIPTION
## Summary
- add an offline-searchable `x1` hardware profile with six focused reference entries
- teach MCP initialization and reference search to distinguish CPU memory, I/O ports, VRAM, and their independent banks
- include the reference in the still-unreleased `x1pen-mcp` 2.6.0 without changing X1Pen, WASM, or the Chrome extension

## Initial coverage
- Z80 CPU-memory and 16-bit I/O address spaces
- X1turbo/Z low-memory bank RAM and ROM switching
- text, attribute, ANK, and kanji VRAM including canonical ranges and mirrors
- graphics bank 0/1, B/R/G planes, and PPI simultaneous access
- CRTC/screen control and independent display/access banks
- PCG pattern ports and the base graphics palette

Each entry includes a bundled-assembler-checked Z80 example. I/O examples use the X1's 16-bit port form (`LD BC,xxxxH` plus `IN/OUT (C)`), and the low-memory bank example executes from stable memory above 8000H.

The reference explicitly leaves the broader PSG, sub-CPU, CTC, DMA, FDC, SASI, and EMM I/O map for incremental follow-up work.

## Verification
- `npm run test:mcp` (37/37)
- `npm run test:mcp-package` (1/1)
- implementation-derived assertions for bank count, VRAM ports, screen bits, and simultaneous-access behavior
- Japanese and English search cases for all six entries

Completes the initial hardware-reference scope of Issue #72. The broader I/O catalog remains follow-up work.
