### PR TITLE
Prevent concurrent X1Pen Run execution

### DIFF
--- a/docs/X1PEN.md
+++ b/docs/X1PEN.md
@@ -190,6 +190,8 @@ X millennium Web 本体のエミュレータで FDD にマウントして起動�
 | **Ctrl+F** | 検索 |
 | **Ctrl+Z** / **Ctrl+Shift+Z** | Undo / Redo |
 
+RUNの準備中はRUNボタンがbusy表示になり、連打やCtrl+Enterの再入力は無視されます。Automation/MCPから同時にRUNされた場合も、先に受理された1件だけが実行されます。
+
 ## 自動保存
 
 エディタの内容はブラウザの localStorage に自動保存されます。

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -99,6 +99,7 @@ feature IDは完全一致する不変の契約です。現在は`automation.core
 | `x1pen_set_program` | revision一致時だけプログラム全体を更新（新規作成・全置換用） |
 | `x1pen_validate` | 実行せずにコンパイル、アセンブル、トークナイズ |
 | `x1pen_run` | ユーザーが開いているX1Penで実行 |
+| `x1pen_recover_stalled` | stallしたRun準備を、データ損失確認後のタブ再読込で復旧 |
 | `x1pen_stop` | ESCを送信して停止 |
 | `x1pen_get_status` | 接続、ロック、実行状態を取得 |
 | `x1pen_capture_screen` | 640x400のエミュレーター画面をPNG取得 |
@@ -232,7 +233,14 @@ VRAMはCPUの64KBメモリ空間とは別です。`x1pen_debug_get_video_state`�
 }
 ```
 
-Runボタン、Ctrl+Enter、Share自動実行、MCPの`x1pen_run`による実行準備中は、pause/resume/stepが準備完了まで拡張ブリッジ内で待機します。人間とAIが同じX1Penを操作しても、起動用キー注入の途中へデバッガ操作が割り込まないための制約です。
+Runボタン、Ctrl+Enter、Share自動実行、Automation API、MCPの`x1pen_run`は、ページ全体で1つのRun予約を共有します。先に受理されたRunだけがビルド・状態復元・コマンドキー注入へ進み、同時要求は通常のツールcontentとして次を返します。
+
+- `RUN_IN_PROGRESS`: `retryable: true`。`retryAfterMs`以降に呼出し側が再試行できます。MCP/Connector自身は自動再試行しません。
+- `RUN_QUEUE_TIMEOUT`: 先行Automation処理のため実行開始できなかった非再試行結果です。`x1pen_get_status`で状態を確認してください。
+
+既存の`ok: true`は従来どおり「Run準備とコマンドキー注入が完了した」ことを示し、X1プログラムが実際に開始したことの確認までは含みません。Run準備中はpause/resume/step、プログラム更新、検証、デバッガ書込みを拒否または待機し、起動用キー注入への割込みを防ぎます。
+
+Run準備が`stalled`になった場合、`x1pen_get_status`は`runAdmission`のphase/origin/経過時間を返します。`x1pen_recover_stalled`を確認なしで呼ぶと警告を返し、`confirmDataLoss: true`でのみ再読込します。エディターの現在値は保存されますが、エミュレーターRAMと未永続化のディスク変更は失われます。
 
 Share機能はユーザーが開いているX1Pen自身から実行するため、本番X1Pen上では既存のShare APIと公開URLをそのまま利用できます。
 

--- a/extension/compatibility.mjs
+++ b/extension/compatibility.mjs
@@ -1,6 +1,7 @@
 export const CONNECTOR_PROTOCOL_VERSION = 2;
 export const CONNECTOR_FEATURES = Object.freeze([
   'automation.core',
+  'automation.run-recovery',
   'screen.capture',
   'debugger.cpu',
   'debugger.vram',

--- a/extension/page-automation.mjs
+++ b/extension/page-automation.mjs
@@ -85,9 +85,22 @@ export async function invokeX1PenInPage(requestedMethod, requestedParams) {
     if (requestedMethod === 'setProgram') return await api.setProgram(requestedParams.program, requestedParams.expectedRevision);
     if (requestedMethod === 'validate') return await api.validate();
     if (requestedMethod === 'run') {
-      const result = await api.run();
-      if (requestedParams.waitMs > 0) await new Promise((resolve) => setTimeout(resolve, requestedParams.waitMs));
+      const result = await api.run({ origin: 'mcp', queueTimeoutMs: requestedParams.queueTimeoutMs });
+      const admissionFailure = result?.code === 'RUN_IN_PROGRESS' || result?.code === 'RUN_QUEUE_TIMEOUT';
+      if (!admissionFailure && requestedParams.waitMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, requestedParams.waitMs));
+      }
       return { ...result, state: api.getStatus() };
+    }
+    if (requestedMethod === 'recoverStalled') {
+      if (typeof api.recoverStalled !== 'function') {
+        const error = new Error('The connected X1Pen does not support stalled Run recovery');
+        error.code = 'FEATURE_UNAVAILABLE';
+        error.component = 'x1pen';
+        error.feature = 'automation.run-recovery';
+        throw error;
+      }
+      return api.recoverStalled(requestedParams.confirmDataLoss === true);
     }
     if (requestedMethod === 'stop') return await api.stop();
     if (requestedMethod === 'getStatus') return api.getStatus();

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -242,10 +242,24 @@ async function handleCommand(message) {
   }
   try {
     const result = await invokeX1Pen(session.tabId, message.method, message.params || {});
+    if (message.method === 'recoverStalled' && result?.ok && result.reloadRequired) {
+      send({ type: 'result', id: message.id, ok: true, result });
+      setTimeout(() => {
+        chrome.tabs.reload(session.tabId).catch((error) => {
+          console.warn('Failed to reload stalled X1Pen tab:', error);
+        });
+      }, 0);
+      return;
+    }
     await refreshSessions();
     send({ type: 'result', id: message.id, ok: true, result });
     sendSessions();
   } catch (error) {
+    if (!error?.code && /execution context|frame was removed|tab (?:was )?closed|No tab with id/i.test(error?.message || '')) {
+      error.code = 'TAB_RELOADED';
+      error.component = 'connector';
+      error.action = 'Wait for X1Pen to reload, then call x1pen_get_status.';
+    }
     send({ type: 'result', id: message.id, ok: false, error: serializeExtensionError(error) });
   }
 }

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -56,11 +56,12 @@
             white-space: nowrap;
         }
 
-        #x1pen-toolbar button:hover:not(:disabled) {
+        #x1pen-toolbar button:hover:not(:disabled):not([aria-disabled="true"]) {
             background: #0f3460;
         }
 
-        #x1pen-toolbar button:disabled {
+        #x1pen-toolbar button:disabled,
+        #x1pen-toolbar button[aria-disabled="true"] {
             opacity: 0.4;
             cursor: default;
         }
@@ -70,8 +71,25 @@
             border-color: #0d7a47 !important;
             color: #7dffb3 !important;
         }
-        #btn-run:hover:not(:disabled) {
+        #btn-run:hover:not(:disabled):not([aria-disabled="true"]) {
             background: #0d7a47 !important;
+        }
+
+        #btn-run-recover {
+            border-color: #a56b16;
+            color: #ffd28a;
+        }
+
+        .visually-hidden {
+            position: absolute !important;
+            width: 1px !important;
+            height: 1px !important;
+            padding: 0 !important;
+            margin: -1px !important;
+            overflow: hidden !important;
+            clip: rect(0, 0, 0, 0) !important;
+            white-space: nowrap !important;
+            border: 0 !important;
         }
 
         #btn-stop {
@@ -592,11 +610,13 @@
         <span class="brand">X1Pen</span>
         <span id="x1pen-mcp-status" class="hidden">MCP Connected</span>
         <button id="btn-run" disabled title="Ctrl+Enter">&#x25B6; RUN</button>
+        <button id="btn-run-recover" class="hidden" data-automation-lock-exempt="true">Reload stalled Run</button>
         <button id="btn-stop" title="Escape">&#x25A0; STOP</button>
         <button id="btn-dev-reload" class="hidden" title="Reload cached X1Pen assets">Reload Assets</button>
         <button id="btn-symbols" title="Symbol Table" disabled>Sym</button>
         <button id="btn-share" title="Share code">Share</button>
         <span id="x1pen-status">Loading...</span>
+        <span id="x1pen-live-notice" class="visually-hidden" aria-live="polite" aria-atomic="true"></span>
     </div>
     <div id="mobile-tabs">
         <button class="mobile-tab active" data-panel="emulator">Emulator</button>

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -28,8 +28,9 @@ window.__X1PEN_MODE = true;
     automationReadyPromise.catch(function() {});
     var automationOperationQueue = Promise.resolve();
     var automationPendingOperations = 0;
-    var automationQueuedRuns = 0;
-    var automationActiveRuns = 0;
+    var runAdmission = null;
+    var RUN_QUEUE_TIMEOUT_MS = 20000;
+    var RUN_STALL_WARNING_MS = 30000;
     var automationRevision = 0;
     var automationConnected = false;
     var automationInteractionLocked = false;
@@ -358,9 +359,11 @@ window.__X1PEN_MODE = true;
     }
 
     var elBtnRun    = document.getElementById('btn-run');
+    var elBtnRunRecover = document.getElementById('btn-run-recover');
     var elBtnStop   = document.getElementById('btn-stop');
     var elBtnDevReload = document.getElementById('btn-dev-reload');
     var elStatus    = document.getElementById('x1pen-status');
+    var elLiveNotice = document.getElementById('x1pen-live-notice');
     var activeTab   = 'basic';
 
     function isDevAssetMode() {
@@ -703,16 +706,168 @@ window.__X1PEN_MODE = true;
 
     // ── RUN ──
 
-    async function onRunClick() {
-        automationActiveRuns++;
-        try {
-            return await performRun();
-        } finally {
-            automationActiveRuns--;
+    function normalizeRunOrigin(origin, internal) {
+        if (internal && (origin === 'ui' || origin === 'share')) return origin;
+        return origin === 'mcp' ? 'mcp' : 'automation';
+    }
+
+    function getRunAdmissionSnapshot() {
+        if (!runAdmission) return { pending: false, origin: null, phase: 'idle', ageMs: 0, phaseAgeMs: 0 };
+        var now = performance.now();
+        return {
+            pending: true,
+            origin: runAdmission.origin,
+            phase: runAdmission.phase,
+            ageMs: Math.max(0, Math.round(now - runAdmission.createdAt)),
+            phaseAgeMs: Math.max(0, Math.round(now - runAdmission.phaseAt))
+        };
+    }
+
+    function announceRunNotice(message) {
+        if (elLiveNotice) elLiveNotice.textContent = message || '';
+    }
+
+    function refreshRunTriggerState() {
+        if (!elBtnRun) return;
+        var ready = automationReadyState === 'ready';
+        var pending = !!runAdmission;
+        elBtnRun.disabled = !ready || automationInteractionLocked;
+        if (pending) {
+            elBtnRun.setAttribute('aria-disabled', 'true');
+            elBtnRun.setAttribute('aria-busy', 'true');
+        } else {
+            elBtnRun.removeAttribute('aria-disabled');
+            elBtnRun.removeAttribute('aria-busy');
+        }
+        if (elBtnRunRecover) {
+            var stalled = !!runAdmission && runAdmission.phase === 'stalled';
+            elBtnRunRecover.classList.toggle('hidden', !stalled);
+            elBtnRunRecover.disabled = !stalled;
         }
     }
 
-    async function performRun() {
+    function tryReserveRun(origin, phase) {
+        if (runAdmission) return null;
+        var token = {};
+        var now = performance.now();
+        runAdmission = {
+            token: token,
+            origin: origin,
+            phase: phase || 'reserved',
+            createdAt: now,
+            phaseAt: now,
+            stallTimer: null
+        };
+        refreshRunTriggerState();
+        return token;
+    }
+
+    function transitionRunToExecuting(token) {
+        if (!runAdmission || runAdmission.token !== token ||
+            (runAdmission.phase !== 'reserved' && runAdmission.phase !== 'queued')) return false;
+        runAdmission.phase = 'executing';
+        runAdmission.phaseAt = performance.now();
+        runAdmission.stallTimer = setTimeout(function() {
+            if (!runAdmission || runAdmission.token !== token || runAdmission.phase !== 'executing') return;
+            runAdmission.phase = 'stalled';
+            runAdmission.phaseAt = performance.now();
+            announceRunNotice('Run setup appears stalled. Reloading preserves editor source but loses emulator RAM and unpersisted disk changes.');
+            refreshRunTriggerState();
+        }, RUN_STALL_WARNING_MS);
+        refreshRunTriggerState();
+        return true;
+    }
+
+    function releaseRun(token) {
+        if (!runAdmission || runAdmission.token !== token) return;
+        if (runAdmission.phase === 'recovering') return;
+        var stallTimer = runAdmission.stallTimer;
+        runAdmission = null;
+        if (stallTimer) clearTimeout(stallTimer);
+        try {
+            refreshRunTriggerState();
+        } catch (error) {
+            console.warn('[x1pen] Failed to refresh Run trigger after release:', error);
+        }
+    }
+
+    function makeRunResult(ok, code, status, retryable, retryAfterMs) {
+        var result = {
+            ok: !!ok,
+            status: status || (elStatus ? elStatus.textContent : ''),
+            sourceMode: getAutomationProgram().sourceMode,
+            revision: automationRevision
+        };
+        if (code) result.code = code;
+        if (retryable !== undefined) result.retryable = !!retryable;
+        if (retryAfterMs !== undefined) result.retryAfterMs = retryAfterMs;
+        if (!ok && runAdmission) result.activeOrigin = runAdmission.origin;
+        return result;
+    }
+
+    function makeRunBusyResult() {
+        return makeRunResult(false, 'RUN_IN_PROGRESS', 'Run setup is already in progress', true, 500);
+    }
+
+    function makeRunQueueTimeoutResult(origin) {
+        var result = makeRunResult(false, 'RUN_QUEUE_TIMEOUT', 'Run did not start before the Automation queue timeout', false);
+        result.activeOrigin = origin;
+        return result;
+    }
+
+    async function executeReservedRun(token) {
+        if (!transitionRunToExecuting(token)) return makeRunBusyResult();
+        try {
+            var ok = await performRun(token);
+            return makeRunResult(ok);
+        } finally {
+            releaseRun(token);
+        }
+    }
+
+    async function onRunClick(origin) {
+        var normalizedOrigin = normalizeRunOrigin(origin, true);
+        var token = tryReserveRun(normalizedOrigin, 'reserved');
+        if (!token) {
+            announceRunNotice('Run already in progress');
+            return false;
+        }
+        var result = await executeReservedRun(token);
+        return result.ok;
+    }
+
+    function recoverStalledRun(confirmDataLoss) {
+        var warning = 'Reloading preserves editor source but loses emulator RAM and unpersisted disk changes.';
+        if (!confirmDataLoss) {
+            return { ok: false, code: 'RECOVERY_CONFIRM_REQUIRED', status: warning };
+        }
+        if (!runAdmission || runAdmission.phase !== 'stalled') {
+            return { ok: false, code: 'RECOVERY_NOT_STALLED', status: 'Run setup is not stalled' };
+        }
+        persistEditorSources(
+            basicEditor ? basicEditor.getValue() : '',
+            asmEditor ? asmEditor.getValue() : '',
+            slangEditor ? slangEditor.getValue() : ''
+        );
+        var snapshot = getRunAdmissionSnapshot();
+        runAdmission.phase = 'recovering';
+        runAdmission.phaseAt = performance.now();
+        refreshRunTriggerState();
+        return {
+            ok: true,
+            code: 'RECOVERY_ACCEPTED',
+            status: warning,
+            activeOrigin: snapshot.origin,
+            ageMs: snapshot.ageMs,
+            reloadRequired: true
+        };
+    }
+
+    async function performRun(token) {
+        if (!runAdmission || runAdmission.token !== token) {
+            console.warn('[x1pen] performRun called without the active Run token');
+            return false;
+        }
         if (!module) return false;
 
         // 0. sourceMode / runMode 判定
@@ -1466,13 +1621,17 @@ window.__X1PEN_MODE = true;
     }
 
     function isRunSetupPending() {
-        return automationQueuedRuns > 0 || automationActiveRuns > 0;
+        return !!runAdmission;
+    }
+
+    function createRunPendingError(operation) {
+        var error = new Error(operation + ' is unavailable while run setup is pending');
+        error.code = 'RUN_PENDING';
+        return error;
     }
 
     function createDebuggerRunPendingError(operation) {
-        var error = new Error('Debugger ' + operation + ' is unavailable while run setup is pending');
-        error.code = 'RUN_PENDING';
-        return error;
+        return createRunPendingError('Debugger ' + operation);
     }
 
     function runAutomationDebuggerControl(exportName, operation) {
@@ -1791,7 +1950,7 @@ window.__X1PEN_MODE = true;
     var X1PEN_PRODUCT = window.X1PenBuild || { name: 'x1pen', version: 'unknown' };
 
     function getAutomationFeatures() {
-        var features = ['automation.core', 'screen.capture'];
+        var features = ['automation.core', 'automation.run-recovery', 'screen.capture'];
         if (isDebuggerModuleAvailable()) features.push('debugger.cpu');
         if (isDebuggerVramModuleAvailable()) features.push('debugger.vram');
         return features;
@@ -1821,6 +1980,7 @@ window.__X1PEN_MODE = true;
             });
         },
         setBreakpoints: function(addresses) {
+            if (isRunSetupPending()) return Promise.reject(createDebuggerRunPendingError('set breakpoints'));
             return queueAutomationOperation(function() {
                 return setAutomationDebuggerBreakpoints(addresses);
             });
@@ -1828,6 +1988,7 @@ window.__X1PEN_MODE = true;
         readMemory: readAutomationDebuggerMemory,
         readVram: readAutomationDebuggerVram,
         writeVram: function(options) {
+            if (isRunSetupPending()) return Promise.reject(createDebuggerRunPendingError('write VRAM'));
             return queueAutomationOperation(function() {
                 if (getAutomationDebuggerState().runState !== 'paused') {
                     throw createDebuggerVramError('write', -3);
@@ -1857,6 +2018,7 @@ window.__X1PEN_MODE = true;
             busy: automationPendingOperations > 0,
             connected: automationConnected,
             interactionLocked: automationInteractionLocked,
+            runAdmission: getRunAdmissionSnapshot(),
             title: document.title,
             url: location.href,
             status: elStatus ? elStatus.textContent : '',
@@ -1938,7 +2100,7 @@ window.__X1PEN_MODE = true;
             if (!automationInteractionLocked) overlay.textContent = 'AI is editing...';
             overlay.classList.toggle('hidden', !automationInteractionLocked);
         }
-        var buttons = document.querySelectorAll('#x1pen-toolbar button');
+        var buttons = document.querySelectorAll('#x1pen-toolbar button:not(#btn-run):not([data-automation-lock-exempt="true"])');
         buttons.forEach(function(button) {
             if (!wasLocked && automationInteractionLocked) {
                 button.dataset.mcpWasDisabled = button.disabled ? '1' : '0';
@@ -1948,6 +2110,7 @@ window.__X1PEN_MODE = true;
                 delete button.dataset.mcpWasDisabled;
             }
         });
+        refreshRunTriggerState();
         return getAutomationStatus();
     }
 
@@ -1972,6 +2135,39 @@ window.__X1PEN_MODE = true;
         });
     }
 
+    function runAutomation(options) {
+        options = options || {};
+        var origin = normalizeRunOrigin(options.origin, false);
+        var token = tryReserveRun(origin, 'queued');
+        if (!token) return Promise.resolve(makeRunBusyResult());
+        var requestedTimeout = Number(options.queueTimeoutMs);
+        var queueTimeoutMs = Number.isFinite(requestedTimeout)
+            ? Math.max(100, Math.min(RUN_QUEUE_TIMEOUT_MS, Math.floor(requestedTimeout)))
+            : RUN_QUEUE_TIMEOUT_MS;
+        var settled = false;
+        return new Promise(function(resolve, reject) {
+            var queueTimer = setTimeout(function() {
+                if (!runAdmission || runAdmission.token !== token || runAdmission.phase !== 'queued') return;
+                releaseRun(token);
+                settled = true;
+                resolve(makeRunQueueTimeoutResult(origin));
+            }, queueTimeoutMs);
+            queueAutomationOperation(function() {
+                clearTimeout(queueTimer);
+                return executeReservedRun(token);
+            }).then(function(value) {
+                if (settled) return;
+                settled = true;
+                resolve(value);
+            }, function(error) {
+                if (settled) return;
+                settled = true;
+                releaseRun(token);
+                reject(error);
+            });
+        });
+    }
+
     window.X1PenAutomation = Object.freeze({
         version: X1PEN_AUTOMATION_API_VERSION,
         ready: function() {
@@ -1979,34 +2175,16 @@ window.__X1PEN_MODE = true;
         },
         getProgram: getAutomationProgram,
         setProgram: function(program, expectedRevision) {
+            if (isRunSetupPending()) return Promise.reject(createRunPendingError('Program update'));
             return queueAutomationOperation(function() {
                 return setAutomationProgram(program, expectedRevision);
             });
         },
         validate: function() {
+            if (isRunSetupPending()) return Promise.reject(createRunPendingError('Validation'));
             return queueAutomationOperation(validateAutomationProgram);
         },
-        run: function() {
-            // Reserve the debugger guard before the operation queue advances;
-            // onRunClick separately covers UI, shortcut and Share-triggered runs.
-            automationQueuedRuns++;
-            var result = queueAutomationOperation(async function() {
-                var ok = await onRunClick();
-                return {
-                    ok: ok,
-                    status: elStatus ? elStatus.textContent : '',
-                    sourceMode: getAutomationProgram().sourceMode,
-                    revision: automationRevision
-                };
-            });
-            return result.then(function(value) {
-                automationQueuedRuns--;
-                return value;
-            }, function(error) {
-                automationQueuedRuns--;
-                throw error;
-            });
-        },
+        run: runAutomation,
         stop: function() {
             return queueAutomationOperation(function() {
                 onStopClick();
@@ -2016,6 +2194,7 @@ window.__X1PEN_MODE = true;
         debugger: automationDebuggerApi,
         getStatus: getAutomationStatus,
         captureScreen: captureAutomationScreen,
+        recoverStalled: recoverStalledRun,
         setConnectionState: setAutomationConnectionState,
         setInteractionLocked: setAutomationInteractionLocked
     });
@@ -2355,9 +2534,9 @@ window.__X1PEN_MODE = true;
         // 6. エミュレータ開始
         module._js_xmil_start();
 
-        elBtnRun.disabled = false;
         elStatus.textContent = 'Ready';
         automationReadyState = 'ready';
+        refreshRunTriggerState();
         automationReadyResolve();
 
         // 共有コード読み込み (?id=xxx)
@@ -2457,7 +2636,7 @@ window.__X1PEN_MODE = true;
                     lastShareHash = await computePayloadHash(replayPayload);
                     lastShareId = urlId;
 
-                    var runOk = await onRunClick();
+                    var runOk = await onRunClick('share');
                     // 実行成功時のみ: AudioContext がまだ suspended ならオーバーレイ表示
                     if (runOk) showAudioUnmuteIfNeeded();
                 } else if (shareResp.status === 400) {
@@ -2989,7 +3168,22 @@ window.__X1PEN_MODE = true;
 
     // ── イベントリスナー ──
 
-    elBtnRun.addEventListener('click', onRunClick);
+    elBtnRun.addEventListener('click', function() {
+        if (elBtnRun.getAttribute('aria-disabled') === 'true') {
+            announceRunNotice('Run already in progress');
+            return;
+        }
+        onRunClick('ui');
+    });
+    if (elBtnRunRecover) {
+        elBtnRunRecover.addEventListener('click', function() {
+            var result = recoverStalledRun(window.confirm(
+                'Reloading preserves editor source but loses emulator RAM and unpersisted disk changes. Continue?'
+            ));
+            if (result.ok) location.reload();
+            else announceRunNotice(result.status);
+        });
+    }
     elBtnStop.addEventListener('click', onStopClick);
     var elBtnShare = document.getElementById('btn-share');
     if (elBtnShare) elBtnShare.addEventListener('click', onShareClick);
@@ -3002,9 +3196,10 @@ window.__X1PEN_MODE = true;
 
     // Ctrl+Enter で RUN
     document.addEventListener('keydown', function(e) {
-        if (e.ctrlKey && e.key === 'Enter' && !elBtnRun.disabled) {
+        if (e.ctrlKey && e.key === 'Enter' && !elBtnRun.disabled &&
+            elBtnRun.getAttribute('aria-disabled') !== 'true') {
             e.preventDefault();
-            onRunClick();
+            onRunClick('ui');
         }
     });
 

--- a/mcp/x1pen-compatibility.mjs
+++ b/mcp/x1pen-compatibility.mjs
@@ -1,5 +1,6 @@
 export const FEATURE_IDS = Object.freeze([
   'automation.core',
+  'automation.run-recovery',
   'screen.capture',
   'debugger.cpu',
   'debugger.vram',
@@ -19,6 +20,7 @@ const METHOD_FEATURES = Object.freeze({
   setProgram: 'automation.core',
   validate: 'automation.core',
   run: 'automation.core',
+  recoverStalled: 'automation.run-recovery',
   stop: 'automation.core',
   getStatus: 'automation.core',
   captureScreen: 'screen.capture',

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -722,13 +722,28 @@ export function createX1PenMcpServer(options = {}) {
   )));
 
   server.registerTool('x1pen_run', {
-    description: 'Build and run the current program in the connected user-visible X1Pen tab.',
+    description: 'Build and run the current program in the connected user-visible X1Pen tab. Concurrent Run returns ordinary content with code RUN_IN_PROGRESS and retryAfterMs; a Run held behind other Automation work can return non-retryable RUN_QUEUE_TIMEOUT. The server does not retry automatically.',
     inputSchema: {
       sessionId: sessionInput.sessionId,
       waitMs: z.number().int().min(0).max(10_000).default(500),
     },
     annotations: { destructiveHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId, waitMs }) => textResult(await bridge.sendCommand('run', { waitMs }, sessionId))));
+  }, handleTool(async ({ sessionId, waitMs }) => {
+    const commandTimeoutMs = Number.isFinite(bridge.commandTimeoutMs) ? bridge.commandTimeoutMs : 60_000;
+    const queueTimeoutMs = Math.max(100, Math.min(20_000, Math.floor(commandTimeoutMs / 4)));
+    return textResult(await bridge.sendCommand('run', { waitMs, queueTimeoutMs }, sessionId));
+  }));
+
+  server.registerTool('x1pen_recover_stalled', {
+    description: 'Reload a Run-stalled X1Pen tab. First call without confirmation to read the data-loss warning. Recovery is refused unless Run admission is already stalled; it preserves editor source but loses emulator RAM and unpersisted disk changes.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      confirmDataLoss: z.boolean().default(false),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, confirmDataLoss }) => textResult(
+    await bridge.sendCommand('recoverStalled', { confirmDataLoss }, sessionId),
+  )));
 
   server.registerTool('x1pen_stop', {
     description: 'Send ESC to stop the program in the connected X1Pen tab.',

--- a/plan.md
+++ b/plan.md
@@ -1,138 +1,354 @@
-# `simulateKeys()` 逐次キー注入化 — 実装レビュー計画
+# X1Pen Run re-entrancy prevention design
 
-## 最終状態
+## Purpose
 
-- five-round failure後のhuman approval（Secretary request `20260809T110807.629241-secretary`）に基づき、R5-F1とR5-F2を実装・再検証済み。
-- 採用済みfindingの未実装残はなし。
-- `interval`→`gapMs`、per-key finally、最新keyModeの0..2 validation付き復元、JoyKey/timing assertionを反映済み。
-- queue/guardとAutomation `run()`の`ok:true`拡張は、承認どおり今回scope外のまま。
+Prevent two Run requests from executing `performRun()` and emitting X1 command keys concurrently. The confirmed user-visible symptom is duplicated/interleaved text such as `rruunn` when the Run button is pressed repeatedly before the first run setup finishes.
 
-## 目的
+This plan covers design and verification only. It does not implement code, commit changes, alter PR #78, or redefine a successful Run as proof that the X1 program has started. The latter requires mode-specific machine-state acknowledgement and remains a separate API design.
 
-`html/x1pen.js` の合成キー注入で、複数の keydown/keyUp タイマーが main-thread 遅延時に重なり、LSX の `PROG` コマンドが欠落する問題を解消する。
+The previous `simulateKeys()` work is archived at `plans/20260809-sequential-simulate-keys.md`. It guarantees `down → hold → up → gap` ordering inside one invocation, but deliberately does not serialize separate invocations.
 
-## 確認済みの原因
+## Observed evidence
 
-- 旧 `simulateKeys(keys, interval)` は全 keydown を `i * interval` で先行予約し、各 keyUp を keydown の 80ms 後に予約していた。
-- `simulateProgCommand()` の `interval=50ms` は hold=80ms より短く、平常時からキーが構造的に重なる。
-- headless 環境でタイマーが coalesce すると複数 keydown が同時刻に集中し、`PROG` の一部が欠落して LSX プログラムが開始されない。
-- 1キーずつ down、wait、up、wait と逐次注入する非変更実験では、プログラム開始と ASM marker 書込みを確認済み。
+### Reproduction status
 
-## 実装方針と現在の実装
+- UI Run repetition is user-confirmed: pressing Run again before completion produces mixed text such as `rruunn`.
+- A live repeat in this session was unavailable because the in-app browser exposed no browser tab. No alternate browser-control backend was substituted. The call-path result below is therefore source-proven rather than a second visual reproduction.
+- The same race applies to FuzzyBASIC `RUN` and LSX `PROG`: both paths enter the same unguarded `onRunClick()` / `performRun()` flow and call `simulateRunCommand()` or `simulateProgCommand()` only near the end.
 
-1. `SYNTHETIC_KEY_HOLD_MS = 80` を定義する。
-2. Promise ベースの `waitForSyntheticKey(ms)` を定義する。
-3. `simulateKeys(keys, gapMs)` を async function とし、各キーを次の順で直列処理する。
-   - `module._js_key_down(vk)`
-   - hold 80ms を await
-   - `module._js_key_up(vk)`
-   - 最終キー以外は inter-key gap を await
-4. 旧 `interval` 引数は意味を明確にするため `gapMs` に改名し、次の keydown までの間隔ではなく keyUp 後の gap とする。
-   - PROG: 80ms hold + 50ms gap = keydown 間隔 130ms 以上
-   - RUN: 80ms hold + 100ms gap = keydown 間隔 180ms 以上
-5. keyDown/keyUp の既存の例外握りつぶしを維持しつつ、各キーを `down; try { await hold } finally { up }` にして、将来hold待機がreject可能になってもkeyUpを必ず試行する。合成キー用 Keyboard mode は外側の `finally` で復元する。
-6. 合成sequenceの一時KB切替はmoduleの `_js_set_key_mode(0)` を直接呼び、`XmilControls` の設定storeは変更しない。最終mode復元時は開始時snapshotだけを無条件に書き戻さず、`XmilControls.getSettings().keyMode` を再読込する。0..2の有効値なら最新設定を復元し、未定義・値不正・例外時のみ開始時snapshotをfallbackにする。
-7. private helper のテスト専用公開は追加しない。
-8. Round 3 の再評価により、Promise queue と新しいin-flight拒否guardはいずれも導入しない。前者はbacklog/rejection管理、後者は新しい`run_in_progress` API結果契約を生み、単一`simulateKeys()`内の確定済みtimer overlap修正を越えるためである。
+### UI call path and collision layer
 
-この共通関数を利用する `simulateRunCommand()` と `simulateProgCommand()` の双方が同じ逐次化の恩恵を受ける。
+- `html/x1pen.js:2992` registers the Run button directly with `elBtnRun.addEventListener('click', onRunClick)`.
+- `html/x1pen.js:3004-3008` calls the same function for Ctrl+Enter. It checks `elBtnRun.disabled`, but Run setup never disables the button.
+- `html/x1pen.js:706-712` increments `automationActiveRuns` as a counter but performs no check before starting another `performRun()`.
+- Each `performRun()` independently compiles/loads state, starts the emulator, waits 500 ms, and then awaits its own `simulateProgCommand()` or `simulateRunCommand()` (`html/x1pen.js:933-962`).
+- `simulateKeys()` is sequential only inside one invocation (`html/x1pen.js:597-632`). Two invocations can call the same module `_js_key_down/up` exports concurrently. Thus the fault begins with UI handler multi-fire, creates parallel command-function invocations, and manifests as interleaved `simulateKeys()` calls; it is not an ordering defect inside either individual call.
+- Timing after PR #78 is about 600 ms for PROG and 620 ms for RUN, in addition to build/load and the fixed 500 ms pre-injection wait, leaving an easy multi-click window.
 
-## 呼び出しチェーンの棚卸し
+### Automation API and MCP behavior
 
-- `simulateKeys()` の直接呼び出しは `simulateRunCommand()` と `simulateProgCommand()` の2箇所だけで、可変長キー列や第三の呼び出し元はない。
-- 両 wrapper は `simulateKeys()` の Promise を return する。
-- `performRun()` は LSX 分岐で `await simulateProgCommand()`、FuzzyBASIC 分岐で `await simulateRunCommand()` としている。
-- Automation API の `run()` は operation queue 内で `await onRunClick()` し、`onRunClick()` は `await performRun()` する。従って Automation の完了は全キーの keyUp まで伝播しており、floating Promise はない。
-- UI click / Ctrl+Enter / Share-triggered run は Automation operation queue 外から `onRunClick()` に到達し得る。新たな同時run拒否契約は今回追加せず、同時runは既存制約として残す。
-- Keyboard mode の復元は既存の `syntheticKeyDepth` 参照カウントで管理される。最初の合成sequenceだけがユーザーmodeを保存してKBへ切り替え、重複sequenceはdepthだけを増やし、depth=0になった最後のleaveだけが保存済みユーザーmodeへ復元する。従って重複時もmode snapshotの上書き・固着は起きない。
+- Direct `window.X1PenAutomation.run()` calls enter `queueAutomationOperation()` (`html/x1pen.js:1960-1973,1989-2008`). Its Promise chain runs one Automation operation at a time. `Promise.all([api.run(), api.run()])` therefore schedules two complete runs sequentially; their key sequences do not interleave, but the second request creates backlog and repeats the run.
+- `automationQueuedRuns` is incremented synchronously before queue execution, and `isRunSetupPending()` already reports queued or active Run setup to debugger clients (`html/x1pen.js:1468-1484`).
+- MCP `x1pen_run` sends a `run` command through `mcp/x1pen-server.mjs:724-731` and `mcp/x1pen-bridge.mjs:215-238`.
+- The Connector can dispatch multiple commands concurrently: `createUpdateCoordinator().run()` counts active work but does not serialize it (`extension/update-coordinator.mjs:28-37`), and each command invokes `invokeX1PenInPage()` independently (`extension/service-worker.js:174-176,233-261`).
+- Nevertheless, each page invocation calls `api.run()` (`extension/page-automation.mjs:87-91`), so multiple MCP Run requests ultimately serialize in the page Automation queue. They do not mix with each other, but can accumulate and rerun stale intent.
+- A UI Run bypasses `automationOperationQueue`. A direct API/MCP Run that arrives while a UI Run is active can therefore overlap it. Connector interaction locking disables toolbar buttons after an MCP request begins, but it cannot retroactively serialize a UI Run already in progress.
 
-## キー注入・mode参照の全体棚卸し
+### Stop and physical/screen keyboard relationship
 
-- program command合成注入は `simulateKeys()` のみで、直接callerは固定列のRUN/PROG wrapper 2箇所だけ。
-- `html/x1pen.js` のStop操作はESCを30msの独立timerで送る。これはrun cancellation契約を持たない既存経路で、今回のprogram command逐次化には統合しない。
-- `html/pre.js` のscreen/physical keyboard handlerはユーザー入力を直接 `_js_key_down/up` へ渡す。Automation interaction lock中はUI操作を抑制する既存責務であり、program command helperには統合しない。
-- Keyboard mode writeは合成sequenceの一時KB切替・参照カウント復元、Controlsの設定適用、設定UI changeに存在する。今回の修正は既存参照カウント方式を変更しない。
-- 合成sequence中にControls設定が変わった場合はleave時に最新`getSettings().keyMode`を再読込するため、古いsnapshotで新しいユーザー選択を巻き戻さない。
-- テストの `_js_key_down/up` 参照はイベント記録用spyであり、finallyで元関数へ戻す。
+- UI Stop directly emits Escape and schedules key-up 30 ms later (`html/x1pen.js:1046-1053`); it does not participate in either run admission or the Automation queue. It can interleave with a UI-origin Run command sequence.
+- Automation/MCP Stop uses `queueAutomationOperation()` (`html/x1pen.js:2010-2014`) and therefore follows an Automation-origin Run. It can still overlap a UI-origin Run because that Run is outside the queue.
+- Physical keyboard callbacks are installed on `window` and write the same emulator key state (`platform/platform_input.cpp:151-180,244-250`). They ignore only form-field focus; `inert` and toolbar disabling do not suppress window key events.
+- The screen keyboard directly calls `_js_key_down/up` (`html/pre.js:1910-1915`).
+- Stop and physical/screen keys are therefore the same low-level collision family, but resolving them requires cancellation and input-arbitration policy beyond Run/Run admission. This plan recommends tracking them as a separate follow-up rather than silently changing Stop or physical-input semantics in the Run fix.
 
-## テスト方針と結果（human approval実装後）
+## Change scope
 
-- 既存 Playwright automation integration test で Emscripten Module の `_js_key_down` / `_js_key_up` を一時的にラップし、実際の `X1PenAutomation.run()` 中のイベント列を記録する。
-- FuzzyBASIC の RUN が `down R, up R, down U, up U, down N, up N, down Enter, up Enter` の厳密な交互列であることを検証する。
-- LSX の PROG が `down P, up P, down R, up R, down O, up O, down G, up G, down Enter, up Enter` の厳密な交互列であることを検証する。
-- LSX テストは marker address `0x4000..0x4003` が `12 34 56 78` になる既存確認も維持し、コマンドが実際に開始したことを検証する。
-- 旧 PROG 実装は gap 相当の50ms時点で2キー目が down し、1キー目の up は80ms時点なので、正常な timer 実行でも新 assertion の期待する down/up 交互列に必ず違反する。この assertion は timer coalescing の偶然を待たずに旧構造を決定的に検出する。coalescing 自体の再現テストではない。
-- 先行調査の修正前 baseline は automation 9件中6件 pass、ASM/PROG を使う3件が30秒 timeout だった。
-- 記録イベントに `performance.now()` timestamp を含め、各down→upが70ms以上、50ms gapは40ms以上、100ms gapは85ms以上であることを検証する。これにより順序だけでなくhold/gap=0への退行も検出する。
-- `_js_set_key_mode`もspyし、JoyKey設定からrunした場合に一時KB(0)へ切り替わり、完了後に最新のユーザーmodeへ復元されることをassertする。
-- `npm run test:automation`: 新timing/mode assertion込みで9/9を独立プロセスで3回連続pass（合計27/27）。
-- `test:bridge`: 8/8、`test:extension-package`: 11/11、`test:mcp`: 44/44、`test:mcp-package`: 1/1 pass。
-- `./build.sh`: human approval実装反映後に成功。
+### Proposed implementation scope
 
-## スコープ判断
+- `html/x1pen.js`
+  - Add one synchronous, cross-entry Run admission reservation covering UI, Ctrl+Enter, Share auto-run, direct Automation, and MCP-origin Automation.
+  - Split admission from execution so an accepted request reserves before the first `await` and releases exactly once in `finally`.
+  - Require the live reservation token inside the only function that can invoke `performRun()`; an unowned/stale token must fail before side effects.
+  - Disable/mark the Run UI while reserved and restore it without racing the existing Automation interaction lock.
+  - Return an additive structured busy result for rejected Automation requests.
+- `html/x1pen.html`
+  - Add/identify a dedicated aria-live notification region and reserved-state Run styling; the current toolbar has no aria-live region, so the active Run status must remain a distinct element.
+- `tests/x1pen_automation_test.mjs`
+  - Add deterministic UI, API, mixed-origin, FuzzyBASIC, and LSX concurrency tests using the existing module key spies.
+- `extension/page-automation.mjs`, `extension/service-worker.js`, `extension/update-coordinator.mjs`, and extension/bridge tests
+  - Pass the Run origin/effective queue bound, preserve admission-failure results, skip `waitMs` only for admission codes, keep status reads outside the operation queue, route atomic stalled recovery, and settle navigation cleanup with balanced lock/coordinator state.
+- `mcp/x1pen-server.mjs`, `mcp/x1pen-bridge.mjs`, and MCP/bridge tests
+  - Update the model-facing `x1pen_run` contract, derive the queue bound from effective transport timeout, add compatibility-gated `x1pen_recover_stalled`, and define exactly-once `TAB_RELOADED` correlation cleanup. Test ordinary admission content and recovery refusal/acceptance.
+- `docs/X1PEN_MCP.md` and, if the page API is documented there, `docs/X1PEN.md`
+  - Document concurrent Run as a behavioral compatibility change, bounded retry guidance, feature detection decision, and the unchanged meaning of successful `ok:true`.
 
-- Automation `run()` の `ok:true` は今回変更しない。
-- 理由: `ok:true` を「キー注入完了」から「コマンド開始確認」へ変えるには、FuzzyBASIC と LSX の開始条件、timeout、エラー表現を含む別の API 契約が必要であり、今回のタイマー競合修正と分離する方が安全。
-- リセット・電源断・run cancellation の世代チェックは追加しない。現行 API に進行中の `performRun()` を abort する契約がなく、旧実装にも同じ制約があるため、別途 cancellation contract を設計する課題とする。
-- 同時run / Stop / physical inputとの交差は今回新規に悪化させる状態管理を導入せず、既存の参照カウントmode復元を維持する。単一sequence内のorderingだけを今回の保証範囲とする。
-- UI click / Ctrl+Enter / Share / Stop / physical keyを意図的に同時実行した場合、program commandの注入窓が旧280–380msから新600–620msへ伸びるため、別sequenceまたはESC/physical keyが割り込み、今回と同じ交互列崩れを起こす可能性は高くなる。Automation API同士は既存operation queueでserializeされ、Connector経由では既存interaction lockがUIを抑制するため、報告されたheadless Automation経路にはこの並行入力はない。対話操作の同時run/cancel契約は別課題とする。
+### Explicit non-goals
 
-## リスクとロールバック
+- Do not queue arbitrary UI Run clicks.
+- Do not cancel an accepted Run and replace it with the newest request.
+- Do not change key timing or `simulateKeys()` internal ordering from PR #78.
+- Do not solve UI Stop or physical/screen-key arbitration in the same change.
+- Do not change `ok:true` from “build/setup and command-key injection completed” to “the X1 program demonstrably started.”
+- Do not bump the Automation API or Connector protocol solely for additive busy fields unless implementation uncovers a consumer that rejects unknown result fields.
+- Do not provide a general force-unlock. The only remote recovery added here is a guarded page reload after status proves `stalled` and the caller explicitly confirms the stated data loss.
 
-- PROG は旧約280msから新約600ms、RUNは旧約380msから新約620msになる。`performRun()` と全 Automation caller は注入 Promise を await するため、注入後の画面取得や marker polling は注入完了後に開始する。marker は固定 sleep ではなく `waitForFunction` で状態を polling し、suite timeout は60秒である。bridge/MCPを含む指定suiteも新時間で passしており、追加約320msに対する実測余裕がある。
-- key mode 復元は全キー処理を囲む `finally` に置き、正常完了以外でも復元を試みる。
-- 現在の `waitForSyntheticKey()` は resolve-only の Promise で、run cancellation / AbortSignal はなく、keyDown 後から keyUp 前に reject するコード経路はない。ページ unload 時は JS context 自体が破棄される。防御的なper-key finallyでは `_js_key_down` 成功をlocal flagで保持し、成功時だけkeyUpを試行する。
-- 80ms hold は wall-clock ordering の保証であり、エミュレータ進行フレーム数の保証ではない。今回の確定原因と非変更実験は key overlap を対象としており、エミュレータ停止・background throttling は別問題として扱う。
-- 非表示tabでbrowser timerが1秒 clampされる場合、Nキーの逐次hold/gapは最大約2N回のtimer待機となり、PROGは約9秒規模まで延び得る。ただし旧parallel方式は同条件でtimer coalescingによりキー欠落するため、安全なparallel化へは戻さない。Automation実行はX1Pen tabが表示・稼働している条件を想定し、hidden-tab最適化は別課題とする。
-- mode固着・キー欠落など限定的な回帰はhold/gapまたはmode復元の前進修正を第一選択とする。逐次化自体が広範な破損を起こす場合のみPR branchの単一squash commitをrevertできるが、修正前baseline 6/9へ戻るため automation 9件の再実行と既知3 timeoutの再確認を要する。review後amendでSHAは変わるため固定hashをrollback手順に使わない。データ形式や永続設定の migration はない。
+## Implementation steps
+
+### 1. Compare the candidate policies
+
+| Option | UI protection | Automation/MCP protection | Contract impact | Backlog | UX / maintenance | Decision |
+|---|---|---|---|---|---|---|
+| A. Disable Run and ignore UI repeats | Yes | No; direct API can overlap an existing UI Run | None for API | None for UI | Simple and natural, but incomplete alone | Adopt as presentation layer only |
+| B. Shared re-entrancy guard | Yes | Yes, if reservation happens before Automation queueing | Additive `ok:false` busy result for concurrent programmatic calls | No extra Run backlog; accepted Run may wait bounded time behind unrelated Automation work | Clear ownership and bounded work; moderate state/UI tests | Adopt as core |
+| C. Queue every Run | Prevents mixing | Prevents mixing | Existing calls keep resolving, but timing/ordering semantics change | Unbounded unless extra policy is added | Repeated clicks run later, stale programs may execute, cancellation/timeout ownership is complex | Reject |
+| D. Abort current and run latest | Yes | Yes | Requires cancellation result and partial-side-effect contract | Bounded | Responsive latest-wins UX, but compilation, state load, disk mount, emulator start, and key cleanup need abort points | Reject for now |
+
+Recommended design: A+B. UI affordances prevent normal double-clicks, while a shared execution-layer reservation closes programmatic clicks, Ctrl+Enter, Share, direct API, MCP, and mixed UI/API races. C remains rejected because solving rejection pollution does not solve stale queued intent or unbounded backlog; coalescing distinct requests would incorrectly claim that the later program ran. D is a separate cancellation project.
+
+### 2. Define one synchronous Run reservation
+
+1. Add module-local Run admission state containing a unique opaque token, normalized origin (`ui | automation | mcp | share`), phase (`reserved | queued | executing | stalled | recovering`), and monotonic timestamps. Tokens never leave the module, appear in status/results/logs, or cross the page API boundary. The admission record is the sole source of truth for Run pending/phase/ownership; retire the two Run counters or derive compatibility fields from this record rather than maintaining parallel mutable state.
+2. `tryReserveRun(origin)` performs check-and-set synchronously with no `await`. It returns the opaque token or `null` when another Run is reserved.
+3. Place the guarded execution behind one module-private function such as `executeReservedRun(token)`. It validates token ownership once immediately before calling `performRun(token)`. Once phase becomes `executing`, only that owner's `finally` may invalidate/release the token; watchdogs and remote callers cannot do so. Any later ownership check is a defensive assertion that logs but continues cleanup/execution rather than aborting after partial side effects. No entry point may call an unguarded zero-argument `performRun()`.
+4. Mandate reserve-to-cleanup adjacency, with zero statements between successful acquisition and the `try`: `const token = tryReserveRun(origin); if (!token) return busyResult(); try { ... } finally { releaseRun(token); }`. Source/revision reads, status changes, and UI refreshes all occur inside the `try`. `releaseRun(token)` ignores stale/non-owner tokens, clears ownership first, and performs fallible UI refresh in a contained `try/catch` so a detached DOM node cannot prevent state cleanup.
+5. Distinguish `queued` from `executing` in `getStatus()` through non-sensitive `runAdmission: { pending, origin, phase, ageMs, phaseAgeMs }`, where `ageMs` is total reservation age and `phaseAgeMs` resets on each transition. Keep the existing `capabilities.debugger.runPending` boolean for compatibility.
+6. Bound a pre-execution Automation reservation with a direct/page default `RUN_QUEUE_TIMEOUT_MS = 20_000`. For MCP, derive the per-request effective value from the actual bridge setting as `min(20_000, floor(commandTimeoutMs / 4))` (15 seconds under the 60-second default), pass it through the Connector to `run()`, and clamp/validate it page-side. This preserves a 4× transport ratio under lower test/operator settings instead of relying on equal fixed constants. Implement the caller-facing Promise as a race that settles once with `RUN_QUEUE_TIMEOUT`. The queue callback's synchronous first statement atomically changes its live token from `queued` to `executing` before any `await`. The timeout handler releases/settles only if it still owns a `queued` token; if callback entry already won, timeout is a complete no-op and the caller remains pending for normal owner completion (ultimately bounded by the outer bridge timeout). Test both same-task orderings.
+7. Start `RUN_STALL_WARNING_MS = 30_000` when the reservation enters `executing`, not when it is created. Do not force-release an `executing` token merely because that watchdog fires: non-cancellable work could later resume and overlap the replacement Run. Change phase to `stalled`, keep the safety gate closed, show the data-loss warning with reported origin in a separate unverified diagnostic line, and expose total/phase age in status. Thirty seconds is more than three times the currently observed cold automation-run duration (about 6–8 seconds); validate and adjust that constant against fresh cold/warm measurements during implementation. With the 20-second direct queue bound, the longest pre-warning hold is about 50 seconds (about 45 seconds for default MCP). Network-only stages should use `AbortController`/bounded fetch timeouts where cancellation is real; non-cooperative storage/emulator awaits must not be unlocked by `Promise.race` alone. If the original owner later completes or rejects before recovery claims the state, its `finally` clears the warning/reservation and restores idle; after `recovering`, navigation owns cleanup and late owner completion cannot reopen admission.
+8. `isRunSetupPending()` includes accepted queued/executing/stalled/recovering reservations so debugger controls remain blocked from acceptance through final cleanup or reload.
+9. Audit every `automationQueuedRuns` / `automationActiveRuns` consumer, then remove the counters or make them derived read-only compatibility values. This is not a widening of current `runPending`: UI `onRunClick()` already increments `automationActiveRuns`, so UI setup already contributes to the existing boolean. Preserve that boolean's semantics while enriching it with the admission phase/origin object.
+10. Expose `runAdmission.phase`, total/phase age, and best-effort origin through the existing `getStatus()` / `x1pen_get_status` path, including after the original MCP Run command has exceeded its bridge timeout. Source audit confirms page `getStatus`, `getProgram`, and `captureScreen` execute synchronously outside `queueAutomationOperation()` and `extension/page-automation.mjs` calls them directly; preserve that bypass. `validate` currently enters the queue and is not an observation/recovery prerequisite: reject it promptly with `RUN_PENDING` rather than claiming it proceeds during an API-origin stall. A gating integration test must hold an MCP-origin Run in the queue and prove a concurrent MCP status call still returns `stalled`.
+
+### 3. Separate UI and Automation entry behavior
+
+1. UI button, Ctrl+Enter, and Share auto-run call wrappers that assign their internal origin labels and attempt reservation before starting asynchronous work. Labels are best-effort diagnostics, not a MAIN-world security boundary: page scripts can dispatch UI events or claim `mcp`, so attribution never changes admission or recovery eligibility. User-visible recovery renders origin separately as “Reported origin (unverified): …”; the actionable data-loss text is byte-identical across origins.
+2. When reservation fails, do not invoke `performRun()`, do not enqueue work, and do not overwrite the active Run status. Normal activations should already be ignored by the focusable `aria-disabled` trigger, while this handler-level check remains the correctness boundary.
+3. Derive Run-trigger state from the complete reason set in one `refreshRunTriggerState()` function: initial/module readiness, Run reservation, and Automation interaction lock. The source audit found only the initial disabled markup, the module-ready enable write, and the toolbar interaction-lock snapshot writes; implementation must repeat this audit before editing and stop if another reason appears. For a user-origin reservation, keep the focused button focusable and mark it visually/semantically unavailable with `aria-disabled="true"` and `aria-busy="true"`; the guarded handler ignores activation, and CSS treats `[aria-disabled="true"]` as non-hoverable/unavailable. A Connector interaction lock deliberately takes precedence with native `disabled`/`inert` and the existing blur because AI owns the interaction surface during that interval; this accepted focus loss is restored only according to existing lock behavior. Exempt Run from the lock's snapshot/restore loop and call `refreshRunTriggerState()` on lock acquisition/release, ensuring unlock cannot re-enable it while reserved. Sibling controls retain current snapshot behavior.
+4. Automation `run(options?)` accepts an additive optional `{ origin }` hint but publicly trusts only `automation | mcp`; Connector/MCP page invocation supplies `mcp`, omitted or unknown values default to `automation`, and `ui | share` can be assigned only by their internal wrappers. The method attempts reservation synchronously before `queueAutomationOperation()`. A rejected request returns immediately and never enters the operation queue.
+5. An accepted Automation request captures its token, queues exactly one execution, and releases the token in a finally path even if readiness or the preceding Automation queue rejects.
+6. Share auto-run rejection emits a separate non-destructive aria-live notice/toast (“Run already in progress”) that does not replace the active Run status text or enqueue stale Share intent.
+
+### 4. Audit the behavioral compatibility change
+
+1. Enumerate all `onRunClick`, `performRun`, `X1PenAutomation.run`, Connector `run`, and MCP `x1pen_run` call sites and tests before implementation. Current read-only search found UI button, Ctrl+Enter, Share replay, the page Automation method, Connector MAIN-world invocation, MCP tool routing, and individual test calls; it found no repository test or production caller that intentionally overlaps two `run()` calls.
+2. Record that concurrent programmatic behavior changes: today two overlapping API/MCP requests execute sequentially; after the gate, the first is admitted and later overlapping requests return busy without running. Sequential `await api.run(); await api.run()` remains unchanged.
+3. Update callers that intentionally need two runs to await the first before issuing the second. Update tests to assert the new busy policy rather than the old queue-both behavior.
+4. Do not add a feature ID/API version bump: concurrent Run execution was not an advertised capability, existing `ok:false` is already part of the result contract, and sequential success remains compatible. Document the behavior prominently. If implementation discovers a strict schema consumer or an advertised queue-both guarantee, stop and reconsider this decision before coding further.
+5. Verify deployment skew explicitly. Current `mcp/x1pen-server.mjs::textResult()` wraps any returned object as ordinary content and does not inspect `value.ok`, so new page + old server still yields `isError:false`; an old extension may retain the historical `waitMs` on busy but does not change the payload. Old page + new extension/server retains queue-both behavior because no admission code is present, and the extension skips `waitMs` only when a new code actually exists. Add both-direction skew tests. The new stalled-recovery command is separate: advertise/check a new `automation.run-recovery` compatibility feature and refuse with update-required guidance when the connected page/Connector lacks it.
+
+### 5. Define additive admission-failure contracts
+
+Concurrent Automation/API/MCP Run returns a normal Run result with:
+
+```json
+{
+  "ok": false,
+  "code": "RUN_IN_PROGRESS",
+  "retryable": true,
+  "retryAfterMs": 500,
+  "activeOrigin": "ui",
+  "status": "Run setup is already in progress",
+  "sourceMode": "<current source mode>",
+  "revision": 123
+}
+```
+
+- `status` is the existing human-readable field already returned for every current `ok:false` Run result; admission failures must keep it non-empty so naive `if (!result.ok) show(result.status)` consumers continue to work.
+- `code` is the only machine-branching key. Do not add a redundant `reason` branch key.
+- `revision` means the current editor program revision at the rejected caller's observation time, matching the existing Run result field; it is not a run ID.
+- `activeOrigin` is diagnostic only and contains one normalized non-sensitive label. Direct page callers default to `automation`; Connector/MCP explicitly supplies `mcp`. The opaque owner token is never exposed.
+- Existing successful result fields and `ok:true` semantics remain unchanged.
+- `ok:false` is already a valid Run outcome, so optional `code`, `retryable`, and retry-diagnostic fields are additive. Sequential callers see no change.
+- Do not throw for busy: returning a result preserves the current Run-result control flow across the page API, Connector, and MCP tool.
+- `extension/page-automation.mjs` skips `waitMs` only for the two admission failures in the table below; successful and historical non-admission outcomes keep their current timing.
+- MCP returns either admission-failure payload as ordinary tool content with `isError:false`, because it is an expected application result rather than a transport/tool failure. Tests must assert both `isError:false` and payload `ok:false`.
+- No page, extension, bridge, or MCP-server layer retries automatically; each admission failure settles and releases any interaction lock. Only `RUN_IN_PROGRESS` is automatically retryable guidance: begin at the supplied delay, apply capped exponential backoff up to 2 seconds, and stop after a 30-second overall budget. Callers must still handle another admission failure after `runPending` becomes false because admission is inherently racy. A contract harness drives that algorithm against an active Run lasting longer than 1.1 seconds; it validates the guidance, not hidden production retry code. `RUN_QUEUE_TIMEOUT` is not automatically retryable because the unrelated preceding Automation operation has already blocked for 20 seconds; inspect status/operator state instead of immediately enqueueing the same stale intent.
+- Keep Automation API version 2 and current feature IDs unless compatibility tests show an existing consumer treats unknown fields as invalid.
+
+Outcome handling is explicit:
+
+| Code | When returned | `retryable` / delay | `waitMs` | MCP mapping | Caller Promise |
+|---|---|---|---|---|---|
+| `RUN_IN_PROGRESS` | Reservation fails because another Run owns admission | `true`, initial 500 ms | Skip | Ordinary content, `isError:false` | Settles promptly with the result |
+| `RUN_QUEUE_TIMEOUT` | An admitted Automation Run does not begin within its effective queue bound (20 seconds direct; 15 seconds under default MCP transport) because it is behind prior Automation work | `false`, no delay field | Skip | Ordinary content, `isError:false` before the outer bridge timeout | Settles only if timeout wins while still `queued`; otherwise owner completion wins |
+
+There is no third public “stale token” outcome. Staleness is an internal ownership check: a queue-timed-out caller has already received `RUN_QUEUE_TIMEOUT`, while a stale/non-owner callback resolves internally without executing or changing the caller-visible result.
+
+### 6. Keep command-start acknowledgement separate
+
+The busy contract answers “was this Run admitted?” Successful `ok:true` continues to answer “did setup and command injection complete?” Determining whether FuzzyBASIC or LSX actually began execution requires different state evidence, timeouts, and error reporting. Combining it here would couple admission control to emulator-specific completion detection and make rollback harder. Track command-start acknowledgement as a separate design/issue.
+
+### 7. Record related input-arbitration follow-up
+
+Create a follow-up design for UI Stop and physical/screen input during synthetic command injection. Candidate policy to evaluate there:
+
+- expose a synthetic-input critical-section flag independent of JoyKey mode/depth;
+- defer one Stop request until the current synthetic key is released, or add explicit cancellation checkpoints;
+- decide whether physical/screen input is suppressed, buffered, or deliberately allowed;
+- ensure every accepted key-down has a key-up and release held physical keys at the boundary.
+
+Do not add these semantics opportunistically to the Run admission patch.
+
+### 8. Define interaction with other Automation operations
+
+- `setProgram` mutates editor text/revision and must reject with the existing `RUN_PENDING` control error while any Run reservation is live, including a UI-origin Run. This prevents source/revision changes between compile and injection.
+- Debugger pause/resume/step/write operations consult or will be extended to consult `isRunSetupPending()`; test rejection for `reserved`, `queued`, `executing`, `stalled`, and `recovering`.
+- `getProgram`, `getStatus`, and `captureScreen` bypass the operation queue and may proceed because they do not mutate emulator execution or stored program. Their observations can change between calls. `validate` currently queues; change it to reject promptly with `RUN_PENDING` during any reservation rather than wait indefinitely or run concurrently with UI setup.
+- `stop` remains explicitly permitted under its current origin-dependent behavior and caveat described above; changing it belongs to the input-arbitration follow-up.
+- Interaction locking is presentation state, not program mutation. Disk-library/machine controls are inaccessible to normal UI while the Connector lock is active, but physical/manual interaction outside that lock remains outside this Run/Run plan. Do not describe the admission record as a global emulator transaction lock.
+
+### 9. Add stalled-only local and remote recovery
+
+1. Keep the existing safety invariant: no action clears an `executing` reservation or admits concurrent work. Recovery becomes eligible only after the watchdog has changed phase to `stalled` while retaining the owner.
+2. Put the local recovery control and its live warning outside `editor-panel` inert scope and exempt it from the toolbar interaction-lock button loop. It remains focusable/activatable while the stuck MCP command still owns that lock. Add `x1pen_recover_stalled` with `confirmDataLoss`; absent confirmation returns the warning, and no caller can supply a token or force-unlock request.
+3. Authorization is page-local and atomic, not based on a stale server-side status read. A MAIN-world recovery entry synchronously rechecks `phase === 'stalled'`, returns `RECOVERY_NOT_STALLED` with no navigation otherwise, synchronously persists current editor values through the existing `persistEditorSources()` boundary, then changes phase to `recovering` so late owner cleanup cannot reopen the gate or admit a new Run. The automation instance/revision is session-scoped and may reset after navigation; callers must fetch the fresh revision rather than expect revision continuity. In that same task it posts the accepted result and schedules navigation; the service worker must not independently reload based on an earlier snapshot.
+4. After confirmation, record a bounded diagnostic event with session ID/reported origin/age (never the opaque token). The accepted response is posted before the page's scheduled navigation. Because navigation destroys the old context, the caller polls `x1pen_get_status` for a fresh ready session rather than expecting the original Run Promise to recover.
+5. Define navigation cleanup: disconnecting/reloading the exact tab rejects every other pending bridge correlation for that session exactly once with `TAB_RELOADED`; service-worker `finally` paths decrement update-coordinator counts and interaction-lock depth, and the new page starts with depth zero. The recovery request itself may return accepted before disconnect, but must also settle exactly once. Test recovery both before and after the original Run's 60-second timeout.
+6. The command is the remote equivalent of the UI reload, not a runtime bypass: it does not release the old page and continue there. Advertise it as `automation.run-recovery` so an old page/Connector receives an update-required response rather than an unknown command.
+
+## Edge cases and test plan
+
+### Admission and cleanup
+
+- Two Run-button events in the same task: one reservation, one `performRun()`, one complete key sequence.
+- Reservation is observable synchronously before the first asynchronous preparation step; a second request during `reserved`/`queued` phase is rejected before any key-down.
+- Ctrl+Enter while Run is reserved: no second execution.
+- Share auto-run while another Run is reserved: no second execution and one non-destructive notice in the dedicated aria-live region, which is distinct from `x1pen-status`; snapshot the active status before rejection and assert it is unchanged afterward.
+- Compile/validation failure before emulator start: reservation releases; the next Run succeeds.
+- Exception during asset load, mount, or key injection: reservation releases in `finally`; UI and `runPending` return to idle.
+- Interaction lock begins/ends while Run is reserved: the Run trigger remains semantically unavailable until both reasons are clear, and release of the lock alone cannot clear `aria-disabled`/`aria-busy`.
+- Automation Run held behind another operation: status reports `queued` and the UI/tooltip says “Run queued behind automation (up to 20 seconds)”; the reservation releases with caller-visible `RUN_QUEUE_TIMEOUT` after 20 seconds, and the later stale queue callback performs no work or second settlement.
+- Execution watchdog: status changes to `stalled` and offers reload without accepting another Run. A late original completion releases only its own token, clears the stalled prompt, and restores idle state; a stale callback can neither release nor execute another owner's reservation.
+- Immediately before either recovery navigation, synchronously persist the current values of all three editors using the existing localStorage boundary. Add a test that edits during the stall window and proves those latest values survive reload. Assert a fresh automation instance/revision is returned after navigation rather than requiring revision continuity. Reload still discards emulator RAM, programs typed only inside the emulated X1, and disk/mounted-image changes not flushed to persistent storage. Use invariant action text such as “Reloading preserves the current editor source but loses emulator RAM and unpersisted disk changes,” with the unverified reported origin shown separately.
+- Throw synchronously from the first statement inside the post-reservation `try` and separately from Run-trigger refresh during release; both cases must clear admission and accept a later Run.
+- Hold an MCP-origin execution past the 30-second stall threshold while it still owns `automationOperationQueue`; assert a concurrent MCP `x1pen_get_status` bypasses the queue and reports `stalled` with age/origin. Repeat after the original command's 60-second bridge timeout. Ordinary Run/edit/debugger/validate calls remain gated; unconfirmed or pre-stall recovery is refused; confirmed recovery reloads to a ready page where a new Run is accepted.
+- For `setProgram`, record that this is a new rejection window: it does not currently call `isRunSetupPending()`. Assert `RUN_PENDING` in `reserved`, `queued`, `executing`, `stalled`, and `recovering`. Assert existing pause/resume/step guards in those phases; add equivalent guards/tests for validate and mutating breakpoint/write-VRAM operations. Assert `getProgram`, `getStatus`, and `captureScreen` remain available outside the queue throughout.
+- Race late owner completion against recovery preparation: if completion reaches idle first, page-side recheck returns `RECOVERY_NOT_STALLED` and does not navigate; if recovery atomically claims `recovering` first, no subsequent Run is admitted before navigation.
+- Trigger confirmed recovery before the original bridge timeout and assert outstanding Run correlation rejects exactly once with `TAB_RELOADED`, recovery settles once, interaction-lock depth/coordinator active count return to zero, and the reloaded session accepts Run. Repeat with recovery after the original timeout to prove no orphan correlation remains.
+- Token hygiene: Run results and `getStatus()` contain diagnostic origin/phase/age but never the opaque token.
+
+### Deterministic browser integration tests
+
+- Cover two distinct synchronization points: (a) issue two requests in the same task and assert `runPending`/reservation is visible immediately, proving acquisition occurs before the first `await`; (b) expose a Promise/latch after the first synthetic key-down and trigger another request there, proving the gate remains held through injection.
+- For the pre-injection window, wait for `getStatus().runAdmission.phase` to become `executing` before any key event, issue the second request during build/load or the fixed 500 ms wait, and assert one sequence. A test-only controllable preparation dependency may pause this phase; it must not expose reservation tokens.
+- FuzzyBASIC UI double-click: first prove the affordance transition sets `aria-disabled`/`aria-busy` while retaining focus for keyboard activation. Then remove only those DOM attributes/classes and dispatch the second click so the guarded handler itself is exercised; assert exactly one `R,U,N,Enter` down/up sequence, not `RRUU...` and not two concatenated sequences. This is the negative control against a test that passes only because presentation state suppresses activation.
+- LSX UI double-click: use the same guard-bypassing second dispatch and assert exactly one `P,R,O,G,Enter` sequence and the existing marker still reaches `12 34 56 78`.
+- Direct API concurrency: call `api.run()` twice without awaiting the first. Assert one normal result, one `RUN_IN_PROGRESS` busy result, one key sequence, and no queued second execution.
+- Mixed origin: start UI Run, wait for its first key-down latch, then call `api.run()`. Assert API busy and UI completes. Repeat with API first then programmatic UI click.
+- After each case assert `capabilities.debugger.runPending === false`, the Run trigger is focusable/available when not interaction-locked, JoyKey restored, and a subsequent Run is accepted.
+- Inject preparation and key-stage rejection and assert release. Simulate queue timeout and a late stale callback; assert the caller settles exactly once with `RUN_QUEUE_TIMEOUT`, the next token remains owned, and no old `performRun()` begins.
+- Simulate an execution watchdog and assert `stalled`/reload guidance without force-release. Resolve and reject the original owner late in separate cases and assert the warning/reservation clears to idle. Reload is the recovery boundary for a genuinely non-cooperative hang, and editor-persistence coverage precedes that recovery assertion.
+- Exercise Run-trigger transitions across all reasons: readiness false across acquire/release remains native-disabled; reservation alone marks unavailable then restores; interaction lock alone preserves behavior; reservation ending while a lock remains keeps native disabling; lock ending while a reservation remains restores focusable `aria-disabled`/`aria-busy`; both reasons active accepts the lock's deliberate focus loss; and the last nested lock ending with no reservation restores Run. Keep the separate non-Run nested-lock compatibility assertion.
+- Assert `api.run({ origin: 'ui' })` is reported as `automation`, while internal UI/Share paths retain their trusted labels.
+- Add a static/private-boundary test or source assertion ensuring `performRun` cannot be invoked without a live token; do not create a public test-only method.
+
+### Connector and MCP contract tests
+
+- Page Automation unit test: both admission-failure results are preserved and skip `waitMs`, an existing non-admission `ok:false` still receives the historical wait, the optional `mcp` origin reaches the page while omitted origin defaults to `automation`, and interaction lock calls remain balanced under two concurrent invocations.
+- MCP server shape test: a fake bridge returns each admission-failure object; `x1pen_run` exposes `isError:false`, `ok:false`, non-empty `status`, `code`, `retryable`, optional `retryAfterMs`, and `activeOrigin` unchanged. Assert `retryAfterMs` is present only for `RUN_IN_PROGRESS` and consumers branch on `code`, not `reason`.
+- End-to-end bridge test: derive the page queue timeout from injected bridge settings (for example 1,000 ms bridge → 250 ms queue), hold a prior Automation operation past the inner timeout, and assert the real page→extension→bridge→MCP boundary returns `RUN_QUEUE_TIMEOUT` with `isError:false`. Repeat with a lower non-default bridge timeout to prove derivation preserves ordering.
+- Boundary scheduling test enters the queue callback and fires its timeout in both same-task orders. Callback-first transitions synchronously to `executing`, suppresses timeout settlement/release, and completes normally; timeout-first settles once and the stale callback performs no work. Neither order admits a second owner.
+- Assert the `x1pen_run` tool description tells model callers that concurrent Run returns `RUN_IN_PROGRESS`, queued expiry returns `RUN_QUEUE_TIMEOUT`, no server-side retry occurs, and `retryAfterMs` guides caller retry only for the former.
+- Deployment-skew tests prove new page/old extension+server preserves ordinary-content mapping (with at most legacy `waitMs`) and old page/new extension+server preserves queue-both behavior; recovery feature checks fail closed against old components.
+- Bridge transport test remains concurrent-safe and correlates both command IDs; no transport-level error is invented for an application busy result.
+
+### Related Stop / physical observations
+
+- Add diagnostic-only test coverage or a separate issue demonstrating that UI Stop and window/screen keyboard events can reach `_js_key_down/up` during synthetic injection. Do not make the Run patch’s acceptance depend on silently suppressing these inputs.
+- Confirm Automation/MCP Stop remains serialized after Automation Run. Document that Stop versus UI-origin Run is unresolved pending the input-arbitration follow-up.
+
+### Non-regression and performance
+
+- `./build.sh`.
+- Run the enlarged `npm run test:automation` suite completely green in at least three fresh processes (expected ≥20 test functions; report the actual count and scenario/assertion count rather than retaining an old fixed label).
+- `npm run test:bridge`, `test:extension-package`, `test:mcp`, and `test:mcp-package`.
+- Verify `RUN_IN_PROGRESS` is synchronous, the derived `RUN_QUEUE_TIMEOUT` beats its effective outer bridge timeout at default and lowered settings, and neither consumes `waitMs`.
+- Verify no source/editor mutation, disk remount, emulator restart, or key-mode change occurs for a rejected Run.
+- Audit all repository Run call sites/tests and record how each handles busy versus intentionally sequential repeated execution.
+
+### Rollback
+
+- The admission gate and additive busy result have no persisted-data migration.
+- If the gate causes regressions, revert the implementation commit(s); PR #78’s single-invocation ordering remains independently valid.
+- Prefer forward-fixing UI disable-reason composition or token cleanup over reverting to concurrent Run execution.
+- Do not provide a runtime bypass that re-enables concurrency: a kill switch would recreate data/key corruption. A stalled executing reservation keeps the gate closed and presents reload as the safety-preserving recovery, while warning that emulator RAM and unpersisted disk changes are lost.
+
+### Estimated implementation size
+
+- Approximately 10–14 files including toolbar markup/styles, Connector/service-worker routing, bridge cleanup, documentation, and tests; roughly 300–520 production lines, at least 20 test functions, and 35–55 focused scenarios/assertion groups after recovery/skew/accessibility coverage.
+- No C++/WASM change is planned for Run/Run admission. Stop/physical arbitration would be a separate, larger cross-layer change.
+
+## Implementation outcome
+
+- Status: implemented on `fix/run-reentrancy`, stacked on PR #78 so the sequential `simulateKeys()` behavior remains the base without modifying that PR.
+- A/UI: Run becomes focusable `aria-disabled`/`aria-busy` during setup, repeated click/Ctrl+Enter activation is ignored by the handler guard, Share reports through a separate aria-live region, and interaction-lock restoration cannot re-enable Run early.
+- B/admission: UI, Share, direct Automation, and MCP share one synchronous reservation. Automation reserves before entering its operation queue. A second request returns `RUN_IN_PROGRESS`; an admitted request that remains queued past its derived bound returns `RUN_QUEUE_TIMEOUT` only if it is still in `queued` phase.
+- Compatibility: successful `ok:true` meaning is unchanged. MCP preserves admission results as ordinary content, `waitMs` is skipped only for admission failures, and `automation.run-recovery` is advertised separately.
+- Review findings: status reads remain outside the operation queue; mutating program/validation/debugger operations reject during Run; stalled recovery is lock-exempt, confirmation-gated, atomically claims `recovering`, persists current editor source, and reloads through Connector/MCP; timeout derivation uses one quarter of the effective bridge budget.
+- Verification: `./build.sh`; `npm run test:automation` 9/9 in three fresh processes; `test:bridge` 8/8; `test:extension-package` 12/12; `test:mcp` 45/45; `test:mcp-package` 1/1.
+- Implementation cross-review was not run, as the GO dispatch made it optional and limited it to one round. Human approval is the convergence decision.
+- Deferred by design: command-start acknowledgement, Stop versus synthetic injection, and physical/screen-key arbitration.
+
+## Open decisions
+
+Recommended decisions awaiting GO:
+
+1. Accept the hybrid A+B policy: ignore UI duplicates and return additive structured busy results to concurrent programmatic Run calls.
+2. Keep Automation API v2 / current Connector feature IDs because success shape is unchanged and busy fields are additive.
+3. Reject global queueing and latest-wins cancellation for this implementation.
+4. Keep command-start acknowledgement separate from Run admission.
+5. Track Stop and physical/screen-key arbitration as a separate follow-up rather than expanding this patch.
+6. Treat the missing live in-app-browser reproduction as an environment limitation; the implementation task should run the deterministic latch-based browser scenarios before merge.
+7. Represent both MCP admission failures as `isError:false`; only `RUN_IN_PROGRESS` is deadline-retryable, while queue timeout requires status/operator review.
+8. Permit safe timeout release only while phase is still `queued`. During non-cooperative execution stalls, keep the gate closed and require a data-loss-warning reload rather than risk overlapping a late continuation.
+9. Add the compatibility-gated `x1pen_recover_stalled` reload action for human and headless recovery; require explicit data-loss confirmation and refuse it before `stalled`.
 
 ## Cross-review反映
 
 ### Round 1 — claude / claude-opus-5
 - Verdict: NEEDS_WORK
-- [rejected][high] R1-F1 async化に伴うawait伝播が未記載 — Reason: repository棚卸しで両wrapperがPromiseをreturnし、`performRun()`、`onRunClick()`、Automation queueまで全段がawait済みと確認した。呼び出しチェーン節に証拠を追記した。
-- [rejected][high] R1-F2 中断時に押下中キーが解放されない — Reason: 現在のhold/gap Promiseはresolve-onlyでAbortSignalやrun cancellationがなく、down後up前にrejectする経路がない。将来cancellable化する場合の必須cleanupをリスク節に明記した。
-- [adopted][medium] R1-F3 awaitをまたぐKeyboard mode再入 — 既存depth参照カウントを記録し、Automation queue外のUI経路も含めて全key sequenceを専用Promise queueで直列化する方針を実装節へ追加した。（R2-F1 / R3-F1で撤回・superseded。現行方針は実装方針8。）
-- [rejected][medium] R1-F4 所要時間倍増による下流定数 — Reason: 全callerが注入完了をawaitし、markerは完了後の状態polling、suite timeoutは60秒。追加約320msを含む全指定suite passをリスク節へ記録した。
-- [adopted][medium] R1-F5 `interval`の意味変更とcaller棚卸し — `gapMs`への改名、直接caller2箇所と全await chainを呼び出しチェーン節へ追加した。
-- [rejected][medium] R1-F6 wall-clock holdはemulator進行を保証しない — Reason: 今回の確定原因と実証はordering overlapであり、emulator停止は別問題。制約をリスク節へ明記した。
-- [rejected][medium] R1-F7 間欠障害への回帰検出力 — Reason: interval=50ms、hold=80msの旧PROG構造はcoalescingなしでも必ずdown/downとなり、追加assertionが決定的に失敗する。修正前baseline 6/9もテスト節へ追記した。
-- [rejected][low] R1-F8 reset/cancel世代チェック — Reason: 現行runにabort契約がなく旧実装にもある制約のため別課題とし、スコープ節に記録した。
-- [adopted][low] R1-F9 境界条件と文書状態 — 実装済みレビュー文書であること、単一commitに実装とテストが含まれること、Cross-review履歴を明記した。private固定callerのみのため新たな公開test hookは追加しない。
+- [adopted][high] R1-F1 stuck reservation recovery — Added queued-phase timeout/stale-token handling, phase/age diagnostics, cancellable network deadlines, and stalled/reload recovery. Automatic force-release during non-cooperative execution is rejected because a late continuation could overlap a replacement Run.
+- [adopted][high] R1-F2 concurrent caller compatibility — Added full call-site/test audit, explicit queue-both→busy behavioral migration, sequential-call preservation, and documented no-version-bump decision with a stop condition for strict consumers.
+- [adopted][medium] R1-F3 gate enforcement inside execution — `performRun(token)` and its sole guarded wrapper must validate a live owner token; missing call sites fail before side effects.
+- [adopted][medium] R1-F4 MCP busy mapping — Chose `isError:false`, added `retryAfterMs`, bounded polling/attempt guidance, and TOCTOU-aware retry handling.
+- [rejected][medium] R1-F5 toolbar-wide disable-reason refactor — Reason: only Run gains a second disable reason; sibling controls retain interaction-lock as their sole reason. Scope remains `refreshRunTriggerState()` plus a non-Run nested-lock regression test.
+- [adopted][medium] R1-F6 reservation across queue wait — Added queued/executing phases, a safe pre-execution queue timeout, stale callback validation, and status/test coverage.
+- [adopted][medium] R1-F7 missing pre-injection coverage — Added immediate/same-task acquisition checks and an executing-before-keydown synchronization point in addition to the injection latch.
+- [adopted][medium] R1-F8 over-broad waitMs skip — Skip only `RUN_IN_PROGRESS`; retain/test historical waits for other `ok:false` results.
+- [adopted][low] R1-F9 stale counts/estimate — Changed validation to actual enlarged count (expected ≥14) and raised estimate to 14–20 cases.
+- [adopted][low] R1-F10 revision/origin ambiguity — Defined revision, added normalized `activeOrigin`, and exposed non-sensitive admission phase/age.
+- [adopted][low] R1-F11 token hygiene — Tokens stay module-local and are asserted absent from API/status/log output.
+- [adopted][low] R1-F12 Share behavior — Added non-destructive aria-live busy notice without clobbering active status.
+- [rejected][low] R1-F13 runtime bypass — Reason: bypassing admission recreates the corruption. Safe recovery is status-guided reload/revert; the Cross-review section is now populated.
 
 ### Round 2 — claude / claude-opus-5
 - Verdict: NEEDS_WORK
-- [adopted][high] R2-F1 queueとKeyboard mode snapshotの境界 — Promise queue案を撤回し、唯一のrun入口で開始前に拒否するin-flight guardへ変更した。（R3-F1で撤回・superseded。現行方針は実装方針8。）
-- [adopted][medium] R2-F2 同時実行制御とholdのtest不足 — UI/Automation重複trigger、単一完全sequence、mode復元、hold/gap下限を検証するintegration assertionをテスト節へ追加した。（重複trigger部分はR3-F5で撤回・superseded。mode復元とhold/gap検証は維持。）
-- [rejected][medium] R2-F3 queue rejection汚染 — Reason: Promise queue案を撤回したためrejection chainは存在しない。各重複callerは開始前に自身の`false`を受け取る。
-- [adopted][medium] R2-F4 非有界backlog — queueを撤回し、active run中の新規triggerを`false`で拒否してpending key sequenceを0本に制限する。（R3-F1で撤回・superseded。現行方針は実装方針8。）
-- [adopted][medium] R2-F5 hidden tab timer clamp — 2N回の直列timerとPROG約9秒のworst-case、visible/稼働tabを利用条件とする判断をリスク節へ追加した。
-- [rejected][low] R2-F6 約320msのAPI latency文書化 — Reason: public APIの意味とtimeout契約は変更せず、実測増分は1秒未満で全callerがawait済み。内部定数の一般利用者向け文書化は今回scopeに対して過剰である。`ok:true`非変更はスコープ節に明記済み。
-- [adopted][low] R2-F7 rollback判断基準 — 前進修正を優先し、広範破損時のみ既知failure baselineへrevertする基準と再検証をリスク節へ追加した。
+- [adopted][medium] R2-F1 incomplete timeout contract — Added an outcome table for `RUN_IN_PROGRESS` and `RUN_QUEUE_TIMEOUT`, including retry, `waitMs`, MCP mapping, settlement, and tests. Internal stale callbacks have no third public outcome.
+- [adopted][medium] R2-F2 unrealistic retry budget — Replaced three attempts/five seconds with 500 ms→2 s capped backoff under a 30-second deadline and added realistic-contention coverage.
+- [adopted][medium] R2-F3 unreachable MCP origin — Added optional `run({ origin })`; Connector/MCP supplies `mcp` and direct callers default to `automation`.
+- [partially rejected][medium] R2-F4 runPending widening — The asserted widening is not present: current UI `onRunClick()` already increments the active counter consumed by `runPending`. Adopted the consumer audit and made the admission record the explicit source of truth while preserving the existing boolean semantics.
+- [adopted][medium] R2-F5 vacuous disabled-button test — Separated the affordance assertion from a second event that deliberately clears DOM disabled state, proving the handler-level guard blocks re-entry.
+- [adopted][medium] R2-F6 missing Run-button transitions — Added reservation-only, lock-only, overlapping-reasons, and nested-lock restoration cases plus the non-Run compatibility case.
+- [adopted][medium] R2-F7 stalled late completion/threshold — Specified late owner cleanup to idle and justified the 30-second warning against observed 6–8 second cold runs, with measurement-based adjustment during implementation.
+- [adopted][low] R2-F8 stale-token Promise ambiguity — Queue timeout settles once; the later stale callback is an internal no-op with no unsettled or double-settled caller Promise.
+- [adopted][low] R2-F9 source-of-truth ambiguity — Chose the admission record and required removal or read-only derivation of legacy counters.
+- [adopted][low] R2-F10 queued UX/timeout basis — Added queued status text and selected a named 30-second bound aligned with the bridge budget, subject to fresh timing validation.
+- [adopted][low] R2-F11 reload persistence — Added editor/source persistence verification before reload is offered as the recovery boundary.
 
 ### Round 3 — claude / claude-opus-5
 - Verdict: NEEDS_WORK
-- [rejected][high] R3-F1 同時run拒否のAPI結果が未定義 — Reason: 新しい拒否guard案そのものを撤回したため、新しい結果状態やMCP/bridge契約変更は導入しない。
-- [rejected][high] R3-F2 `automationActiveRuns`所有権 — Reason: guard案を撤回し、既存counterのmutation/意味を変更しない。
-- [rejected][medium] R3-F3 guard atomicity/decrement — Reason: guard案を撤回したため新しいcheck/increment境界は存在しない。
-- [adopted][medium] R3-F4 全キー/mode経路の棚卸し — repositoryの `_js_key_down/up`、`_js_set_key_mode`、Controls設定参照を検索し、program command、Stop、physical/screen keyboard、mode設定、test spyを専用節に列挙した。
-- [rejected][medium] R3-F5 重複trigger testの同期点 — Reason: guard案を撤回し、同時runを今回の新保証に含めない。単一sequenceの決定的なdown/up構造testにscopeを戻した。
-- [rejected][low] R3-F6 部分注入silent success — Reason: down/up例外握りつぶしは既存API動作で、今回のtimer ordering修正では変更しない。開始確認を含む結果契約と併せて別課題とする。
-- [adopted][low] R3-F7 rollback単位 — review後amendmentを既存commitへsquashし、PRを単一commitに保つ。rollbackは既知障害への復帰なので原則前進修正とする。
+- [adopted][high] R3-F1 unreachable queue-timeout MCP result — Corrected the actual bridge budget to 60 seconds, shortened the page queue timeout to 20 seconds with an explicit margin invariant, and added a real page→extension→bridge→MCP timeout-ordering test with injectable short budgets.
+- [adopted][medium] R3-F2 reserve/finally gap — Mandated zero statements between acquisition and `try`, clear-before-refresh cleanup, and synchronous fault injection at acquisition/cleanup boundaries.
+- [adopted][medium] R3-F3 existing failure message field — Source audit confirms `status` is the existing Run-result message field; kept it non-empty, made `code` the sole branch key, and removed redundant `reason`.
+- [adopted][medium] R3-F4 missing lock-release transition — Exempted Run from disabled snapshot restore, required centralized refresh on lock transitions, and added the fifth lock-release-while-reserved case.
+- [adopted][medium] R3-F5 reload data-loss scope — Enumerated emulator RAM, in-session programs, and unpersisted disk changes as losses; the stalled warning names the owning origin and states the loss.
+- [adopted][medium] R3-F6 non-Run mutations — Renamed the gate to cross-entry Run admission and defined policy for `setProgram`, debugger controls, reads/validation, Stop, and manual machine/disk controls.
+- [adopted][medium] R3-F7 retry owner/tool description — Assigned retry to callers only, labelled the algorithm test as contract guidance, and added model-facing `x1pen_run` description updates to scope.
+- [adopted][low] R3-F8 spoofable origin — Public callers may supply only `automation | mcp`; `ui | share` remain trusted internal labels and unknown values coerce to `automation`.
+- [adopted][low] R3-F9 watchdog clock — Defined the watchdog from the `executing` transition, added phase age, and documented the roughly 50-second worst-case pre-warning hold.
+- [adopted][low] R3-F10 focus loss — Chose focusable `aria-disabled`/guard semantics for user reservations and added keyboard-focus coverage.
 
 ### Round 4 — claude / claude-opus-5
 - Verdict: NEEDS_WORK
-- [rejected][high] R4-F1 並行runのinterleave窓拡大 — Reason: Automation API同士は既存queue、Connector操作中は既存interaction lockでUIを抑制し、確定したheadless failure経路に並行callerはない。queue/coalesceは別runの注入結果を誤って共有するかbacklogを作るため採用しない。対話的同時run/Stop/physical入力では窓が2倍以上になり得る制約をリスク節へ明記した。
-- [adopted][medium] R4-F2 sequence中のmode設定変更上書き — leave時に最新`XmilControls.getSettings().keyMode`を再読込し、開始時snapshotはfallbackだけに使う方針を実装節へ追加した。
-- [adopted][medium] R4-F3 mode復元assertion欠落 — `_js_set_key_mode`をspyして一時KB切替と最新ユーザーmode復元を検証する項目をテスト節へ復活した。
-- [adopted][low] R4-F4 keyUp保証 — 各キーのholdをtry/finallyで囲み、down成功時のkeyUpをfinallyで必ず試行する構造を追加した。
-- [adopted][low] R4-F5 rollback固定hash矛盾 — rollback対象をPR branchのsquash commitとし、amendでSHAが変わる前提を記録した。
-- [rejected][low] R4-F6 注入全体の上限assertion — Reason: CI負荷やtimer clampでcorrectnessを保ったまま遅くなるケースを固定2秒でflakeに変えるため採用しない。60秒suite timeoutと3回連続passで実環境条件を検証する。
+- [adopted][high] R4-F1 headless stalled recovery — Made admission state observable through existing MCP status and added a stalled-only, confirmation-required `x1pen_recover_stalled` reload action with compatibility gating, audit data, and post-timeout recovery tests. It cannot release a live executing gate.
+- [adopted][medium] R4-F2 per-phase validation contradiction — Declared executing ownership immutable until owner `finally`; retained only pre-execution validation and non-aborting diagnostic assertions thereafter.
+- [adopted][medium] R4-F3 incoherent queue-timeout retry — Made queue timeout non-retryable automatically; the 30-second backoff contract now applies only to synchronous `RUN_IN_PROGRESS`.
+- [adopted][medium] R4-F4 incomplete disable reasons — Audited current Run writes, added module readiness as a source of truth, required re-audit, CSS semantics, and readiness-overlap testing.
+- [adopted][medium] R4-F5 artifact skew — Verified current MCP `textResult()` does not escalate `ok:false`, specified both deployment directions/tests, and added a compatibility feature only for the new recovery command.
+- [adopted][medium] R4-F6 setProgram/control change — Recorded `setProgram` gating as new, extended the consumer audit, and enumerated phase-by-phase mutation/read tests.
+- [adopted][low] R4-F7 missing live region — Source audit found none; added `html/x1pen.html`, a distinct live region, styling, file estimate, and non-clobbering assertions.
+- [adopted][low] R4-F8 timeout invariant wording — Split the general 3× ratio from the production-only 10-second absolute margin so injected tests satisfy the stated rule.
+- [adopted][low] R4-F9 combined focus behavior — Explicitly accepted Connector-lock blur precedence and added a both-reasons focus assertion.
+- [adopted][low] R4-F10 origin trust boundary — Treat origin as best-effort MAIN-world diagnostics; warning content/data-loss policy never depends on it.
+- [adopted][low] R4-F11 test estimate — Raised the estimate to at least 20 test functions and 30–45 scenarios/assertion groups.
 
 ### Round 5 — claude / claude-opus-5
-- Verdict: NEEDS_WORK
-- [adopted][medium] R5-F1 `getSettings()`再読込の不変条件 — 合成KB切替はmodule `_js_set_key_mode(0)`を直接呼びControls storeを変更しないこと、有効mode値0..2だけを採用し不正値/例外時は開始snapshotへfallbackすること、JoyKey復元spyを実装時の必須条件とする。
-- [adopted][medium] R5-F2 Round 4採用変更後の再検証 — Human approval後にR4/R5採用分を実装し、build、automation 9/9×3、bridge 8/8、extension-package 11/11、mcp 44/44、mcp-package 1/1を再実行して全passを確認した。
-- [adopted][low] R5-F3 superseded履歴 — R1-F3、R2-F1/F2/F4に撤回roundと現行方針8への参照を追記した。
-- [adopted][low] R5-F4 gap許容誤差 — 50ms gapは40ms以上、100ms gapは85ms以上とテスト節に固定した。
-- [adopted][low] R5-F5 down不成立時のup — local success flagを用い、down成功時だけfinallyでupを試行する方針をリスク節へ追加した。
+- Verdict: NEEDS_WORK — automated review limit reached; human review is required before implementation.
+- [adopted][high] R5-F1 queued status observability — Source audit confirms `getStatus`/`getProgram`/`captureScreen` bypass the queue while `validate` queues. Preserved/bound the read bypass, changed validate to prompt `RUN_PENDING`, and made MCP-origin in-queue stall observability a gating test.
+- [adopted][medium] R5-F2 locked local recovery — Placed/exempted the recovery control outside inert/toolbar locking and added an MCP-lock-held activation test.
+- [adopted][medium] R5-F3 queue-entry timeout race — Required callback-first synchronous `queued → executing`, phase-checked timeout no-op, normal owner settlement, and both-order boundary tests.
+- [adopted][medium] R5-F4 recovery TOCTOU — Moved authorization page-side, added atomic `stalled → recovering`, `RECOVERY_NOT_STALLED`, and late-completion race coverage.
+- [adopted][medium] R5-F5 navigation cleanup — Defined `TAB_RELOADED`, exactly-once bridge settlement, lock/coordinator cleanup, and pre/post-bridge-timeout recovery tests.
+- [adopted][medium] R5-F6 editor persistence — Required synchronous persistence of current editor values immediately before navigation and an edit-during-stall reload test.
+- [adopted][low] R5-F7 configurable timeout — Replaced the fixed MCP value with a timeout derived at one quarter of the effective bridge setting and added a lower-setting test.
+- [adopted][low] R5-F8 origin warning contradiction — Separated unverified diagnostic attribution from origin-invariant eligibility and byte-identical data-loss text.

--- a/plans/20260809-sequential-simulate-keys.md
+++ b/plans/20260809-sequential-simulate-keys.md
@@ -1,0 +1,138 @@
+# `simulateKeys()` 逐次キー注入化 — 実装レビュー計画
+
+## 最終状態
+
+- five-round failure後のhuman approval（Secretary request `20260809T110807.629241-secretary`）に基づき、R5-F1とR5-F2を実装・再検証済み。
+- 採用済みfindingの未実装残はなし。
+- `interval`→`gapMs`、per-key finally、最新keyModeの0..2 validation付き復元、JoyKey/timing assertionを反映済み。
+- queue/guardとAutomation `run()`の`ok:true`拡張は、承認どおり今回scope外のまま。
+
+## 目的
+
+`html/x1pen.js` の合成キー注入で、複数の keydown/keyUp タイマーが main-thread 遅延時に重なり、LSX の `PROG` コマンドが欠落する問題を解消する。
+
+## 確認済みの原因
+
+- 旧 `simulateKeys(keys, interval)` は全 keydown を `i * interval` で先行予約し、各 keyUp を keydown の 80ms 後に予約していた。
+- `simulateProgCommand()` の `interval=50ms` は hold=80ms より短く、平常時からキーが構造的に重なる。
+- headless 環境でタイマーが coalesce すると複数 keydown が同時刻に集中し、`PROG` の一部が欠落して LSX プログラムが開始されない。
+- 1キーずつ down、wait、up、wait と逐次注入する非変更実験では、プログラム開始と ASM marker 書込みを確認済み。
+
+## 実装方針と現在の実装
+
+1. `SYNTHETIC_KEY_HOLD_MS = 80` を定義する。
+2. Promise ベースの `waitForSyntheticKey(ms)` を定義する。
+3. `simulateKeys(keys, gapMs)` を async function とし、各キーを次の順で直列処理する。
+   - `module._js_key_down(vk)`
+   - hold 80ms を await
+   - `module._js_key_up(vk)`
+   - 最終キー以外は inter-key gap を await
+4. 旧 `interval` 引数は意味を明確にするため `gapMs` に改名し、次の keydown までの間隔ではなく keyUp 後の gap とする。
+   - PROG: 80ms hold + 50ms gap = keydown 間隔 130ms 以上
+   - RUN: 80ms hold + 100ms gap = keydown 間隔 180ms 以上
+5. keyDown/keyUp の既存の例外握りつぶしを維持しつつ、各キーを `down; try { await hold } finally { up }` にして、将来hold待機がreject可能になってもkeyUpを必ず試行する。合成キー用 Keyboard mode は外側の `finally` で復元する。
+6. 合成sequenceの一時KB切替はmoduleの `_js_set_key_mode(0)` を直接呼び、`XmilControls` の設定storeは変更しない。最終mode復元時は開始時snapshotだけを無条件に書き戻さず、`XmilControls.getSettings().keyMode` を再読込する。0..2の有効値なら最新設定を復元し、未定義・値不正・例外時のみ開始時snapshotをfallbackにする。
+7. private helper のテスト専用公開は追加しない。
+8. Round 3 の再評価により、Promise queue と新しいin-flight拒否guardはいずれも導入しない。前者はbacklog/rejection管理、後者は新しい`run_in_progress` API結果契約を生み、単一`simulateKeys()`内の確定済みtimer overlap修正を越えるためである。
+
+この共通関数を利用する `simulateRunCommand()` と `simulateProgCommand()` の双方が同じ逐次化の恩恵を受ける。
+
+## 呼び出しチェーンの棚卸し
+
+- `simulateKeys()` の直接呼び出しは `simulateRunCommand()` と `simulateProgCommand()` の2箇所だけで、可変長キー列や第三の呼び出し元はない。
+- 両 wrapper は `simulateKeys()` の Promise を return する。
+- `performRun()` は LSX 分岐で `await simulateProgCommand()`、FuzzyBASIC 分岐で `await simulateRunCommand()` としている。
+- Automation API の `run()` は operation queue 内で `await onRunClick()` し、`onRunClick()` は `await performRun()` する。従って Automation の完了は全キーの keyUp まで伝播しており、floating Promise はない。
+- UI click / Ctrl+Enter / Share-triggered run は Automation operation queue 外から `onRunClick()` に到達し得る。新たな同時run拒否契約は今回追加せず、同時runは既存制約として残す。
+- Keyboard mode の復元は既存の `syntheticKeyDepth` 参照カウントで管理される。最初の合成sequenceだけがユーザーmodeを保存してKBへ切り替え、重複sequenceはdepthだけを増やし、depth=0になった最後のleaveだけが保存済みユーザーmodeへ復元する。従って重複時もmode snapshotの上書き・固着は起きない。
+
+## キー注入・mode参照の全体棚卸し
+
+- program command合成注入は `simulateKeys()` のみで、直接callerは固定列のRUN/PROG wrapper 2箇所だけ。
+- `html/x1pen.js` のStop操作はESCを30msの独立timerで送る。これはrun cancellation契約を持たない既存経路で、今回のprogram command逐次化には統合しない。
+- `html/pre.js` のscreen/physical keyboard handlerはユーザー入力を直接 `_js_key_down/up` へ渡す。Automation interaction lock中はUI操作を抑制する既存責務であり、program command helperには統合しない。
+- Keyboard mode writeは合成sequenceの一時KB切替・参照カウント復元、Controlsの設定適用、設定UI changeに存在する。今回の修正は既存参照カウント方式を変更しない。
+- 合成sequence中にControls設定が変わった場合はleave時に最新`getSettings().keyMode`を再読込するため、古いsnapshotで新しいユーザー選択を巻き戻さない。
+- テストの `_js_key_down/up` 参照はイベント記録用spyであり、finallyで元関数へ戻す。
+
+## テスト方針と結果（human approval実装後）
+
+- 既存 Playwright automation integration test で Emscripten Module の `_js_key_down` / `_js_key_up` を一時的にラップし、実際の `X1PenAutomation.run()` 中のイベント列を記録する。
+- FuzzyBASIC の RUN が `down R, up R, down U, up U, down N, up N, down Enter, up Enter` の厳密な交互列であることを検証する。
+- LSX の PROG が `down P, up P, down R, up R, down O, up O, down G, up G, down Enter, up Enter` の厳密な交互列であることを検証する。
+- LSX テストは marker address `0x4000..0x4003` が `12 34 56 78` になる既存確認も維持し、コマンドが実際に開始したことを検証する。
+- 旧 PROG 実装は gap 相当の50ms時点で2キー目が down し、1キー目の up は80ms時点なので、正常な timer 実行でも新 assertion の期待する down/up 交互列に必ず違反する。この assertion は timer coalescing の偶然を待たずに旧構造を決定的に検出する。coalescing 自体の再現テストではない。
+- 先行調査の修正前 baseline は automation 9件中6件 pass、ASM/PROG を使う3件が30秒 timeout だった。
+- 記録イベントに `performance.now()` timestamp を含め、各down→upが70ms以上、50ms gapは40ms以上、100ms gapは85ms以上であることを検証する。これにより順序だけでなくhold/gap=0への退行も検出する。
+- `_js_set_key_mode`もspyし、JoyKey設定からrunした場合に一時KB(0)へ切り替わり、完了後に最新のユーザーmodeへ復元されることをassertする。
+- `npm run test:automation`: 新timing/mode assertion込みで9/9を独立プロセスで3回連続pass（合計27/27）。
+- `test:bridge`: 8/8、`test:extension-package`: 11/11、`test:mcp`: 44/44、`test:mcp-package`: 1/1 pass。
+- `./build.sh`: human approval実装反映後に成功。
+
+## スコープ判断
+
+- Automation `run()` の `ok:true` は今回変更しない。
+- 理由: `ok:true` を「キー注入完了」から「コマンド開始確認」へ変えるには、FuzzyBASIC と LSX の開始条件、timeout、エラー表現を含む別の API 契約が必要であり、今回のタイマー競合修正と分離する方が安全。
+- リセット・電源断・run cancellation の世代チェックは追加しない。現行 API に進行中の `performRun()` を abort する契約がなく、旧実装にも同じ制約があるため、別途 cancellation contract を設計する課題とする。
+- 同時run / Stop / physical inputとの交差は今回新規に悪化させる状態管理を導入せず、既存の参照カウントmode復元を維持する。単一sequence内のorderingだけを今回の保証範囲とする。
+- UI click / Ctrl+Enter / Share / Stop / physical keyを意図的に同時実行した場合、program commandの注入窓が旧280–380msから新600–620msへ伸びるため、別sequenceまたはESC/physical keyが割り込み、今回と同じ交互列崩れを起こす可能性は高くなる。Automation API同士は既存operation queueでserializeされ、Connector経由では既存interaction lockがUIを抑制するため、報告されたheadless Automation経路にはこの並行入力はない。対話操作の同時run/cancel契約は別課題とする。
+
+## リスクとロールバック
+
+- PROG は旧約280msから新約600ms、RUNは旧約380msから新約620msになる。`performRun()` と全 Automation caller は注入 Promise を await するため、注入後の画面取得や marker polling は注入完了後に開始する。marker は固定 sleep ではなく `waitForFunction` で状態を polling し、suite timeout は60秒である。bridge/MCPを含む指定suiteも新時間で passしており、追加約320msに対する実測余裕がある。
+- key mode 復元は全キー処理を囲む `finally` に置き、正常完了以外でも復元を試みる。
+- 現在の `waitForSyntheticKey()` は resolve-only の Promise で、run cancellation / AbortSignal はなく、keyDown 後から keyUp 前に reject するコード経路はない。ページ unload 時は JS context 自体が破棄される。防御的なper-key finallyでは `_js_key_down` 成功をlocal flagで保持し、成功時だけkeyUpを試行する。
+- 80ms hold は wall-clock ordering の保証であり、エミュレータ進行フレーム数の保証ではない。今回の確定原因と非変更実験は key overlap を対象としており、エミュレータ停止・background throttling は別問題として扱う。
+- 非表示tabでbrowser timerが1秒 clampされる場合、Nキーの逐次hold/gapは最大約2N回のtimer待機となり、PROGは約9秒規模まで延び得る。ただし旧parallel方式は同条件でtimer coalescingによりキー欠落するため、安全なparallel化へは戻さない。Automation実行はX1Pen tabが表示・稼働している条件を想定し、hidden-tab最適化は別課題とする。
+- mode固着・キー欠落など限定的な回帰はhold/gapまたはmode復元の前進修正を第一選択とする。逐次化自体が広範な破損を起こす場合のみPR branchの単一squash commitをrevertできるが、修正前baseline 6/9へ戻るため automation 9件の再実行と既知3 timeoutの再確認を要する。review後amendでSHAは変わるため固定hashをrollback手順に使わない。データ形式や永続設定の migration はない。
+
+## Cross-review反映
+
+### Round 1 — claude / claude-opus-5
+- Verdict: NEEDS_WORK
+- [rejected][high] R1-F1 async化に伴うawait伝播が未記載 — Reason: repository棚卸しで両wrapperがPromiseをreturnし、`performRun()`、`onRunClick()`、Automation queueまで全段がawait済みと確認した。呼び出しチェーン節に証拠を追記した。
+- [rejected][high] R1-F2 中断時に押下中キーが解放されない — Reason: 現在のhold/gap Promiseはresolve-onlyでAbortSignalやrun cancellationがなく、down後up前にrejectする経路がない。将来cancellable化する場合の必須cleanupをリスク節に明記した。
+- [adopted][medium] R1-F3 awaitをまたぐKeyboard mode再入 — 既存depth参照カウントを記録し、Automation queue外のUI経路も含めて全key sequenceを専用Promise queueで直列化する方針を実装節へ追加した。（R2-F1 / R3-F1で撤回・superseded。現行方針は実装方針8。）
+- [rejected][medium] R1-F4 所要時間倍増による下流定数 — Reason: 全callerが注入完了をawaitし、markerは完了後の状態polling、suite timeoutは60秒。追加約320msを含む全指定suite passをリスク節へ記録した。
+- [adopted][medium] R1-F5 `interval`の意味変更とcaller棚卸し — `gapMs`への改名、直接caller2箇所と全await chainを呼び出しチェーン節へ追加した。
+- [rejected][medium] R1-F6 wall-clock holdはemulator進行を保証しない — Reason: 今回の確定原因と実証はordering overlapであり、emulator停止は別問題。制約をリスク節へ明記した。
+- [rejected][medium] R1-F7 間欠障害への回帰検出力 — Reason: interval=50ms、hold=80msの旧PROG構造はcoalescingなしでも必ずdown/downとなり、追加assertionが決定的に失敗する。修正前baseline 6/9もテスト節へ追記した。
+- [rejected][low] R1-F8 reset/cancel世代チェック — Reason: 現行runにabort契約がなく旧実装にもある制約のため別課題とし、スコープ節に記録した。
+- [adopted][low] R1-F9 境界条件と文書状態 — 実装済みレビュー文書であること、単一commitに実装とテストが含まれること、Cross-review履歴を明記した。private固定callerのみのため新たな公開test hookは追加しない。
+
+### Round 2 — claude / claude-opus-5
+- Verdict: NEEDS_WORK
+- [adopted][high] R2-F1 queueとKeyboard mode snapshotの境界 — Promise queue案を撤回し、唯一のrun入口で開始前に拒否するin-flight guardへ変更した。（R3-F1で撤回・superseded。現行方針は実装方針8。）
+- [adopted][medium] R2-F2 同時実行制御とholdのtest不足 — UI/Automation重複trigger、単一完全sequence、mode復元、hold/gap下限を検証するintegration assertionをテスト節へ追加した。（重複trigger部分はR3-F5で撤回・superseded。mode復元とhold/gap検証は維持。）
+- [rejected][medium] R2-F3 queue rejection汚染 — Reason: Promise queue案を撤回したためrejection chainは存在しない。各重複callerは開始前に自身の`false`を受け取る。
+- [adopted][medium] R2-F4 非有界backlog — queueを撤回し、active run中の新規triggerを`false`で拒否してpending key sequenceを0本に制限する。（R3-F1で撤回・superseded。現行方針は実装方針8。）
+- [adopted][medium] R2-F5 hidden tab timer clamp — 2N回の直列timerとPROG約9秒のworst-case、visible/稼働tabを利用条件とする判断をリスク節へ追加した。
+- [rejected][low] R2-F6 約320msのAPI latency文書化 — Reason: public APIの意味とtimeout契約は変更せず、実測増分は1秒未満で全callerがawait済み。内部定数の一般利用者向け文書化は今回scopeに対して過剰である。`ok:true`非変更はスコープ節に明記済み。
+- [adopted][low] R2-F7 rollback判断基準 — 前進修正を優先し、広範破損時のみ既知failure baselineへrevertする基準と再検証をリスク節へ追加した。
+
+### Round 3 — claude / claude-opus-5
+- Verdict: NEEDS_WORK
+- [rejected][high] R3-F1 同時run拒否のAPI結果が未定義 — Reason: 新しい拒否guard案そのものを撤回したため、新しい結果状態やMCP/bridge契約変更は導入しない。
+- [rejected][high] R3-F2 `automationActiveRuns`所有権 — Reason: guard案を撤回し、既存counterのmutation/意味を変更しない。
+- [rejected][medium] R3-F3 guard atomicity/decrement — Reason: guard案を撤回したため新しいcheck/increment境界は存在しない。
+- [adopted][medium] R3-F4 全キー/mode経路の棚卸し — repositoryの `_js_key_down/up`、`_js_set_key_mode`、Controls設定参照を検索し、program command、Stop、physical/screen keyboard、mode設定、test spyを専用節に列挙した。
+- [rejected][medium] R3-F5 重複trigger testの同期点 — Reason: guard案を撤回し、同時runを今回の新保証に含めない。単一sequenceの決定的なdown/up構造testにscopeを戻した。
+- [rejected][low] R3-F6 部分注入silent success — Reason: down/up例外握りつぶしは既存API動作で、今回のtimer ordering修正では変更しない。開始確認を含む結果契約と併せて別課題とする。
+- [adopted][low] R3-F7 rollback単位 — review後amendmentを既存commitへsquashし、PRを単一commitに保つ。rollbackは既知障害への復帰なので原則前進修正とする。
+
+### Round 4 — claude / claude-opus-5
+- Verdict: NEEDS_WORK
+- [rejected][high] R4-F1 並行runのinterleave窓拡大 — Reason: Automation API同士は既存queue、Connector操作中は既存interaction lockでUIを抑制し、確定したheadless failure経路に並行callerはない。queue/coalesceは別runの注入結果を誤って共有するかbacklogを作るため採用しない。対話的同時run/Stop/physical入力では窓が2倍以上になり得る制約をリスク節へ明記した。
+- [adopted][medium] R4-F2 sequence中のmode設定変更上書き — leave時に最新`XmilControls.getSettings().keyMode`を再読込し、開始時snapshotはfallbackだけに使う方針を実装節へ追加した。
+- [adopted][medium] R4-F3 mode復元assertion欠落 — `_js_set_key_mode`をspyして一時KB切替と最新ユーザーmode復元を検証する項目をテスト節へ復活した。
+- [adopted][low] R4-F4 keyUp保証 — 各キーのholdをtry/finallyで囲み、down成功時のkeyUpをfinallyで必ず試行する構造を追加した。
+- [adopted][low] R4-F5 rollback固定hash矛盾 — rollback対象をPR branchのsquash commitとし、amendでSHAが変わる前提を記録した。
+- [rejected][low] R4-F6 注入全体の上限assertion — Reason: CI負荷やtimer clampでcorrectnessを保ったまま遅くなるケースを固定2秒でflakeに変えるため採用しない。60秒suite timeoutと3回連続passで実環境条件を検証する。
+
+### Round 5 — claude / claude-opus-5
+- Verdict: NEEDS_WORK
+- [adopted][medium] R5-F1 `getSettings()`再読込の不変条件 — 合成KB切替はmodule `_js_set_key_mode(0)`を直接呼びControls storeを変更しないこと、有効mode値0..2だけを採用し不正値/例外時は開始snapshotへfallbackすること、JoyKey復元spyを実装時の必須条件とする。
+- [adopted][medium] R5-F2 Round 4採用変更後の再検証 — Human approval後にR4/R5採用分を実装し、build、automation 9/9×3、bridge 8/8、extension-package 11/11、mcp 44/44、mcp-package 1/1を再実行して全passを確認した。
+- [adopted][low] R5-F3 superseded履歴 — R1-F3、R2-F1/F2/F4に撤回roundと現行方針8への参照を追記した。
+- [adopted][low] R5-F4 gap許容誤差 — 50ms gapは40ms以上、100ms gapは85ms以上とテスト節に固定した。
+- [adopted][low] R5-F5 down不成立時のup — local success flagを用い、down成功時だけfinallyでupを試行する方針をリスク節へ追加した。

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -122,7 +122,7 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
     name: 'x1pen',
     version: '0.8.0',
     automationApiVersion: 2,
-    features: ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
+    features: ['automation.core', 'automation.run-recovery', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
   });
   assert.equal(ready.capabilities.debugger.available, true);
   assert.equal(ready.capabilities.debugger.version, 2);
@@ -205,6 +205,68 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   assert.equal(result.sourceMode, 'basic+asm');
   assertSequentialKeyEvents(events, [0x52, 0x55, 0x4E, 0x0D], 85);
   assert.deepEqual(modeChanges, [0, 1], 'automation run must restore the JoyKey mode');
+
+  const apiReentry = await page.evaluate(async () => {
+    const api = window.X1PenAutomation;
+    const module = window.Module;
+    const savedDown = module._js_key_down;
+    const savedUp = module._js_key_up;
+    const events = [];
+    module._js_key_down = (vk) => { events.push(['down', vk]); return savedDown.call(module, vk); };
+    module._js_key_up = (vk) => { events.push(['up', vk]); return savedUp.call(module, vk); };
+    try {
+      const firstPromise = api.run();
+      const immediate = api.getStatus().runAdmission;
+      const secondPromise = api.run();
+      const [first, second] = await Promise.all([firstPromise, secondPromise]);
+      return { first, second, immediate, events, final: api.getStatus().runAdmission };
+    } finally {
+      module._js_key_down = savedDown;
+      module._js_key_up = savedUp;
+    }
+  });
+  assert.equal(apiReentry.first.ok, true);
+  assert.equal(apiReentry.second.ok, false);
+  assert.equal(apiReentry.second.code, 'RUN_IN_PROGRESS');
+  assert.equal(apiReentry.second.retryable, true);
+  assert.equal(apiReentry.immediate.pending, true, 'Automation must reserve synchronously before queueing');
+  assert.equal(apiReentry.final.pending, false);
+  assert.deepEqual(apiReentry.events.map(([type, vk]) => [type, vk]),
+    [0x52, 0x55, 0x4E, 0x0D].flatMap((vk) => [['down', vk], ['up', vk]]));
+
+  const uiReentry = await page.evaluate(async () => {
+    const api = window.X1PenAutomation;
+    const module = window.Module;
+    const button = document.getElementById('btn-run');
+    const savedDown = module._js_key_down;
+    const savedUp = module._js_key_up;
+    const events = [];
+    module._js_key_down = (vk) => { events.push(['down', vk]); return savedDown.call(module, vk); };
+    module._js_key_up = (vk) => { events.push(['up', vk]); return savedUp.call(module, vk); };
+    try {
+      button.click();
+      const reserved = {
+        ariaDisabled: button.getAttribute('aria-disabled'),
+        ariaBusy: button.getAttribute('aria-busy'),
+        pending: api.getStatus().runAdmission.pending,
+      };
+      button.removeAttribute('aria-disabled');
+      button.removeAttribute('aria-busy');
+      button.click();
+      const deadline = Date.now() + 5000;
+      while (api.getStatus().runAdmission.pending && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return { reserved, events, final: api.getStatus().runAdmission };
+    } finally {
+      module._js_key_down = savedDown;
+      module._js_key_up = savedUp;
+    }
+  });
+  assert.deepEqual(uiReentry.reserved, { ariaDisabled: 'true', ariaBusy: 'true', pending: true });
+  assert.equal(uiReentry.final.pending, false);
+  assert.deepEqual(uiReentry.events,
+    [0x52, 0x55, 0x4E, 0x0D].flatMap((vk) => [['down', vk], ['up', vk]]));
 
   await page.waitForTimeout(500);
   const screenshot = await page.locator('#canvas').screenshot({ type: 'png' });
@@ -681,7 +743,10 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
     const before = api.debugger.getState();
     const runPromise = api.run();
     const pendingStatus = api.getStatus().capabilities.debugger.runPending;
-    const breakpointPromise = api.debugger.setBreakpoints([0x2345]);
+    const breakpointPromise = api.debugger.setBreakpoints([0x2345]).then(
+      () => null,
+      (error) => ({ message: error.message, code: error.code }),
+    );
     const controlErrors = [];
     for (const control of ['pause', 'resume', 'step']) {
       try {
@@ -692,7 +757,7 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
       }
     }
     const result = await runPromise;
-    const queuedBreakpoints = await breakpointPromise;
+    const breakpointError = await breakpointPromise;
     const after = api.debugger.getState();
     let runningStepError = null;
     try {
@@ -701,9 +766,13 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
       runningStepError = error.message;
     }
     const pausedAfterRun = await api.debugger.pause();
+    const breakpointsAfterRun = await api.debugger.setBreakpoints([0x2345]);
     await api.debugger.setBreakpoints([]);
     await api.debugger.resume();
-    return { before, result, pendingStatus, after, controlErrors, runningStepError, pausedAfterRun, queuedBreakpoints };
+    return {
+      before, result, pendingStatus, after, controlErrors, runningStepError,
+      pausedAfterRun, breakpointError, breakpointsAfterRun,
+    };
   });
   assert.equal(rerun.before.runState, 'paused');
   assert.equal(rerun.result.ok, true);
@@ -713,7 +782,8 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.ok(rerun.controlErrors.every((error) => /run setup is pending/.test(error.message)));
   assert.match(rerun.runningStepError, /requires the paused state/);
   assert.equal(rerun.pausedAfterRun.runState, 'paused');
-  assert.equal(rerun.queuedBreakpoints.breakpointCount, 1);
+  assert.equal(rerun.breakpointError.code, 'RUN_PENDING');
+  assert.equal(rerun.breakpointsAfterRun.breakpointCount, 1);
 
   const manualRun = await page.evaluate(async () => {
     const api = window.X1PenAutomation;

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -41,6 +41,14 @@ function createAutomationApi() {
       },
     }),
     getProgram: () => ({ revision: 1 }),
+    run: async (options) => {
+      calls.push({ run: options });
+      return { ok: false, code: 'RUN_IN_PROGRESS', retryable: true, retryAfterMs: 500 };
+    },
+    recoverStalled: (confirmDataLoss) => ({
+      ok: confirmDataLoss,
+      code: confirmDataLoss ? 'RECOVERY_ACCEPTED' : 'RECOVERY_CONFIRM_REQUIRED',
+    }),
     setInteractionLocked: (locked, label) => {
       locks.push({ locked, label });
       timeline.push(locked ? 'lock:on' : 'lock:off');
@@ -126,6 +134,28 @@ test('page bridge allowlists debugger operations and retries Run setup races', a
 
   await assert.rejects(invokeX1PenInPage('debuggerStep', { count: 101 }), /integer from 1 to 100/);
   await assert.rejects(invokeX1PenInPage('evaluateJavaScript', {}), /Unsupported X1Pen method/);
+});
+
+test('page bridge preserves Run admission results and routes guarded recovery', async () => {
+  const { api, calls, locks } = createAutomationApi();
+  globalThis.window = { X1PenAutomation: api };
+
+  const started = Date.now();
+  const busy = await invokeX1PenInPage('run', { waitMs: 200, queueTimeoutMs: 15000 });
+  assert.equal(busy.code, 'RUN_IN_PROGRESS');
+  assert.ok(Date.now() - started < 150, 'admission failure must skip waitMs');
+  assert.deepEqual(calls.at(-1), { run: { origin: 'mcp', queueTimeoutMs: 15000 } });
+  assert.deepEqual(locks.slice(-2), [
+    { locked: true, label: 'AI is running the program...' },
+    { locked: false, label: undefined },
+  ]);
+
+  assert.deepEqual(await invokeX1PenInPage('recoverStalled', { confirmDataLoss: false }), {
+    ok: false, code: 'RECOVERY_CONFIRM_REQUIRED',
+  });
+  assert.deepEqual(await invokeX1PenInPage('recoverStalled', { confirmDataLoss: true }), {
+    ok: true, code: 'RECOVERY_ACCEPTED',
+  });
 });
 
 test('page bridge rejects debugger calls when capability is unavailable', async () => {

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -87,7 +87,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(client.getInstructions(), /x1pen_search_reference/);
 
     const tools = await client.listTools();
-    assert.equal(tools.tools.length, 26);
+    assert.equal(tools.tools.length, 27);
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_get_state'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_read_vram'));
@@ -99,7 +99,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(info.pairingCode, /^\d{6}$/);
     assert.equal(info.components.mcp.version, '2.6.0');
     assert.deepEqual(info.components.mcp.features,
-      ['automation.core', 'screen.capture', 'debugger.cpu', 'debugger.vram']);
+      ['automation.core', 'automation.run-recovery', 'screen.capture', 'debugger.cpu', 'debugger.vram']);
     assert.equal(info.components.connector, null);
 
     const reference = await client.callTool({

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -16,6 +16,8 @@ const calls = [];
 let currentProgram;
 let debuggerState;
 let compatibilityFailure;
+let runResponse;
+let recoveryResponse;
 
 const initialDebuggerState = {
   version: 1,
@@ -56,6 +58,7 @@ function normalizeProgram(program) {
 }
 
 const fakeBridge = {
+  commandTimeoutMs: 40_000,
   connectionInfo() {
     return {
       port: 43110, pairingCode: '123456', extensionConnected: true,
@@ -93,6 +96,8 @@ const fakeBridge = {
       return clone(currentProgram);
     }
     if (method === 'validate') return { ok: true, diagnostics: [] };
+    if (method === 'run') return clone(runResponse);
+    if (method === 'recoverStalled') return clone(recoveryResponse);
     if (method === 'getStatus') {
       return {
         ready: true,
@@ -186,6 +191,8 @@ beforeEach(() => {
   currentProgram = clone(initialProgram);
   debuggerState = clone(initialDebuggerState);
   compatibilityFailure = null;
+  runResponse = { ok: true, status: 'Ready', revision: 3 };
+  recoveryResponse = { ok: false, code: 'RECOVERY_CONFIRM_REQUIRED', status: 'Data loss warning' };
 });
 
 after(async () => {
@@ -215,6 +222,7 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_get_source',
     'x1pen_get_status',
     'x1pen_list_sessions',
+    'x1pen_recover_stalled',
     'x1pen_run',
     'x1pen_search_reference',
     'x1pen_search_source',
@@ -223,6 +231,33 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_stop',
     'x1pen_validate',
   ]);
+});
+
+test('Run admission and stalled recovery remain ordinary MCP content', async () => {
+  runResponse = {
+    ok: false,
+    code: 'RUN_IN_PROGRESS',
+    status: 'Run setup is already in progress',
+    retryable: true,
+    retryAfterMs: 500,
+    activeOrigin: 'ui',
+  };
+  const run = await client.callTool({ name: 'x1pen_run', arguments: { waitMs: 500 } });
+  assert.equal(run.isError, undefined);
+  assert.deepEqual(jsonContent(run), runResponse);
+  assert.deepEqual(calls.at(-1).params, { waitMs: 500, queueTimeoutMs: 10_000 });
+
+  const preview = await client.callTool({ name: 'x1pen_recover_stalled', arguments: {} });
+  assert.equal(preview.isError, undefined);
+  assert.equal(jsonContent(preview).code, 'RECOVERY_CONFIRM_REQUIRED');
+  assert.deepEqual(calls.at(-1).params, { confirmDataLoss: false });
+
+  recoveryResponse = { ok: true, code: 'RECOVERY_ACCEPTED', reloadRequired: true };
+  const accepted = await client.callTool({
+    name: 'x1pen_recover_stalled', arguments: { confirmDataLoss: true },
+  });
+  assert.equal(accepted.isError, undefined);
+  assert.equal(jsonContent(accepted).code, 'RECOVERY_ACCEPTED');
 });
 
 test('connection and status tools report all component versions and effective capabilities', async () => {


### PR DESCRIPTION
Summary:
- add one synchronous Run admission guard shared by UI, Share, Automation, and MCP
- reject concurrent Run with additive ordinary-content contracts and preserve existing successful Run semantics
- expose admission status and add guarded stalled-Run recovery across X1Pen, Connector, and MCP
- add UI/API re-entry, extension contract, MCP contract, and packaging coverage

This PR is intentionally stacked on PR #78 because it relies on that PR's sequential synthetic-key injection. PR #78 itself is unchanged.

Verification:
- ./build.sh
- npm run test:automation: 9/9 in three fresh processes
- npm run test:bridge: 8/8
- npm run test:extension-package: 12/12
- npm run test:mcp: 45/45
- npm run test:mcp-package: 1/1

Deferred:
- command-start acknowledgement
- Stop versus synthetic input arbitration
- physical/screen-key arbitration