### PR TITLE
chore: prepare X1Pen 0.8.1 release

### DIFF
--- a/html/x1pen-version.js
+++ b/html/x1pen-version.js
@@ -3,6 +3,6 @@
 
     window.X1PenBuild = Object.freeze({
         name: 'x1pen',
-        version: '0.8.0'
+        version: '0.8.1'
     });
 })();

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -120,7 +120,7 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
   assert.deepEqual(ready.x1pen, {
     name: 'x1pen',
-    version: '0.8.0',
+    version: '0.8.1',
     automationApiVersion: 2,
     features: ['automation.core', 'automation.run-recovery', 'screen.capture', 'debugger.cpu', 'debugger.vram'],
   });

--- a/tests/x1pen_extension_package_test.mjs
+++ b/tests/x1pen_extension_package_test.mjs
@@ -110,7 +110,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
 
 test('X1Pen product version is declared once and copied into browser builds', async () => {
   const versionSource = await readFile(join(repoRoot, 'html/x1pen-version.js'), 'utf8');
-  assert.match(versionSource, /version:\s*'0\.8\.0'/);
+  assert.match(versionSource, /version:\s*'0\.8\.1'/);
   assert.match(versionSource, /name:\s*'x1pen'/);
 
   const x1penHtml = await readFile(join(repoRoot, 'html/x1pen.html'), 'utf8');


### PR DESCRIPTION
## Summary
- bump X1Pen Web from 0.8.0 to 0.8.1 for the merged key-loss and run-admission fixes from PRs #78 and #79
- align exact-version release assertions
- keep MCP 2.6.0 and Connector 1.2.0 unchanged

## Verification
- ./build.sh
- npm run test:automation (9/9)
- npm run test:bridge (8/8)
- npm run test:extension-package (12/12)
- npm run test:mcp (45/45)
- npm run test:mcp-package (1/1, child bridge isolated on an ephemeral test port because existing MCP sessions occupy 43110-43119)
- local dist HTTP smoke: x1pen.html and x1pen-version.js returned 200; version 0.8.1
- actual RUN injection and canvas output verified by the automation browser suite
- actual PROG injection and executed memory marker verified by the automation browser suite

No deployment or tag is included in this PR.