### PR TITLE
Negotiate X1Pen component capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(XMillennium-Web)
 
-set(XMIL_VERSION "0.7.3")
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/html/x1pen-version.js" X1PEN_VERSION_SOURCE)
+string(REGEX MATCH "version:[ \t]*'([0-9]+\\.[0-9]+\\.[0-9]+)'" X1PEN_VERSION_MATCH "${X1PEN_VERSION_SOURCE}")
+if(NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "Could not read X1Pen version from html/x1pen-version.js")
+endif()
+set(XMIL_VERSION "${CMAKE_MATCH_1}")
 
 # Emscripten用の設定
 if(EMSCRIPTEN)

--- a/build.sh
+++ b/build.sh
@@ -64,8 +64,9 @@ emcmake cmake .. -DCMAKE_BUILD_TYPE=Release
 echo "Building..."
 emmake make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
-# CMakeLists.txt からバージョン文字列を取得
-XMIL_VERSION=$(grep 'set(XMIL_VERSION' "${SCRIPT_DIR}/CMakeLists.txt" | sed 's/.*"\(.*\)".*/\1/')
+# X1Penの製品バージョンはhtml/x1pen-version.jsを真実の源とする
+XMIL_VERSION=$(sed -n "s/.*version: '\([^']*\)'.*/\1/p" "${SCRIPT_DIR}/html/x1pen-version.js" | head -1)
+[ -n "${XMIL_VERSION}" ] || { echo "Failed to read X1Pen version" >&2; exit 1; }
 COLD_STATE_FILE="fuzzybasic_cold.v1.xmst"
 BOOT_DISK_FILE="fuzzybasic_boot.v1.d88"
 
@@ -89,6 +90,7 @@ cp "${SCRIPT_DIR}/html/apple-touch-icon.png" ./apple-touch-icon.png
 
 # X1Pen IDE ファイル
 cp "${SCRIPT_DIR}/html/x1pen.html"           ./x1pen.html
+cp "${SCRIPT_DIR}/html/x1pen-version.js"     ./x1pen-version.js
 cp "${SCRIPT_DIR}/html/x1pen.js"             ./x1pen.js
 cp "${SCRIPT_DIR}/html/x1pen_tokenizer.js"   ./x1pen_tokenizer.js
 cp "${SCRIPT_DIR}/html/x1pen_z80asm.js"     ./x1pen_z80asm.js
@@ -180,6 +182,7 @@ cp ./apple-touch-icon.png "${DIST_DIR}/"
 
 # X1Pen IDE
 cp "${SCRIPT_DIR}/html/x1pen.html"           "${DIST_DIR}/"
+cp "${SCRIPT_DIR}/html/x1pen-version.js"     "${DIST_DIR}/"
 cp "${SCRIPT_DIR}/html/x1pen.js"             "${DIST_DIR}/"
 cp "${SCRIPT_DIR}/html/x1pen_tokenizer.js"   "${DIST_DIR}/"
 cp "${SCRIPT_DIR}/html/x1pen_z80asm.js"     "${DIST_DIR}/"

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -74,6 +74,14 @@ MCPサーバーのnpm配布とブラウザー拡張の配布は独立してお�
 
 接続されたX1Penには`MCP Connected`と表示されます。複数タブを接続した場合は`x1pen_list_sessions`と`x1pen_select_session`で操作対象を選びます。通常はX1Pen自身の複数タブ警告により1タブだけが接続されます。
 
+### バージョンと機能互換性
+
+`x1pen_connection_info`、`x1pen_list_sessions`、`x1pen_get_status`は、MCPサーバー、Connector、X1Penのバージョンと実効capabilityを返します。バージョンは診断と更新案内に使用し、実際の利用可否は3コンポーネントが申告するfeatureの積集合で決定します。
+
+feature IDは完全一致する不変の契約です。現在は`automation.core`、`screen.capture`、`debugger.cpu`、`debugger.vram`を使用します。後方互換性のない変更では既存IDの意味を変更せず、`debugger.vram-v2`のような新しいIDを追加します。
+
+公開済みのConnector 1.0.1、1.1.0、1.1.1だけは、明示featureがないためMCPサーバーが既知の機能を推定します。この表は歴史的互換性のために凍結されており、Connector 1.2.0以降は明示featureを申告します。未対応機能はConnectorへ送信する前に拒否され、`component`、`feature`、現在版、必要な場合は必要版、対処方法を含む機械可読エラーが返ります。
+
 ## ツール
 
 | Tool | 内容 |
@@ -253,6 +261,16 @@ npm publish ./mcp
 ```
 
 公開後は`npm view x1pen-mcp version`と`npx -y x1pen-mcp@<version> --version`で確認します。
+
+### コンポーネント公開順
+
+互換性機能を追加するリリースは、次の順序で公開します。
+
+1. `html/x1pen-version.js`を更新し、X1Penをデプロイ
+2. `extension/manifest.json`を更新し、ConnectorをChrome Web Storeへ提出・公開
+3. `mcp/package.json`を更新し、MCPサーバーをnpmへ公開
+
+X1Pen製品バージョンの真実の源は`html/x1pen-version.js`です。X1Pen 0.8.0、Connector 1.2.0、MCP 2.6.0から明示的な3層互換性情報に対応します。X1Penのリリースタグは製品バージョンと同じ`v<version>`形式にします。
 
 ## セキュリティ
 

--- a/extension/compatibility.mjs
+++ b/extension/compatibility.mjs
@@ -1,0 +1,78 @@
+export const CONNECTOR_PROTOCOL_VERSION = 2;
+export const CONNECTOR_FEATURES = Object.freeze([
+  'automation.core',
+  'screen.capture',
+  'debugger.cpu',
+  'debugger.vram',
+]);
+
+const FEATURE_PATTERN = /^[a-z][a-z0-9.-]{0,63}$/;
+
+export function normalizeFeatureList(value) {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(value
+    .slice(0, 64)
+    .filter((feature) => typeof feature === 'string' && FEATURE_PATTERN.test(feature))));
+}
+
+export function createConnectorDescriptor(version) {
+  return {
+    name: 'x1pen-connector',
+    version: String(version || 'unknown'),
+    protocolVersion: CONNECTOR_PROTOCOL_VERSION,
+    features: [...CONNECTOR_FEATURES],
+  };
+}
+
+export function normalizeX1PenDescriptor(status) {
+  const advertised = status?.x1pen;
+  const features = normalizeFeatureList(advertised?.features);
+  if (!Array.isArray(advertised?.features)) {
+    features.push('automation.core', 'screen.capture');
+    if (status?.capabilities?.debugger?.available) features.push('debugger.cpu');
+    if (status?.capabilities?.debugger?.vram?.available) features.push('debugger.vram');
+  }
+  return {
+    name: 'x1pen',
+    version: typeof advertised?.version === 'string' ? advertised.version : null,
+    automationApiVersion: Number.isInteger(advertised?.automationApiVersion)
+      ? advertised.automationApiVersion
+      : 2,
+    features: normalizeFeatureList(features),
+  };
+}
+
+export function normalizeMcpServerDescriptor(message) {
+  const server = message?.server;
+  return {
+    name: typeof server?.name === 'string' ? server.name : 'x1pen-mcp',
+    version: typeof server?.version === 'string' ? server.version : null,
+    protocolVersion: Number.isInteger(message?.protocolVersion) ? message.protocolVersion : 1,
+    features: normalizeFeatureList(server?.features),
+  };
+}
+
+export function assertMcpProtocolSupported(server) {
+  if (server.protocolVersion >= 1 && server.protocolVersion <= CONNECTOR_PROTOCOL_VERSION) return;
+  const error = new Error(
+    `MCP bridge protocol ${server.protocolVersion} is not supported by this X1Pen Connector`,
+  );
+  error.code = 'BRIDGE_PROTOCOL_UNSUPPORTED';
+  error.component = 'mcp';
+  error.currentVersion = server.version || 'unknown';
+  error.action = 'Update X1Pen Connector and reconnect this tab.';
+  throw error;
+}
+
+export function serializeExtensionError(error) {
+  const serialized = {
+    message: error?.message || String(error),
+  };
+  if (typeof error?.code === 'string') serialized.code = error.code;
+  if (['mcp', 'connector', 'x1pen'].includes(error?.component)) serialized.component = error.component;
+  if (typeof error?.feature === 'string') serialized.feature = error.feature;
+  if (typeof error?.currentVersion === 'string') serialized.currentVersion = error.currentVersion;
+  if (typeof error?.requiredVersion === 'string') serialized.requiredVersion = error.requiredVersion;
+  if (typeof error?.action === 'string') serialized.action = error.action;
+  return serialized;
+}

--- a/extension/page-automation.mjs
+++ b/extension/page-automation.mjs
@@ -1,24 +1,50 @@
 export async function invokeX1PenInPage(requestedMethod, requestedParams) {
   const api = window.X1PenAutomation;
-  if (!api || api.version < 2) throw new Error('This tab does not provide X1Pen Automation API v2');
+  if (!api || api.version < 2) {
+    const error = new Error('This tab does not provide X1Pen Automation API v2');
+    error.code = 'X1PEN_UPDATE_REQUIRED';
+    error.component = 'x1pen';
+    error.feature = 'automation.core';
+    error.requiredVersion = '0.8.0';
+    error.action = 'Reload X1Pen and reconnect this tab.';
+    throw error;
+  }
   if (requestedMethod === 'probe') return api.ready();
   if (requestedMethod === 'connection') {
     return api.setConnectionState(requestedParams.connected, requestedParams.connected ? 'MCP Connected' : '');
   }
 
   const requireDebugger = () => {
-    const capability = api.getStatus().capabilities?.debugger;
-    if (!api.debugger || !capability?.available) {
-      throw new Error('The connected X1Pen does not provide the debugger API');
+    const status = api.getStatus();
+    const features = status.x1pen?.features;
+    const capability = status.capabilities?.debugger;
+    const available = Array.isArray(features) ? features.includes('debugger.cpu') : capability?.available;
+    if (!api.debugger || !available) {
+      const error = new Error('The connected X1Pen does not provide the debugger API');
+      error.code = 'FEATURE_UNAVAILABLE';
+      error.component = 'x1pen';
+      error.feature = 'debugger.cpu';
+      error.currentVersion = status.x1pen?.version || 'unknown';
+      error.action = 'Reload or update X1Pen and reconnect this tab.';
+      throw error;
     }
     return api.debugger;
   };
   const requireVramDebugger = () => {
     const debuggerApi = requireDebugger();
-    const capability = api.getStatus().capabilities?.debugger?.vram;
-    if (!capability?.available || !debuggerApi.getVideoState ||
+    const status = api.getStatus();
+    const features = status.x1pen?.features;
+    const capability = status.capabilities?.debugger?.vram;
+    const available = Array.isArray(features) ? features.includes('debugger.vram') : capability?.available;
+    if (!available || !debuggerApi.getVideoState ||
         !debuggerApi.readVram || !debuggerApi.writeVram) {
-      throw new Error('The connected X1Pen does not provide the VRAM debugger API');
+      const error = new Error('The connected X1Pen does not provide the VRAM debugger API');
+      error.code = 'FEATURE_UNAVAILABLE';
+      error.component = 'x1pen';
+      error.feature = 'debugger.vram';
+      error.currentVersion = status.x1pen?.version || 'unknown';
+      error.action = 'Reload or update X1Pen and reconnect this tab.';
+      throw error;
     }
     return debuggerApi;
   };

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -88,6 +88,22 @@ button:disabled { opacity: 0.5; cursor: default; }
   color: #9da7b3;
 }
 #status.error { color: #ff8b8b; }
+.versions {
+  margin: 8px 0 0;
+  padding: 7px 0;
+  border-top: 1px solid #2a313b;
+  border-bottom: 1px solid #2a313b;
+  color: #9da7b3;
+  font-size: 11px;
+}
+.versions div {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 8px;
+  padding: 2px 0;
+}
+.versions dt, .versions dd { margin: 0; }
+.versions dd { color: #e6edf3; overflow-wrap: anywhere; }
 ul {
   margin: 7px 0 0;
   padding: 0;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -25,6 +25,11 @@
     <button id="disconnect" class="secondary">Disconnect</button>
   </div>
   <p id="status" role="status">Not connected</p>
+  <dl class="versions" aria-label="Component versions">
+    <div><dt>Connector</dt><dd id="connector-version">unknown</dd></div>
+    <div><dt>MCP server</dt><dd id="mcp-version">not connected</dd></div>
+    <div><dt>X1Pen</dt><dd id="x1pen-version">not connected</dd></div>
+  </dl>
   <ul id="sessions"></ul>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -5,6 +5,9 @@ const connectButton = document.getElementById('connect');
 const disconnectButton = document.getElementById('disconnect');
 const statusElement = document.getElementById('status');
 const sessionsElement = document.getElementById('sessions');
+const connectorVersionElement = document.getElementById('connector-version');
+const mcpVersionElement = document.getElementById('mcp-version');
+const x1penVersionElement = document.getElementById('x1pen-version');
 
 loadState();
 
@@ -48,6 +51,12 @@ async function loadState() {
       portInput.value = state.bridgeConfig.port;
       codeInput.value = state.bridgeConfig.code;
     }
+    connectorVersionElement.textContent = state.connector?.version || 'unknown';
+    mcpVersionElement.textContent = state.server?.version || (state.paired ? 'legacy / unknown' : 'not connected');
+    const x1penVersions = Array.from(new Set(state.sessions
+      .map((session) => session.x1pen?.version)
+      .filter(Boolean)));
+    x1penVersionElement.textContent = x1penVersions.length ? x1penVersions.join(', ') : 'not connected';
     sessionsElement.replaceChildren(...state.sessions.map((session) => {
       const item = document.createElement('li');
       item.textContent = `${session.active ? 'Active: ' : ''}${session.title}`;

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -1,5 +1,12 @@
 import { invokeX1PenInPage } from './page-automation.mjs';
 import { createUpdateCoordinator } from './update-coordinator.mjs';
+import {
+  assertMcpProtocolSupported,
+  createConnectorDescriptor,
+  normalizeMcpServerDescriptor,
+  normalizeX1PenDescriptor,
+  serializeExtensionError,
+} from './compatibility.mjs';
 
 const connectedTabs = new Map();
 let bridgeConfig = null;
@@ -7,6 +14,33 @@ let socket = null;
 let paired = false;
 let connectPromise = null;
 let reconnectTimer = null;
+let serverDescriptor = null;
+
+function connectorDescriptor() {
+  return createConnectorDescriptor(chrome.runtime.getManifest().version);
+}
+
+function sessionFromStatus(status, base = {}) {
+  return {
+    ...base,
+    sessionId: base.sessionId || status.instanceId,
+    title: status.title,
+    url: status.url,
+    revision: status.revision,
+    x1pen: normalizeX1PenDescriptor(status),
+  };
+}
+
+function bridgeSession(session) {
+  return {
+    sessionId: session.sessionId,
+    title: session.title,
+    url: session.url,
+    active: !!session.active,
+    revision: session.revision,
+    x1pen: session.x1pen,
+  };
+}
 
 const updateCoordinator = createUpdateCoordinator({
   prepare: prepareForUpdate,
@@ -23,7 +57,9 @@ async function initialize() {
   const session = await chrome.storage.session.get('connectedTabs');
   for (const item of session.connectedTabs || []) connectedTabs.set(item.sessionId, item);
   updateBadge();
-  if (bridgeConfig && connectedTabs.size > 0) connectBridge().catch(() => {});
+  if (bridgeConfig && connectedTabs.size > 0) {
+    connectBridge().then(refreshSessions).then(sendSessions).catch(() => {});
+  }
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -44,7 +80,13 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 async function handlePopupMessage(message) {
   if (message.type === 'get-state') {
     await refreshSessions();
-    return { bridgeConfig, paired, sessions: Array.from(connectedTabs.values()) };
+    return {
+      bridgeConfig,
+      paired,
+      connector: connectorDescriptor(),
+      server: serverDescriptor,
+      sessions: Array.from(connectedTabs.values(), bridgeSession),
+    };
   }
   if (message.type === 'connect-active-tab') {
     const port = Number(message.port);
@@ -57,21 +99,17 @@ async function handlePopupMessage(message) {
     const status = await invokeX1Pen(tab.id, 'probe', {});
     bridgeConfig = { port, code };
     await chrome.storage.local.set({ bridgeConfig });
-    connectedTabs.set(status.instanceId, {
-      sessionId: status.instanceId,
+    connectedTabs.set(status.instanceId, sessionFromStatus(status, {
       tabId: tab.id,
-      title: status.title,
-      url: status.url,
       active: true,
-      revision: status.revision,
-    });
+    }));
     await persistSessions();
     try {
       await connectBridge();
       await invokeX1Pen(tab.id, 'connection', { connected: true });
       await refreshSessions();
       sendSessions();
-      return { paired: true, session: connectedTabs.get(status.instanceId) };
+      return { paired: true, session: bridgeSession(connectedTabs.get(status.instanceId)) };
     } catch (error) {
       connectedTabs.delete(status.instanceId);
       await persistSessions();
@@ -112,6 +150,7 @@ async function connectBridge() {
       type: 'pair',
       code: bridgeConfig.code,
       extensionVersion: chrome.runtime.getManifest().version,
+      connector: connectorDescriptor(),
     }));
     ws.onmessage = (event) => {
       let message;
@@ -120,6 +159,16 @@ async function connectBridge() {
         clearTimeout(timeout);
         didPair = true;
         paired = true;
+        serverDescriptor = normalizeMcpServerDescriptor(message);
+        try {
+          assertMcpProtocolSupported(serverDescriptor);
+        } catch (error) {
+          paired = false;
+          serverDescriptor = null;
+          ws.close(1002, 'Unsupported MCP bridge protocol');
+          reject(error);
+          return;
+        }
         sendSessions();
         resolve();
       } else if (message.type === 'command') {
@@ -138,6 +187,7 @@ async function connectBridge() {
       if (socket === ws) {
         socket = null;
         paired = false;
+        serverDescriptor = null;
         for (const session of connectedTabs.values()) {
           invokeX1Pen(session.tabId, 'connection', { connected: false }).catch(() => {});
         }
@@ -183,7 +233,11 @@ async function prepareForUpdate() {
 async function handleCommand(message) {
   const session = connectedTabs.get(message.sessionId);
   if (!session) {
-    send({ type: 'result', id: message.id, ok: false, error: 'X1Pen tab is no longer connected' });
+    send({ type: 'result', id: message.id, ok: false, error: {
+      code: 'SESSION_NOT_FOUND',
+      component: 'connector',
+      message: 'X1Pen tab is no longer connected',
+    } });
     return;
   }
   try {
@@ -192,7 +246,7 @@ async function handleCommand(message) {
     send({ type: 'result', id: message.id, ok: true, result });
     sendSessions();
   } catch (error) {
-    send({ type: 'result', id: message.id, ok: false, error: error.message || String(error) });
+    send({ type: 'result', id: message.id, ok: false, error: serializeExtensionError(error) });
   }
 }
 
@@ -212,13 +266,10 @@ async function refreshSessions() {
   for (const [sessionId, session] of Array.from(connectedTabs)) {
     try {
       const status = await invokeX1Pen(session.tabId, 'getStatus', {});
-      connectedTabs.set(sessionId, {
+      connectedTabs.set(sessionId, sessionFromStatus(status, {
         ...session,
-        title: status.title,
-        url: status.url,
-        revision: status.revision,
         active: session.tabId === activeTab?.id,
-      });
+      }));
     } catch {
       connectedTabs.delete(sessionId);
     }
@@ -227,7 +278,7 @@ async function refreshSessions() {
 }
 
 function sendSessions() {
-  send({ type: 'sessions', sessions: Array.from(connectedTabs.values()) });
+  send({ type: 'sessions', sessions: Array.from(connectedTabs.values(), bridgeSession) });
   updateBadge();
 }
 

--- a/html/x1pen-version.js
+++ b/html/x1pen-version.js
@@ -1,0 +1,8 @@
+(function() {
+    'use strict';
+
+    window.X1PenBuild = Object.freeze({
+        name: 'x1pen',
+        version: '0.8.0'
+    });
+})();

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -811,6 +811,7 @@
     <script src="x1pen_editor.bundle.js"></script>
     <script src="x1pen_tokenizer.js"></script>
     <script src="x1pen_z80asm.js"></script>
+    <script src="x1pen-version.js"></script>
     <script src="x1pen.js"></script>
     <script src="disk_container.js"></script>
     <script src="disk_fs.js"></script>

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1770,6 +1770,16 @@ window.__X1PEN_MODE = true;
         });
     }
 
+    var X1PEN_AUTOMATION_API_VERSION = 2;
+    var X1PEN_PRODUCT = window.X1PenBuild || { name: 'x1pen', version: 'unknown' };
+
+    function getAutomationFeatures() {
+        var features = ['automation.core', 'screen.capture'];
+        if (isDebuggerModuleAvailable()) features.push('debugger.cpu');
+        if (isDebuggerVramModuleAvailable()) features.push('debugger.vram');
+        return features;
+    }
+
     // Call X1PenAutomation.ready() before synchronous observation methods.
     // Async debugger methods wait for readiness.
     var automationDebuggerApi = Object.freeze({
@@ -1835,6 +1845,12 @@ window.__X1PEN_MODE = true;
             status: elStatus ? elStatus.textContent : '',
             sourceMode: sourceMode,
             activeLanguageProfile: activeLanguageProfile,
+            x1pen: {
+                name: X1PEN_PRODUCT.name,
+                version: X1PEN_PRODUCT.version,
+                automationApiVersion: X1PEN_AUTOMATION_API_VERSION,
+                features: getAutomationFeatures()
+            },
             capabilities: {
                 debugger: {
                     available: isDebuggerModuleAvailable(),
@@ -1940,7 +1956,7 @@ window.__X1PEN_MODE = true;
     }
 
     window.X1PenAutomation = Object.freeze({
-        version: 2,
+        version: X1PEN_AUTOMATION_API_VERSION,
         ready: function() {
             return automationReadyPromise.then(getAutomationStatus);
         },

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,6 +36,12 @@ Use `claude mcp list` or `/mcp` to check the connection.
 
 The pairing code changes whenever the MCP server process restarts. One browser extension connection can be paired with one running MCP server at a time.
 
+## Compatibility
+
+Connection, session and status results report the versions and effective features of the MCP server, X1Pen Connector and connected X1Pen. Versions are diagnostic; commands are permitted from the exact feature IDs advertised by all required components. Unsupported debugger commands are rejected before they reach an older Connector and return a machine-readable update action.
+
+The current feature contracts are `automation.core`, `screen.capture`, `debugger.cpu` and `debugger.vram`. Feature IDs are immutable. A backward-incompatible successor uses a new ID such as `debugger.vram-v2` rather than changing the meaning of an existing ID.
+
 ## Z80 debugger
 
 The debugger tools expose named CPU/video state, pause/resume, bounded multi-step execution, atomic PC breakpoint replacement, compact hexadecimal CPU/VRAM reads, paused VRAM writes, and filtered pause waiting. They operate only through the allowlisted X1Pen Automation API; arbitrary JavaScript, raw I/O, and raw WASM access are not exposed.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -12,6 +12,7 @@
     "THIRD_PARTY_LICENSES.md",
     "reference",
     "x1pen-bridge.mjs",
+    "x1pen-compatibility.mjs",
     "x1pen-reference.mjs",
     "x1pen-server.mjs"
   ],

--- a/mcp/x1pen-bridge.mjs
+++ b/mcp/x1pen-bridge.mjs
@@ -1,5 +1,13 @@
 import { randomInt, randomUUID } from 'node:crypto';
 import { WebSocket, WebSocketServer } from 'ws';
+import {
+  assertMethodCompatible,
+  createMcpDescriptor,
+  deserializeBridgeError,
+  evaluateCompatibility,
+  normalizeConnectorPair,
+  normalizeX1PenDescriptor,
+} from './x1pen-compatibility.mjs';
 
 const DEFAULT_START_PORT = 43110;
 const DEFAULT_END_PORT = 43119;
@@ -30,6 +38,8 @@ export class X1PenBridge {
     this.selectedSessionId = null;
     this.pendingCommands = new Map();
     this.keepAliveTimer = null;
+    this.serverDescriptor = options.serverDescriptor || createMcpDescriptor('unknown');
+    this.connectorDescriptor = null;
   }
 
   async start() {
@@ -103,9 +113,14 @@ export class X1PenBridge {
           this.socket.close(1012, 'Replaced by a new extension connection');
         }
         this.socket = socket;
+        this.connectorDescriptor = normalizeConnectorPair(message);
         this.sessions.clear();
         this.selectedSessionId = null;
-        socket.send(JSON.stringify({ type: 'paired', protocolVersion: 1 }));
+        socket.send(JSON.stringify({
+          type: 'paired',
+          protocolVersion: this.serverDescriptor.protocolVersion,
+          server: this.serverDescriptor,
+        }));
         this.logger('browser extension paired');
         return;
       }
@@ -117,6 +132,7 @@ export class X1PenBridge {
       clearTimeout(authTimeout);
       if (this.socket !== socket) return;
       this.socket = null;
+      this.connectorDescriptor = null;
       this.sessions.clear();
       this.selectedSessionId = null;
       this.rejectPending(new Error('X1Pen browser extension disconnected'));
@@ -135,6 +151,7 @@ export class X1PenBridge {
           url: String(session.url || ''),
           active: !!session.active,
           revision: Number.isInteger(session.revision) ? session.revision : 0,
+          x1pen: normalizeX1PenDescriptor(session.x1pen),
         });
       }
       if (this.selectedSessionId && !this.sessions.has(this.selectedSessionId)) this.selectedSessionId = null;
@@ -147,7 +164,7 @@ export class X1PenBridge {
       this.pendingCommands.delete(message.id);
       clearTimeout(pending.timeout);
       if (message.ok) pending.resolve(message.result);
-      else pending.reject(new Error(message.error || 'X1Pen command failed'));
+      else pending.reject(deserializeBridgeError(message.error));
     }
   }
 
@@ -159,6 +176,13 @@ export class X1PenBridge {
       extensionConnected: !!this.socket,
       sessionCount: this.sessions.size,
       selectedSessionId: this.selectedSessionId,
+      components: {
+        mcp: this.serverDescriptor,
+        connector: this.connectorDescriptor,
+      },
+      compatibility: this.selectedSessionId && this.sessions.has(this.selectedSessionId)
+        ? this.getSessionCompatibility(this.selectedSessionId)
+        : null,
     };
   }
 
@@ -166,13 +190,15 @@ export class X1PenBridge {
     return Array.from(this.sessions.values()).map((session) => ({
       ...session,
       selected: session.sessionId === this.selectedSessionId,
+      compatibility: this.getSessionCompatibility(session.sessionId),
     }));
   }
 
   selectSession(sessionId) {
     if (!this.sessions.has(sessionId)) throw new Error(`X1Pen session not found: ${sessionId}`);
     this.selectedSessionId = sessionId;
-    return this.sessions.get(sessionId);
+    const session = this.sessions.get(sessionId);
+    return { ...session, selected: true, compatibility: this.getSessionCompatibility(sessionId) };
   }
 
   resolveSession(sessionId) {
@@ -188,6 +214,8 @@ export class X1PenBridge {
 
   sendCommand(method, params = {}, sessionId) {
     const resolvedSessionId = this.resolveSession(sessionId);
+    const compatibility = this.getSessionCompatibility(resolvedSessionId);
+    assertMethodCompatible(method, compatibility.capabilities, compatibility.components);
     const id = randomUUID();
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -210,6 +238,25 @@ export class X1PenBridge {
     });
   }
 
+  getSessionCompatibility(sessionId) {
+    let resolvedSessionId = sessionId || this.selectedSessionId;
+    if (!resolvedSessionId && this.sessions.size === 1) resolvedSessionId = this.sessions.keys().next().value;
+    const session = this.sessions.get(resolvedSessionId);
+    if (!session) throw new Error(`X1Pen session not found: ${sessionId || 'not selected'}`);
+    const components = {
+      mcp: this.serverDescriptor,
+      connector: this.connectorDescriptor,
+      x1pen: session.x1pen,
+    };
+    return {
+      components,
+      capabilities: evaluateCompatibility({
+        ...components,
+        connected: !!this.socket,
+      }),
+    };
+  }
+
   rejectPending(error) {
     for (const pending of this.pendingCommands.values()) {
       clearTimeout(pending.timeout);
@@ -224,6 +271,7 @@ export class X1PenBridge {
     this.rejectPending(new Error('X1Pen bridge closed'));
     if (this.socket) this.socket.close(1001, 'Server shutting down');
     this.socket = null;
+    this.connectorDescriptor = null;
     if (this.server) {
       const server = this.server;
       this.server = null;

--- a/mcp/x1pen-compatibility.mjs
+++ b/mcp/x1pen-compatibility.mjs
@@ -156,6 +156,7 @@ export function assertMethodCompatible(method, compatibility, components) {
       message: `${feature} is not advertised by the connected ${component === 'connector' ? 'Connector' : 'X1Pen'}.`,
     });
   }
+  // Defensive for a future MCP release that deliberately omits a known feature.
   throw new X1PenCompatibilityError({
     code: 'MCP_UPDATE_REQUIRED',
     component,

--- a/mcp/x1pen-compatibility.mjs
+++ b/mcp/x1pen-compatibility.mjs
@@ -1,0 +1,176 @@
+export const FEATURE_IDS = Object.freeze([
+  'automation.core',
+  'screen.capture',
+  'debugger.cpu',
+  'debugger.vram',
+]);
+
+export const MCP_FEATURES = Object.freeze([...FEATURE_IDS]);
+
+const FEATURE_PATTERN = /^[a-z][a-z0-9.-]{0,63}$/;
+const LEGACY_CONNECTOR_FEATURES = Object.freeze({
+  '1.0.1': ['automation.core', 'screen.capture'],
+  '1.1.0': ['automation.core', 'screen.capture', 'debugger.cpu'],
+  '1.1.1': ['automation.core', 'screen.capture', 'debugger.cpu'],
+});
+
+const METHOD_FEATURES = Object.freeze({
+  getProgram: 'automation.core',
+  setProgram: 'automation.core',
+  validate: 'automation.core',
+  run: 'automation.core',
+  stop: 'automation.core',
+  getStatus: 'automation.core',
+  captureScreen: 'screen.capture',
+  debuggerGetState: 'debugger.cpu',
+  debuggerPause: 'debugger.cpu',
+  debuggerResume: 'debugger.cpu',
+  debuggerStep: 'debugger.cpu',
+  debuggerSetBreakpoints: 'debugger.cpu',
+  debuggerReadMemory: 'debugger.cpu',
+  debuggerWaitForPause: 'debugger.cpu',
+  debuggerGetVideoState: 'debugger.vram',
+  debuggerReadVram: 'debugger.vram',
+  debuggerWriteVram: 'debugger.vram',
+});
+
+const CONNECTOR_MINIMUMS = Object.freeze({
+  'debugger.cpu': '1.1.0',
+  'debugger.vram': '1.2.0',
+});
+
+export function normalizeFeatureList(value) {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(value
+    .slice(0, 64)
+    .filter((feature) => typeof feature === 'string' && FEATURE_PATTERN.test(feature))));
+}
+
+export function createMcpDescriptor(version) {
+  return {
+    name: 'x1pen-mcp',
+    version: String(version || 'unknown'),
+    protocolVersion: 2,
+    features: [...MCP_FEATURES],
+  };
+}
+
+export function normalizeConnectorPair(message) {
+  const advertised = message?.connector;
+  const version = typeof advertised?.version === 'string'
+    ? advertised.version
+    : (typeof message?.extensionVersion === 'string' ? message.extensionVersion : null);
+  const hasAdvertisedFeatures = Array.isArray(advertised?.features);
+  const legacyFeatures = version ? LEGACY_CONNECTOR_FEATURES[version] : null;
+  return {
+    name: typeof advertised?.name === 'string' ? advertised.name : 'x1pen-connector',
+    version,
+    protocolVersion: Number.isInteger(advertised?.protocolVersion) ? advertised.protocolVersion : 1,
+    features: hasAdvertisedFeatures
+      ? normalizeFeatureList(advertised.features)
+      : normalizeFeatureList(legacyFeatures),
+    featureSource: hasAdvertisedFeatures ? 'advertised' : (legacyFeatures ? 'legacy' : 'unknown'),
+  };
+}
+
+export function normalizeX1PenDescriptor(value) {
+  if (!value || typeof value !== 'object') return null;
+  const hasAdvertisedFeatures = Array.isArray(value.features);
+  return {
+    name: 'x1pen',
+    version: typeof value.version === 'string' ? value.version : null,
+    automationApiVersion: Number.isInteger(value.automationApiVersion) ? value.automationApiVersion : null,
+    features: normalizeFeatureList(value.features),
+    featureSource: hasAdvertisedFeatures ? 'advertised' : 'unknown',
+  };
+}
+
+function componentFeatureState(component, feature, disconnected = false) {
+  if (!component) return { state: 'unknown', reason: disconnected ? 'disconnected' : 'not-reported' };
+  if (component.featureSource === 'unknown' || !Array.isArray(component.features)) {
+    return { state: 'unknown', reason: 'not-reported' };
+  }
+  return component.features.includes(feature)
+    ? { state: 'available' }
+    : { state: 'unavailable', reason: 'not-advertised' };
+}
+
+export function evaluateCompatibility({ mcp, connector, x1pen, connected = true }) {
+  const result = {};
+  for (const feature of FEATURE_IDS) {
+    const components = {
+      mcp: componentFeatureState({ ...mcp, featureSource: 'advertised' }, feature),
+      connector: componentFeatureState(connector, feature, !connected),
+      x1pen: componentFeatureState(x1pen, feature),
+    };
+    const states = Object.values(components).map((entry) => entry.state);
+    const state = states.includes('unavailable')
+      ? 'unavailable'
+      : (states.every((value) => value === 'available') ? 'available' : 'unknown');
+    result[feature] = {
+      state,
+      available: state === 'available' ? true : (state === 'unavailable' ? false : null),
+      components,
+    };
+  }
+  return result;
+}
+
+export class X1PenCompatibilityError extends Error {
+  constructor(details) {
+    super(details.message);
+    this.name = 'X1PenCompatibilityError';
+    Object.assign(this, details);
+  }
+}
+
+export function assertMethodCompatible(method, compatibility, components) {
+  const feature = METHOD_FEATURES[method];
+  if (!feature || compatibility[feature]?.state !== 'unavailable') return;
+  const states = compatibility[feature].components;
+  const component = ['mcp', 'connector', 'x1pen']
+    .find((name) => states[name].state === 'unavailable') || 'connector';
+  const current = components[component];
+  if (component === 'connector' && current?.featureSource === 'legacy') {
+    const requiredVersion = CONNECTOR_MINIMUMS[feature];
+    throw new X1PenCompatibilityError({
+      code: 'CONNECTOR_UPDATE_REQUIRED',
+      component,
+      feature,
+      currentVersion: current?.version || 'unknown',
+      requiredVersion,
+      action: 'Update X1Pen Connector and reconnect this tab.',
+      message: `${feature} requires X1Pen Connector ${requiredVersion} or later. ` +
+        `Connected version: ${current?.version || 'unknown'}.`,
+    });
+  }
+  if (component === 'connector' || component === 'x1pen') {
+    throw new X1PenCompatibilityError({
+      code: 'FEATURE_UNAVAILABLE',
+      component,
+      feature,
+      currentVersion: current?.version || 'unknown',
+      action: component === 'connector'
+        ? 'Update X1Pen Connector and reconnect this tab.'
+        : 'Reload or update X1Pen and reconnect this tab.',
+      message: `${feature} is not advertised by the connected ${component === 'connector' ? 'Connector' : 'X1Pen'}.`,
+    });
+  }
+  throw new X1PenCompatibilityError({
+    code: 'MCP_UPDATE_REQUIRED',
+    component,
+    feature,
+    currentVersion: current?.version || 'unknown',
+    action: 'Restart the MCP client with x1pen-mcp@latest.',
+    message: `${feature} is not available in this X1Pen MCP server.`,
+  });
+}
+
+export function deserializeBridgeError(value) {
+  if (!value || typeof value !== 'object') return new Error(String(value || 'X1Pen command failed'));
+  const error = new Error(typeof value.message === 'string' ? value.message : 'X1Pen command failed');
+  for (const key of ['code', 'component', 'feature', 'currentVersion', 'requiredVersion', 'action']) {
+    if (typeof value[key] === 'string') error[key] = value[key];
+  }
+  return error;
+}

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -7,6 +7,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as z from 'zod/v4';
 import { X1PenBridge } from './x1pen-bridge.mjs';
+import { createMcpDescriptor } from './x1pen-compatibility.mjs';
 import {
   getReferenceEntries,
   getReferenceManifest,
@@ -40,6 +41,7 @@ const SERVER_INSTRUCTIONS = [
   'Before writing or substantially editing a program, call x1pen_get_language_profile, search the bundled reference with x1pen_search_reference, and fetch only the needed IDs with x1pen_get_reference.',
   'After editing, call x1pen_validate. Run and inspect the visible emulator when behavior must be confirmed.',
   'Prefer bounded source and reference tools so generated ASM and unrelated manual sections do not consume context.',
+  'Connection and status results report MCP, Connector and X1Pen compatibility. Do not retry a feature that reports an update-required error until that component is updated.',
 ].join(' ');
 
 function textResult(value) {
@@ -49,6 +51,16 @@ function textResult(value) {
 }
 
 function toolError(error) {
+  if (error && typeof error.code === 'string') {
+    const details = {};
+    for (const key of ['code', 'component', 'feature', 'message', 'currentVersion', 'requiredVersion', 'action']) {
+      if (typeof error[key] === 'string') details[key] = error[key];
+    }
+    return {
+      isError: true,
+      content: [{ type: 'text', text: JSON.stringify({ error: details }) }],
+    };
+  }
   return {
     isError: true,
     content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
@@ -375,7 +387,10 @@ function compactDebuggerVramWrite(value) {
 }
 
 export function createX1PenMcpServer(options = {}) {
-  const bridge = options.bridge || new X1PenBridge(options.bridgeOptions);
+  const bridge = options.bridge || new X1PenBridge({
+    ...options.bridgeOptions,
+    serverDescriptor: options.bridgeOptions?.serverDescriptor || createMcpDescriptor(PACKAGE.version),
+  });
   const server = new McpServer(
     { name: 'x1pen', version: PACKAGE.version },
     { instructions: SERVER_INSTRUCTIONS },
@@ -725,7 +740,13 @@ export function createX1PenMcpServer(options = {}) {
     description: 'Get readiness, revision, lock and status state from the connected X1Pen tab.',
     inputSchema: sessionInput,
     annotations: { readOnlyHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId }) => textResult(await bridge.sendCommand('getStatus', {}, sessionId))));
+  }, handleTool(async ({ sessionId }) => {
+    const status = await bridge.sendCommand('getStatus', {}, sessionId);
+    const compatibility = typeof bridge.getSessionCompatibility === 'function'
+      ? bridge.getSessionCompatibility(sessionId)
+      : null;
+    return textResult({ ...status, compatibility });
+  }));
 
   server.registerTool('x1pen_capture_screen', {
     description: 'Capture the connected X1Pen emulator canvas as a 640x400 PNG.',

--- a/scripts/package-x1pen-connector.sh
+++ b/scripts/package-x1pen-connector.sh
@@ -15,7 +15,7 @@ staging=$(mktemp -d "${TMPDIR:-/tmp}/x1pen-connector.XXXXXX")
 trap 'rm -rf "$staging"' EXIT HUP INT TERM
 
 mkdir -p "$staging/icons" "$(dirname -- "$output")"
-for file in manifest.json popup.html popup.css popup.js service-worker.js page-automation.mjs update-coordinator.mjs; do
+for file in manifest.json popup.html popup.css popup.js service-worker.js page-automation.mjs compatibility.mjs update-coordinator.mjs; do
   cp "$repo_root/extension/$file" "$staging/$file"
 done
 for size in 16 32 48 128; do

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -71,6 +71,12 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   const ready = await page.evaluate(() => window.X1PenAutomation.ready());
   assert.equal(ready.ready, true);
   assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
+  assert.deepEqual(ready.x1pen, {
+    name: 'x1pen',
+    version: '0.8.0',
+    automationApiVersion: 2,
+    features: ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
+  });
   assert.equal(ready.capabilities.debugger.available, true);
   assert.equal(ready.capabilities.debugger.version, 2);
   assert.equal(ready.capabilities.debugger.addressSpaceSize, 0x10000);

--- a/tests/x1pen_bridge_test.mjs
+++ b/tests/x1pen_bridge_test.mjs
@@ -2,6 +2,12 @@ import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 import { WebSocket } from 'ws';
 import { X1PenBridge } from '../mcp/x1pen-bridge.mjs';
+import {
+  assertMethodCompatible,
+  createMcpDescriptor,
+  evaluateCompatibility,
+  normalizeConnectorPair,
+} from '../mcp/x1pen-compatibility.mjs';
 
 const openBridges = new Set();
 const openSockets = new Set();
@@ -13,7 +19,7 @@ afterEach(async () => {
   openBridges.clear();
 });
 
-async function connectExtension(bridge) {
+async function connectExtension(bridge, pair = {}) {
   const socket = new WebSocket(`ws://127.0.0.1:${bridge.port}`, {
     origin: 'chrome-extension://x1pen-test',
   });
@@ -23,8 +29,8 @@ async function connectExtension(bridge) {
     socket.once('error', reject);
   });
   const paired = waitForMessage(socket, (message) => message.type === 'paired');
-  socket.send(JSON.stringify({ type: 'pair', code: bridge.pairingCode }));
-  await paired;
+  socket.send(JSON.stringify({ type: 'pair', code: bridge.pairingCode, ...pair }));
+  socket.pairedMessage = await paired;
   return socket;
 }
 
@@ -72,6 +78,115 @@ test('bridge pairs an extension and routes commands to one X1Pen tab', async () 
   assert.equal(command.method, 'getProgram');
   socket.send(JSON.stringify({ type: 'result', id: command.id, ok: true, result: { revision: 4 } }));
   assert.deepEqual(await commandPromise, { revision: 4 });
+});
+
+test('bridge negotiates component metadata and computes effective capabilities', async () => {
+  const bridge = new X1PenBridge({
+    startPort: 0,
+    pairingCode: '123456',
+    logger: () => {},
+    serverDescriptor: createMcpDescriptor('2.6.0'),
+  });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = await connectExtension(bridge, {
+    extensionVersion: '1.2.0',
+    connector: {
+      name: 'x1pen-connector', version: '1.2.0', protocolVersion: 2,
+      features: ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
+    },
+  });
+  assert.equal(socket.pairedMessage.protocolVersion, 2);
+  assert.equal(socket.pairedMessage.server.version, '2.6.0');
+
+  socket.send(JSON.stringify({
+    type: 'sessions',
+    sessions: [{
+      sessionId: 'tab-a', title: 'X1Pen', revision: 1,
+      x1pen: {
+        version: '0.8.0', automationApiVersion: 2,
+        features: ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
+      },
+    }],
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const info = bridge.connectionInfo();
+  assert.equal(info.components.mcp.version, '2.6.0');
+  assert.equal(info.components.connector.version, '1.2.0');
+  assert.equal(info.compatibility.capabilities['debugger.vram'].state, 'available');
+  const [session] = bridge.listSessions();
+  assert.equal(session.x1pen.version, '0.8.0');
+  assert.equal(session.compatibility.capabilities['debugger.cpu'].available, true);
+});
+
+test('legacy Connector inference is frozen and blocks unsupported debugger RPCs before sending', async () => {
+  assert.equal(normalizeConnectorPair({ extensionVersion: '1.1.1' }).featureSource, 'legacy');
+  assert.deepEqual(normalizeConnectorPair({ extensionVersion: '1.1.1' }).features,
+    ['automation.core', 'screen.capture', 'debugger.cpu']);
+  assert.equal(normalizeConnectorPair({ extensionVersion: '1.2.0' }).featureSource, 'unknown');
+
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = await connectExtension(bridge, { extensionVersion: '1.1.1' });
+  socket.send(JSON.stringify({
+    type: 'sessions',
+    sessions: [{
+      sessionId: 'tab-a', title: 'X1Pen',
+      x1pen: { version: '0.8.0', automationApiVersion: 2, features: ['debugger.cpu', 'debugger.vram'] },
+    }],
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.throws(
+    () => bridge.sendCommand('debuggerReadVram', { region: 'text', offset: 0, length: 1 }),
+    (error) => error.code === 'CONNECTOR_UPDATE_REQUIRED' && error.component === 'connector' &&
+      error.feature === 'debugger.vram' && error.currentVersion === '1.1.1' &&
+      error.requiredVersion === '1.2.0',
+  );
+});
+
+test('explicit feature advertisements are authoritative without semver inference', () => {
+  const mcp = createMcpDescriptor('2.6.0');
+  const connector = normalizeConnectorPair({
+    extensionVersion: '9.0.0',
+    connector: {
+      name: 'x1pen-connector', version: '9.0.0', protocolVersion: 2,
+      features: ['automation.core', 'screen.capture'],
+    },
+  });
+  const x1pen = {
+    name: 'x1pen', version: '0.8.0', automationApiVersion: 2,
+    features: ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
+    featureSource: 'advertised',
+  };
+  const capabilities = evaluateCompatibility({ mcp, connector, x1pen });
+  assert.equal(capabilities['debugger.vram'].state, 'unavailable');
+  assert.throws(
+    () => assertMethodCompatible('debuggerReadVram', capabilities, { mcp, connector, x1pen }),
+    (error) => error.code === 'FEATURE_UNAVAILABLE' && error.component === 'connector' &&
+      error.currentVersion === '9.0.0' && error.requiredVersion === undefined,
+  );
+});
+
+test('bridge preserves structured command errors from the Connector', async () => {
+  const bridge = new X1PenBridge({ startPort: 0, pairingCode: '123456', logger: () => {} });
+  openBridges.add(bridge);
+  await bridge.start();
+  const socket = await connectExtension(bridge);
+  socket.send(JSON.stringify({ type: 'sessions', sessions: [{ sessionId: 'tab-a', title: 'X1Pen' }] }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const commandMessage = waitForMessage(socket, (message) => message.type === 'command');
+  const result = bridge.sendCommand('getStatus');
+  const command = await commandMessage;
+  socket.send(JSON.stringify({
+    type: 'result', id: command.id, ok: false,
+    error: { code: 'X1PEN_UPDATE_REQUIRED', component: 'x1pen', feature: 'automation.core', message: 'Reload X1Pen' },
+  }));
+  await assert.rejects(result, (error) => error.code === 'X1PEN_UPDATE_REQUIRED' &&
+    error.component === 'x1pen' && error.feature === 'automation.core');
 });
 
 test('bridge requires explicit selection when multiple tabs are connected', async () => {

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { afterEach, test } from 'node:test';
 import { invokeX1PenInPage } from '../extension/page-automation.mjs';
 import { createUpdateCoordinator } from '../extension/update-coordinator.mjs';
@@ -10,6 +11,7 @@ import {
   normalizeX1PenDescriptor,
   serializeExtensionError,
 } from '../extension/compatibility.mjs';
+import { FEATURE_IDS, MCP_FEATURES } from '../mcp/x1pen-compatibility.mjs';
 
 afterEach(() => {
   delete globalThis.window;
@@ -186,6 +188,23 @@ test('connector compatibility metadata is bounded and preserves legacy fallbacks
     () => assertMcpProtocolSupported({ protocolVersion: 3, version: '3.0.0' }),
     (error) => error.code === 'BRIDGE_PROTOCOL_UNSUPPORTED' && error.component === 'mcp',
   );
+});
+
+test('feature IDs match across X1Pen, Connector and MCP', () => {
+  const source = readFileSync(new URL('../html/x1pen.js', import.meta.url), 'utf8');
+  const featureFunction = source.match(
+    /function getAutomationFeatures\(\) \{([\s\S]*?)\n    \}/,
+  );
+  assert.ok(featureFunction, 'getAutomationFeatures implementation was not found');
+
+  const x1penFeatures = Array.from(
+    featureFunction[1].matchAll(/['"]([a-z][a-z0-9.-]+)['"]/g),
+    (match) => match[1],
+  );
+  const expected = [...FEATURE_IDS].sort();
+  assert.deepEqual([...new Set(x1penFeatures)].sort(), expected);
+  assert.deepEqual([...CONNECTOR_FEATURES].sort(), expected);
+  assert.deepEqual([...MCP_FEATURES].sort(), expected);
 });
 
 test('connector serializes machine-readable errors without copying arbitrary fields', () => {

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -2,6 +2,14 @@ import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 import { invokeX1PenInPage } from '../extension/page-automation.mjs';
 import { createUpdateCoordinator } from '../extension/update-coordinator.mjs';
+import {
+  CONNECTOR_FEATURES,
+  assertMcpProtocolSupported,
+  createConnectorDescriptor,
+  normalizeMcpServerDescriptor,
+  normalizeX1PenDescriptor,
+  serializeExtensionError,
+} from '../extension/compatibility.mjs';
 
 afterEach(() => {
   delete globalThis.window;
@@ -135,6 +143,61 @@ test('page bridge rejects VRAM calls when its capability is unavailable', async 
     invokeX1PenInPage('debuggerReadVram', { region: 'text', offset: 0, length: 1 }),
     /does not provide the VRAM debugger API/,
   );
+});
+
+test('page bridge treats advertised features as authoritative', async () => {
+  const { api } = createAutomationApi();
+  api.getStatus = () => ({
+    x1pen: { features: ['automation.core', 'screen.capture', 'debugger.cpu'] },
+    capabilities: { debugger: { available: true, runPending: false, vram: { available: true } } },
+  });
+  globalThis.window = { X1PenAutomation: api };
+  await assert.rejects(
+    invokeX1PenInPage('debuggerReadVram', { region: 'text', offset: 0, length: 1 }),
+    (error) => error.code === 'FEATURE_UNAVAILABLE' && error.component === 'x1pen' &&
+      error.feature === 'debugger.vram',
+  );
+});
+
+test('connector compatibility metadata is bounded and preserves legacy fallbacks', () => {
+  assert.deepEqual(createConnectorDescriptor('1.2.0'), {
+    name: 'x1pen-connector',
+    version: '1.2.0',
+    protocolVersion: 2,
+    features: [...CONNECTOR_FEATURES],
+  });
+  assert.deepEqual(normalizeX1PenDescriptor({
+    x1pen: {
+      version: '0.8.0', automationApiVersion: 2,
+      features: ['automation.core', 'debugger.vram', 'invalid feature', 'debugger.vram'],
+    },
+  }), {
+    name: 'x1pen', version: '0.8.0', automationApiVersion: 2,
+    features: ['automation.core', 'debugger.vram'],
+  });
+  assert.deepEqual(normalizeX1PenDescriptor({
+    capabilities: { debugger: { available: true, vram: { available: false } } },
+  }).features, ['automation.core', 'screen.capture', 'debugger.cpu']);
+  assert.deepEqual(normalizeMcpServerDescriptor({ type: 'paired', protocolVersion: 1 }), {
+    name: 'x1pen-mcp', version: null, protocolVersion: 1, features: [],
+  });
+  assert.doesNotThrow(() => assertMcpProtocolSupported({ protocolVersion: 2 }));
+  assert.throws(
+    () => assertMcpProtocolSupported({ protocolVersion: 3, version: '3.0.0' }),
+    (error) => error.code === 'BRIDGE_PROTOCOL_UNSUPPORTED' && error.component === 'mcp',
+  );
+});
+
+test('connector serializes machine-readable errors without copying arbitrary fields', () => {
+  const error = new Error('Update X1Pen');
+  Object.assign(error, {
+    code: 'X1PEN_UPDATE_REQUIRED', component: 'x1pen', feature: 'debugger.vram',
+    requiredVersion: '0.8.0', action: 'Reload X1Pen', secret: 'discard',
+  });
+  assert.deepEqual(serializeExtensionError(error), {
+    message: 'Update X1Pen', code: 'X1PEN_UPDATE_REQUIRED', component: 'x1pen',
+    feature: 'debugger.vram', requiredVersion: '0.8.0', action: 'Reload X1Pen',
+  });
 });
 
 test('extension update waits for active operations before disconnecting and reloading', async () => {

--- a/tests/x1pen_extension_package_test.mjs
+++ b/tests/x1pen_extension_package_test.mjs
@@ -33,6 +33,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
       '_locales/en/messages.json',
       '_locales/ja/',
       '_locales/ja/messages.json',
+      'compatibility.mjs',
       'icons/',
       'icons/icon-128.png',
       'icons/icon-16.png',
@@ -61,6 +62,8 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
     const serviceWorker = run('unzip', ['-p', zipPath, 'service-worker.js']);
     assert.match(serviceWorker, /chrome\.runtime\.onUpdateAvailable\.addListener/);
     assert.match(serviceWorker, /updateCoordinator\.run/);
+    assert.match(serviceWorker, /connector:\s*connectorDescriptor\(\)/);
+    assert.match(serviceWorker, /normalizeMcpServerDescriptor/);
 
     const jaMessages = JSON.parse(run('unzip', ['-p', zipPath, '_locales/ja/messages.json']));
     const enMessages = JSON.parse(run('unzip', ['-p', zipPath, '_locales/en/messages.json']));
@@ -97,7 +100,28 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
     assert.match(popup, /video memory/);
     assert.match(popup, /x1pen-connector-privacy\.html/);
     assert.match(popup, /id="connect" disabled/);
+    assert.match(popup, /id="connector-version"/);
+    assert.match(popup, /id="mcp-version"/);
+    assert.match(popup, /id="x1pen-version"/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test('X1Pen product version is declared once and copied into browser builds', async () => {
+  const versionSource = await readFile(join(repoRoot, 'html/x1pen-version.js'), 'utf8');
+  assert.match(versionSource, /version:\s*'0\.8\.0'/);
+  assert.match(versionSource, /name:\s*'x1pen'/);
+
+  const x1penHtml = await readFile(join(repoRoot, 'html/x1pen.html'), 'utf8');
+  assert.match(x1penHtml, /<script src="x1pen-version\.js"><\/script>\s*<script src="x1pen\.js"><\/script>/);
+
+  const buildScript = await readFile(join(repoRoot, 'build.sh'), 'utf8');
+  assert.match(buildScript, /html\/x1pen-version\.js.*\.\/x1pen-version\.js/);
+  assert.match(buildScript, /html\/x1pen-version\.js.*DIST_DIR/);
+  assert.match(buildScript, /XMIL_VERSION=.*html\/x1pen-version\.js/);
+
+  const cmake = await readFile(join(repoRoot, 'CMakeLists.txt'), 'utf8');
+  assert.match(cmake, /file\(READ .*html\/x1pen-version\.js/);
+  assert.match(cmake, /set\(XMIL_VERSION "\$\{CMAKE_MATCH_1\}"\)/);
 });

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -51,6 +51,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'reference/slang.json',
       'reference/x1-hardware.json',
       'x1pen-bridge.mjs',
+      'x1pen-compatibility.mjs',
       'x1pen-reference.mjs',
       'x1pen-server.mjs',
     ]);
@@ -95,6 +96,10 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.equal(info.host, '127.0.0.1');
     assert.ok(Number.isInteger(info.port));
     assert.match(info.pairingCode, /^\d{6}$/);
+    assert.equal(info.components.mcp.version, '2.6.0');
+    assert.deepEqual(info.components.mcp.features,
+      ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram']);
+    assert.equal(info.components.connector, null);
 
     const reference = await client.callTool({
       name: 'x1pen_search_reference',

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -15,6 +15,7 @@ const initialProgram = {
 const calls = [];
 let currentProgram;
 let debuggerState;
+let compatibilityFailure;
 
 const initialDebuggerState = {
   version: 1,
@@ -55,11 +56,30 @@ function normalizeProgram(program) {
 }
 
 const fakeBridge = {
-  connectionInfo() { return { port: 43110, pairingCode: '123456', extensionConnected: true }; },
-  listSessions() { return [{ sessionId: 'tab-a', title: 'X1Pen', selected: true }]; },
+  connectionInfo() {
+    return {
+      port: 43110, pairingCode: '123456', extensionConnected: true,
+      components: {
+        mcp: { name: 'x1pen-mcp', version: '2.6.0' },
+        connector: { name: 'x1pen-connector', version: '1.2.0' },
+      },
+    };
+  },
+  listSessions() {
+    return [{ sessionId: 'tab-a', title: 'X1Pen', selected: true, x1pen: { version: '0.8.0' } }];
+  },
   selectSession(sessionId) { return { sessionId }; },
+  getSessionCompatibility() {
+    return {
+      components: {
+        mcp: { version: '2.6.0' }, connector: { version: '1.2.0' }, x1pen: { version: '0.8.0' },
+      },
+      capabilities: { 'debugger.vram': { state: 'available', available: true } },
+    };
+  },
   async sendCommand(method, params, sessionId) {
     calls.push({ method, params: clone(params), sessionId });
+    if (compatibilityFailure && method === compatibilityFailure.method) throw compatibilityFailure.error;
     if (method === 'getProgram') return clone(currentProgram);
     if (method === 'setProgram') {
       if (params.expectedRevision !== currentProgram.revision) {
@@ -165,6 +185,7 @@ beforeEach(() => {
   calls.length = 0;
   currentProgram = clone(initialProgram);
   debuggerState = clone(initialDebuggerState);
+  compatibilityFailure = null;
 });
 
 after(async () => {
@@ -202,6 +223,39 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_stop',
     'x1pen_validate',
   ]);
+});
+
+test('connection and status tools report all component versions and effective capabilities', async () => {
+  const connection = jsonContent(await client.callTool({ name: 'x1pen_connection_info', arguments: {} }));
+  assert.equal(connection.components.mcp.version, '2.6.0');
+  assert.equal(connection.components.connector.version, '1.2.0');
+
+  const sessions = jsonContent(await client.callTool({ name: 'x1pen_list_sessions', arguments: {} }));
+  assert.equal(sessions.sessions[0].x1pen.version, '0.8.0');
+
+  const status = jsonContent(await client.callTool({ name: 'x1pen_get_status', arguments: {} }));
+  assert.equal(status.compatibility.components.x1pen.version, '0.8.0');
+  assert.equal(status.compatibility.capabilities['debugger.vram'].available, true);
+});
+
+test('machine-readable compatibility failures survive the MCP tool boundary', async () => {
+  const error = new Error('debugger.vram requires X1Pen Connector 1.2.0 or later');
+  Object.assign(error, {
+    code: 'CONNECTOR_UPDATE_REQUIRED', component: 'connector', feature: 'debugger.vram',
+    currentVersion: '1.1.1', requiredVersion: '1.2.0', action: 'Update X1Pen Connector and reconnect this tab.',
+  });
+  compatibilityFailure = { method: 'debuggerReadVram', error };
+  const result = await client.callTool({
+    name: 'x1pen_debug_read_vram',
+    arguments: { region: 'text', offset: 0, length: 1 },
+  });
+  assert.equal(result.isError, true);
+  const details = jsonContent(result).error;
+  assert.equal(details.code, 'CONNECTOR_UPDATE_REQUIRED');
+  assert.equal(details.component, 'connector');
+  assert.equal(details.feature, 'debugger.vram');
+  assert.equal(details.currentVersion, '1.1.1');
+  assert.equal(details.requiredVersion, '1.2.0');
 });
 
 test('language reference tools search compact results and fetch selected details', async () => {


### PR DESCRIPTION
## Summary
- expose X1Pen 0.8.0, Connector 1.2.0, and MCP 2.6.0 component metadata
- negotiate exact immutable feature IDs across the browser bridge and report effective three-layer compatibility
- freeze inference to published Connector 1.0.1/1.1.0/1.1.1 and reject known-unsupported RPCs before transmission
- preserve structured compatibility errors through Connector and MCP tool responses
- show component versions in the Connector popup and document the deployment order
- verify the feature ID contract across X1Pen, Connector, and MCP implementations

Dynamic `tools/list_changed` suppression remains intentionally deferred; invocation guards are the correctness boundary and work with clients that cache tool lists.

## Verification
- `./build.sh`
- `npm run test:automation` (9/9)
- `npm run test:bridge` (8/8)
- `npm run test:extension-package` (11/11)
- `npm run test:mcp` (39/39)
- `npm run test:mcp-package` (1/1)
