### PR TITLE
docs: PSG クロックとジョイスティック入力 contract を固定する

### DIFF
--- a/mcp/reference/fuzzybasic.json
+++ b/mcp/reference/fuzzybasic.json
@@ -643,7 +643,7 @@
         "source": "10 J=JOY(0)\n20 PRINT J\n30 GOTO 10"
       }
     ],
-    "relatedIds": ["fuzzybasic.io.console", "fuzzybasic.x1.sound"],
+    "relatedIds": ["fuzzybasic.io.console", "fuzzybasic.x1.sound", "x1.io.psg-joystick"],
     "sourceUrls": ["https://github.com/ho-ogino/FuzzyBASIC/blob/69aaa029bfc80fbb57406994176c63d7f213f04f/src/FUZZY.ASM"]
   },
   {

--- a/mcp/reference/manifest.json
+++ b/mcp/reference/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "referenceVersion": "2026-08-08",
+  "referenceVersion": "2026-08-10",
   "defaultProfiles": {
     "fuzzybasic": "x1pen-fuzzybasic-1.2L",
     "slang": "x1pen-slang-c9e8f53-lsx",

--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -268,7 +268,7 @@
         "source": "MAIN() BEGIN\n  VAR RESULT;\n  RESULT=FOPEN(0, \"A:DATA.BIN\", 0);\n  IF RESULT==0 THEN FCLOSE(0);\n  PRINT(RESULT, /);\nEND;"
       }
     ],
-    "relatedIds": ["slang.machine.system-access", "slang.x1.assets-compression", "slang.x1.display-graphics", "slang.runtime.catalog"],
+    "relatedIds": ["slang.machine.system-access", "slang.x1.assets-compression", "slang.x1.display-graphics", "slang.runtime.catalog", "x1.io.psg-joystick"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_input.asm",
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_file.asm"

--- a/mcp/reference/x1-hardware.json
+++ b/mcp/reference/x1-hardware.json
@@ -313,29 +313,47 @@
     "title": "AY-3-8910 PSG and joystick ports",
     "profiles": ["x1-hardware-xmillennium-web"],
     "symbols": ["1B00H-1BFFH", "1C00H-1CFFH", "PSG", "AY-3-8910", "register 14", "register 15", "x1_psg_dat", "x1_psg_reg", "x1_psg_sta"],
-    "aliases": ["PSG register", "sound chip", "joystick port", "game controller", "AY", "音源", "PSGポート", "ジョイスティック", "ゲームパッド", "レジスタ14", "レジスタ15"],
+    "aliases": ["PSG register", "PSG clock", "tone period", "2 MHz", "sound chip", "joystick port", "joystick bit mapping", "active-low input", "game controller", "AY", "音源", "PSGクロック", "音程計算", "PSGポート", "ジョイスティック", "ジョイスティック ビット割り当て", "ゲームパッド", "押下検出", "レジスタ14", "レジスタ15"],
     "summary": "Select an AY-3-8910 register through the 1CxxH group, then read or write it through the 1BxxH group; input registers 14 and 15 carry joystick-style data.",
     "syntax": [
       "OUT 1CxxH,register   select PSG register 0-15",
       "OUT 1BxxH,value      write selected sound register 0-13",
       "IN  1BxxH           read selected register or joystick input",
-      "registers 0-5 tone, 6 noise, 7 mixer/I/O, 8-10 volume, 11-13 envelope, 14-15 I/O"
+      "registers 0-5 tone, 6 noise, 7 mixer/I/O, 8-10 volume, 11-13 envelope, 14-15 I/O",
+      "PSG clock = 2,000,000 Hz; tone period = clock / (16 * frequency)",
+      "register | controller: 14 | joystick 1; 15 | joystick 2",
+      "bit | mask | active-low input",
+      "0 | 01H | Up",
+      "1 | 02H | Down",
+      "2 | 04H | Left",
+      "3 | 08H | Right",
+      "4 | 10H | Button 4",
+      "5 | 20H | Button 2 (B)",
+      "6 | 40H | Button 1 (A)",
+      "7 | 80H | Button 3"
     ],
     "notes": [
       "Use BC with OUT (C),A and IN A,(C); the X1 decodes the 16-bit port high byte, not only an 8-bit immediate port.",
+      "The AY-3-8910 receives a 2 MHz clock. Round clock / (16 * frequency) to the nearest supported 12-bit tone period; A4 at 440 Hz uses period 284 (011CH; register pair 01H:1CH) and produces about 440.14 Hz.",
       "The Web emulator exposes external joystick flags on register 14 and applies JoyKey keyboard mapping to register 14 or 15 according to Key Mode.",
-      "Joystick bits are active-low. Preserve or interpret all bits according to the controller contract instead of assuming active-high directions.",
+      "Joystick bits are active-low: 0 means pressed, and 255 (FFH) means that no direction or button is pressed.",
+      "For successive raw samples, (NEW XOR OLD) AND OLD yields the newly pressed bits. For example, OLD=FFH and NEW=FEH produces 01H for a new Up press.",
       "Writes to registers 14 and 15 are not modeled as general-purpose output by this implementation.",
       "For FuzzyBASIC or SLANG music playback, prefer their documented PSG drivers unless direct tone-register control is required."
     ],
     "examples": [{
       "title": "Read joystick input from PSG register 14",
       "source": "ORG 0100H\nLD BC,01C00H\nLD A,0EH\nOUT (C),A\nLD BC,01B00H\nIN A,(C)\nRET"
+    }, {
+      "title": "Detect newly pressed active-low joystick bits",
+      "source": "ORG 0100H\n; B=OLD, A=NEW\nXOR B\nAND B\nRET"
     }],
-    "relatedIds": ["x1.io.dispatch-map", "x1.io.ppi-subcpu", "x1.io.opm", "slang.x1.psg", "fuzzybasic.x1.input"],
+    "relatedIds": ["x1.io.dispatch-map", "x1.io.ppi-subcpu", "x1.io.opm", "slang.x1.psg", "slang.runtime.lsx-io-files", "fuzzybasic.x1.input"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/src/X1_SOUND.CPP",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/OPMSOUND/Opmcore.cpp",
       "https://github.com/ho-ogino/xmil-web/blob/main/src/OPMSOUND/ay8910.cpp",
+      "https://github.com/ho-ogino/xmil-web/blob/main/platform/platform_joystick.cpp",
       "http://x1center.org/sdx1/sdx1_0.html"
     ]
   },

--- a/mcp/reference/x1-hardware.json
+++ b/mcp/reference/x1-hardware.json
@@ -334,8 +334,9 @@
     ],
     "notes": [
       "Use BC with OUT (C),A and IN A,(C); the X1 decodes the 16-bit port high byte, not only an 8-bit immediate port.",
-      "The AY-3-8910 receives a 2 MHz clock. Round clock / (16 * frequency) to the nearest supported 12-bit tone period; A4 at 440 Hz uses period 284 (011CH; register pair 01H:1CH) and produces about 440.14 Hz.",
-      "The Web emulator exposes external joystick flags on register 14 and applies JoyKey keyboard mapping to register 14 or 15 according to Key Mode.",
+      "The AY-3-8910 receives a 2 MHz clock. Round clock / (16 * frequency) to the nearest supported 12-bit tone period. For channel A, A4 at 440 Hz uses period 284 (011CH): register 0 (fine) = 1CH and register 1 (coarse) = 01H, producing about 440.14 Hz. The coarse register uses only its low four bits, so tone periods are limited to 12 bits.",
+      "The bit table applies identically to raw bytes read from register 14 or 15. The Web emulator combines physical gamepad state into register 14 and applies JoyKey keyboard mapping to register 14 or 15 according to Key Mode.",
+      "Buttons 3 and 4 are additional mappings exposed by the Web emulator platform layer; do not assume that a physical two-button X1 pad drives those lines.",
       "Joystick bits are active-low: 0 means pressed, and 255 (FFH) means that no direction or button is pressed.",
       "For successive raw samples, (NEW XOR OLD) AND OLD yields the newly pressed bits. For example, OLD=FFH and NEW=FEH produces 01H for a new Up press.",
       "Writes to registers 14 and 15 are not modeled as general-purpose output by this implementation.",

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -165,6 +165,8 @@ test('representative Japanese and English queries reach dedicated X1 hardware en
     ['PSG ジョイスティック', 'x1.io.psg-joystick'],
     ['PSG clock tone period', 'x1.io.psg-joystick'],
     ['ジョイスティック ビット割り当て', 'x1.io.psg-joystick'],
+    ['active-low input', 'x1.io.psg-joystick'],
+    ['押下検出', 'x1.io.psg-joystick'],
     ['FM音源 OPM', 'x1.io.opm'],
     ['CTC タイマー', 'x1.io.ctc'],
     ['タイマー割り込み', 'x1.io.ctc'],
@@ -342,27 +344,38 @@ test('PSG and joystick reference matches the emulator input contract', () => {
   const soundSource = readFileSync(join(repoRoot, 'src/OPMSOUND/Opmcore.cpp'), 'utf8');
   const joystickSource = readFileSync(join(repoRoot, 'platform/platform_joystick.cpp'), 'utf8');
   const entries = new Map(validateReferenceData().entries.map((entry) => [entry.id, entry]));
-  const details = JSON.stringify(getReferenceEntries({
+  const [contract] = getReferenceEntries({
     ids: ['x1.io.psg-joystick'],
     maxCharacters: 16 * 1024,
-  }).entries);
+  }).entries;
+  const details = JSON.stringify(contract);
 
   assert.match(soundSource, /AY8910_init\(2000000,/);
-  for (const [name, value] of [
-    ['JOY_UP_BIT', '0x01'],
-    ['JOY_DOWN_BIT', '0x02'],
-    ['JOY_LEFT_BIT', '0x04'],
-    ['JOY_RIGHT_BIT', '0x08'],
-    ['JOY_BTN4_BIT', '0x10'],
-    ['JOY_BTN2_BIT', '0x20'],
-    ['JOY_BTN1_BIT', '0x40'],
-    ['JOY_BTN3_BIT', '0x80'],
-  ]) {
-    assert.match(joystickSource, new RegExp(`#define\\s+${name}\\s+${value}`));
-  }
+  const inputLabels = {
+    UP: 'Up', DOWN: 'Down', LEFT: 'Left', RIGHT: 'Right',
+    BTN4: 'Button 4', BTN2: 'Button 2 (B)', BTN1: 'Button 1 (A)', BTN3: 'Button 3',
+  };
+  const sourceInputs = new Map(
+    [...joystickSource.matchAll(/^#define JOY_(UP|DOWN|LEFT|RIGHT|BTN[1-4])_BIT\s+(0x[0-9A-F]+)/gmi)]
+      .map(([, name, mask]) => {
+        const numericMask = Number.parseInt(mask, 16);
+        return [Math.log2(numericMask), { mask: numericMask, input: inputLabels[name] }];
+      }),
+  );
+  const documentedInputs = new Map(
+    contract.syntax.flatMap((row) => {
+      const match = row.match(/^(\d) \| ([0-9A-F]+)H \| (.+)$/);
+      return match
+        ? [[Number(match[1]), { mask: Number.parseInt(match[2], 16), input: match[3] }]]
+        : [];
+    }),
+  );
+  assert.deepEqual(documentedInputs, sourceInputs);
   for (const fact of [
     '2,000,000 Hz', 'clock / (16 * frequency)', 'period 284',
-    '14 | joystick 1', '15 | joystick 2', '0 | 01H | Up', '7 | 80H | Button 3',
+    'register 0 (fine) = 1CH', 'register 1 (coarse) = 01H', 'limited to 12 bits',
+    '14 | joystick 1', '15 | joystick 2', 'applies identically',
+    'physical gamepad state into register 14', 'Buttons 3 and 4 are additional mappings',
     '0 means pressed', '255 (FFH) means that no direction or button is pressed',
     '(NEW XOR OLD) AND OLD',
   ]) {

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -163,6 +163,8 @@ test('representative Japanese and English queries reach dedicated X1 hardware en
     ['キーボード サブCPU', 'x1.io.ppi-subcpu'],
     ['キー入力', 'x1.io.ppi-subcpu'],
     ['PSG ジョイスティック', 'x1.io.psg-joystick'],
+    ['PSG clock tone period', 'x1.io.psg-joystick'],
+    ['ジョイスティック ビット割り当て', 'x1.io.psg-joystick'],
     ['FM音源 OPM', 'x1.io.opm'],
     ['CTC タイマー', 'x1.io.ctc'],
     ['タイマー割り込み', 'x1.io.ctc'],
@@ -334,6 +336,40 @@ test('X1 hardware reference matches emulator memory and VRAM constants', () => {
   ]) {
     assert.ok(details.includes(fact), `${fact} must remain documented`);
   }
+});
+
+test('PSG and joystick reference matches the emulator input contract', () => {
+  const soundSource = readFileSync(join(repoRoot, 'src/OPMSOUND/Opmcore.cpp'), 'utf8');
+  const joystickSource = readFileSync(join(repoRoot, 'platform/platform_joystick.cpp'), 'utf8');
+  const entries = new Map(validateReferenceData().entries.map((entry) => [entry.id, entry]));
+  const details = JSON.stringify(getReferenceEntries({
+    ids: ['x1.io.psg-joystick'],
+    maxCharacters: 16 * 1024,
+  }).entries);
+
+  assert.match(soundSource, /AY8910_init\(2000000,/);
+  for (const [name, value] of [
+    ['JOY_UP_BIT', '0x01'],
+    ['JOY_DOWN_BIT', '0x02'],
+    ['JOY_LEFT_BIT', '0x04'],
+    ['JOY_RIGHT_BIT', '0x08'],
+    ['JOY_BTN4_BIT', '0x10'],
+    ['JOY_BTN2_BIT', '0x20'],
+    ['JOY_BTN1_BIT', '0x40'],
+    ['JOY_BTN3_BIT', '0x80'],
+  ]) {
+    assert.match(joystickSource, new RegExp(`#define\\s+${name}\\s+${value}`));
+  }
+  for (const fact of [
+    '2,000,000 Hz', 'clock / (16 * frequency)', 'period 284',
+    '14 | joystick 1', '15 | joystick 2', '0 | 01H | Up', '7 | 80H | Button 3',
+    '0 means pressed', '255 (FFH) means that no direction or button is pressed',
+    '(NEW XOR OLD) AND OLD',
+  ]) {
+    assert.ok(details.includes(fact), `${fact} must remain documented`);
+  }
+  assert.ok(entries.get('fuzzybasic.x1.input').relatedIds.includes('x1.io.psg-joystick'));
+  assert.ok(entries.get('slang.runtime.lsx-io-files').relatedIds.includes('x1.io.psg-joystick'));
 });
 
 test('every X1 hardware example assembles with the bundled Z80 assembler', () => {


### PR DESCRIPTION
## Summary
- document the X1 AY-3-8910 2 MHz clock, tone-period formula, and an A4 calculation example
- document REG14/REG15 and the active-low joystick bit table, including new-press edge detection
- link the hardware contract from FuzzyBASIC and SLANG input references
- add Japanese/English search coverage and tests tied to emulator constants

## Verification
- `npm run test:mcp` — 46/46 passed
- `npm run test:mcp-package` — 1/1 passed (test child bridge isolated on an ephemeral port because existing MCP sessions occupy the default range)
- `git diff --check`

Closes #82