### PR TITLE
Fix M8ALOAD browser assembly

### DIFF
--- a/assets/slang_runtime/libm8a.asm
+++ b/assets/slang_runtime/libm8a.asm
@@ -2,9 +2,10 @@
 ; SLANG Runtime Library (new format)
 
 ; @name M8ALOAD
+; @calls X1WORK
 ; @lib M8ALIB
 
-WIDTH		EQU	40
+M8A_WIDTH	EQU	40
 
 DRAWSPEED	EQU	0	;0=�ȃT�C�Y�ᑬ/1=����/1�ȏ�=���[�v�W�J����
 CALCSPEED	EQU	0	;0=�v�Z�擾�ᑬ/0�ȊO=TABLE�擾����
@@ -17,7 +18,7 @@ DRAWM8A:
 	LD E,C
 
 #IF CALCSPEED == 0
-	; ���݂�WIDTH�l������(CALCSPEED��0�̎��̂ݓ��I��WIDTH�؂�ւ����\�ƂȂ�)
+	; ���݂�M8A_WIDTH�l������(CALCSPEED��0�̎��̂ݓ��I��M8A_WIDTH�؂�ւ����\�ƂȂ�)
 	LD A,(NAME_SPACE_DEFAULT.AT_WIDTH)
 	LD (REWRITE0Y+1),A
 #ENDIF
@@ -44,7 +45,7 @@ DRAWM8A:
 ;	   nn!=0: repeat length (1�`3)
 ;
 ; HL .... DATA POINTER
-; B ..... WIDTH COUNTER
+; B ..... M8A_WIDTH COUNTER
 ; C ..... HEIGHT COUNTER
 ;
 ; BC' ... VRAM address
@@ -98,7 +99,7 @@ REWRITE0X:
 
 	; ���[���W�v�Z
 #IF CALCSPEED == 0
-		LD	C, A		; ���[���W�̌v�Z...(Y AND 7)*2^11 + (Y \ 8)*WIDTH
+		LD	C, A		; ���[���W�̌v�Z...(Y AND 7)*2^11 + (Y \ 8)*M8A_WIDTH
 		AND	7		; Y AND 7
 		ADD	A, A
 		ADD	A, A
@@ -110,7 +111,7 @@ REWRITE0X:
 		RRCA
 		AND	00011111B	; (Y \ 8)
 REWRITE0Y:
-		LD	B, WIDTH
+		LD	B, M8A_WIDTH
 AXBHL:					; A�~B = HL
 		LD	HL, 0		; ���ʂ��N���A
 		LD	D, H		; D=0
@@ -335,9 +336,10 @@ ERREND:
 
 
 ;------------------------------------------------------------------------------
-#IF CALCSPEED != 0 && WIDTH == 40
+#IF CALCSPEED != 0
+#IF M8A_WIDTH == 40
 	ALIGN	256
-	; WIDTH40
+	; M8A_WIDTH 40
 GVRAMADRS_LO:
 	DB	$00,$00,$00,$00,$00,$00,$00,$00		;1	8x 0=  0
 	DB	$28,$28,$28,$28,$28,$28,$28,$28		;2	8x 1=  8
@@ -394,8 +396,8 @@ GVRAMADRS_HI:
 	DB	$43,$4b,$53,$5b,$63,$6b,$73,$7b		;24	8x23=184
 	DB	$43,$4b,$53,$5b,$63,$6b,$73,$7b		;25	8x24=192
 	DB	$43,$4b,$53,$5b,$63,$6b,$73,$7b		;26	8x25=200
-#ELIF CALCSPEED != 0 && WIDTH == 80
-	; WIDTH80
+#ELIF M8A_WIDTH == 80
+	; M8A_WIDTH 80
 GVRAMADRS_LO:
 	DB	$00,$00,$00,$00,$00,$00,$00,$00		;1	  0-  7
 	DB	$50,$50,$50,$50,$50,$50,$50,$50		;2	  8- 15
@@ -453,9 +455,9 @@ GVRAMADRS_HI:
 	DB	$07,$0f,$17,$1f,$27,$2f,$37,$3f		;25	192-200
 	DB	$07,$0f,$17,$1f,$27,$2f,$37,$3f		;26
 #ENDIF
+#ENDIF
 
 MAGICM8A:
      DB "M8A"
-
 
 

--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -540,12 +540,20 @@
       "LZEEE_DECODE(sourceAddress,destinationAddress)",
       "ZX0_DECODE(sourceAddress,destinationAddress)",
       "MAGLOAD(filenameAddress,x,y)",
-      "M8ALOAD(...)"
+      "M8ALOAD(dataAddress,x,y)"
     ],
     "notes": [
       "The decompressors operate on encoded byte streams and write directly to the destination address; allocate enough writable memory for the decoded result.",
-      "MAGLOAD uses LSX file operations and receives a filename, X and Y. It is intended for 200-line X1 images and reserves substantial work buffers.",
-      "M8ALOAD is a low-level format-specific loader; validate memory use and display mode with a small test before combining it with other large libraries."
+      "MAGLOAD uses LSX file operations and receives a filename address, X and Y. Choose it for an M8A-independent MAG file on mounted disk media; it is intended for 200-line X1 images and reserves substantial work buffers.",
+      "M8ALOAD receives the address of an M8A byte stream already in memory plus its X and Y graphics-VRAM origin. Keep the complete encoded data valid until the call returns; it performs no disk I/O.",
+      "M8ALOAD writes the current X1 graphics VRAM but does not select or enable a visible graphics mode. For visible output, choose WIDTH(40) or WIDTH(80), initialize graphics for that layout, and enable graphics display before the call.",
+      "The compact example contains one 8-pixel group and one row. Its four $49 encoded pairs draw eight blue pixels at the graphics-VRAM origin."
+    ],
+    "examples": [
+      {
+        "title": "Draw an embedded M8A strip from memory",
+        "source": "ARRAY BYTE M8A_DATA[] = {\n  $4D,$38,$41,$00,$01,$01,$49,$49,$49,$49\n};\n\nMAIN() BEGIN\n  M8ALOAD(M8A_DATA,0,0);\n  LOOP VSYNC1();\nEND;"
+      }
     ],
     "relatedIds": ["slang.runtime.lsx-io-files", "slang.machine.system-access", "slang.x1.display-graphics", "slang.runtime.catalog"],
     "sourceUrls": [

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1269,3 +1269,85 @@ test('debugger adapter pauses, steps, resumes, and reads mapped memory', { timeo
   assert.ok(manualRun.controlErrors.every((error) => /run setup is pending/.test(error.message)));
   assert.equal(manualRun.paused.runState, 'paused');
 });
+
+test('embedded M8A data assembles and draws into graphics VRAM', { timeout: 60_000 }, async () => {
+  const result = await page.evaluate(async () => {
+    const api = window.X1PenAutomation;
+    const planes = ['blue', 'red', 'green'];
+    const readPlanes = () => Object.fromEntries(planes.map((plane) => [
+      plane,
+      api.debugger.readVram({
+        region: 'graphics', bank: 0, plane, offset: 0, length: 1,
+      }).bytes[0],
+    ]));
+    const original = readPlanes();
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    let observed = null;
+    let validation = null;
+    let run = null;
+
+    await api.debugger.pause();
+    await api.debugger.writeVram({
+      region: 'graphics', bank: 0, plane: 'blue', offset: 0, bytes: [0x00],
+    });
+    await api.debugger.writeVram({
+      region: 'graphics', bank: 0, plane: 'red', offset: 0, bytes: [0xA5],
+    });
+    await api.debugger.writeVram({
+      region: 'graphics', bank: 0, plane: 'green', offset: 0, bytes: [0x5A],
+    });
+    await api.debugger.resume();
+
+    try {
+      const current = api.getProgram();
+      await api.setProgram({
+        sourceMode: 'slang',
+        basic: '',
+        asm: '',
+        slang: [
+          'ARRAY BYTE M8A_DATA[] = {',
+          '  $4D,$38,$41,$00,$01,$01,$49,$49,$49,$49',
+          '};',
+          '',
+          'MAIN() BEGIN',
+          '  M8ALOAD(M8A_DATA,0,0);',
+          '  LOOP VSYNC1();',
+          'END;',
+        ].join('\n'),
+      }, current.revision);
+      validation = await api.validate();
+      if (!validation.ok) {
+        throw new Error(`Embedded M8A validation failed: ${JSON.stringify(validation.diagnostics)}`);
+      }
+      run = await api.run();
+      if (!run.ok) throw new Error(`Embedded M8A Run failed: ${JSON.stringify(run)}`);
+
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        observed = readPlanes();
+        if (observed.blue === 0xFF && observed.red === 0x00 && observed.green === 0x00) break;
+        await sleep(25);
+      }
+      if (!observed || observed.blue !== 0xFF || observed.red !== 0x00 || observed.green !== 0x00) {
+        throw new Error(`M8ALOAD did not produce the expected VRAM planes: ${JSON.stringify(observed)}`);
+      }
+      return { validation, run, observed };
+    } finally {
+      window.Module._js_xmil_reset();
+      await sleep(50);
+      await api.debugger.pause();
+      for (const plane of planes) {
+        await api.debugger.writeVram({
+          region: 'graphics', bank: 0, plane, offset: 0, bytes: [original[plane]],
+        });
+      }
+      await api.debugger.setBreakpoints([]);
+      await api.debugger.resume();
+    }
+  });
+
+  assert.equal(result.validation.ok, true);
+  assert.equal(result.run.ok, true);
+  assert.equal(result.run.sourceMode, 'slang');
+  assert.deepEqual(result.observed, { blue: 0xFF, red: 0x00, green: 0x00 });
+});

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
@@ -573,6 +573,112 @@ test('bundled SLANG examples compile with the exact X1Pen compiler and VFS', () 
     });
     assert.equal(result.errors.length, 0, `${example.title}: ${JSON.stringify(result.errors)}`);
     assert.ok(result.asm.length > 0, `${example.title} must generate ASM`);
+  }
+});
+
+test('documented embedded M8A example compiles and assembles with its standalone dependencies', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const vfs = loadSlangVfs();
+  const entry = validateReferenceData().entries
+    .find((candidate) => candidate.id === 'slang.x1.assets-compression');
+  const example = entry.examples.find((candidate) => candidate.title.includes('embedded M8A'));
+  assert.ok(example, 'the M8ALOAD reference must retain its executable embedded-data example');
+
+  const compiled = compiler.compile(example.source, vfs, {
+    defaultOrg: 0x100,
+    codeReadonly: false,
+    defines: { ENV_TYPE: 1 },
+  });
+  assert.equal(compiled.errors.length, 0, JSON.stringify(compiled.errors));
+  assert.match(compiled.asm, /CALL\s+M8ALIB\.M8ALOAD/);
+  assert.match(compiled.asm, /NAME_SPACE_DEFAULT\.AT_WIDTH/);
+
+  const assembled = assembler.assemble(compiled.asm, { ENV_TYPE: 1 });
+  assert.equal(assembled.errors.length, 0, JSON.stringify(assembled.errors));
+  assert.ok(assembled.bytes.length > 0);
+  assert.equal(assembled.symbols['M8ALIB.GVRAMADRS_LO'], undefined,
+    'the shipped CALCSPEED=0 build must omit dormant address tables');
+  assert.equal(assembled.symbols['M8ALIB.GVRAMADRS_HI'], undefined,
+    'the shipped CALCSPEED=0 build must omit dormant address tables');
+  assert.ok('NAME_SPACE_DEFAULT.AT_WIDTH' in assembled.symbols,
+    'M8ALOAD must pull X1WORK without requiring the caller to use WIDTH first');
+});
+
+test('M8A runtime conditionals use supported syntax and preserve both dormant width tables', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const vfs = loadSlangVfs();
+  const runtimeDir = join(repoRoot, 'assets/slang_runtime');
+  const unsupported = [];
+  for (const filename of readdirSync(runtimeDir).filter((name) => name.endsWith('.asm'))) {
+    const source = readFileSync(join(runtimeDir, filename), 'utf8');
+    source.split(/\r?\n/).forEach((line, index) => {
+      if (/^\s*#(?:IF|ELIF|ELSEIF)\b.*(?:&&|\|\|)/i.test(line)) {
+        unsupported.push(`${filename}:${index + 1}`);
+      }
+    });
+  }
+  assert.deepEqual(unsupported, [], 'assembler runtime directives must avoid unsupported logical tokens');
+
+  const m8aSource = vfs['libm8a.asm'];
+  const magSource = vfs['libmag.asm'];
+  assert.match(m8aSource, /^; @calls X1WORK$/m);
+  assert.match(m8aSource, /^M8A_WIDTH\s+EQU\s+40$/m);
+  assert.doesNotMatch(m8aSource, /^WIDTH\s+EQU\b/m);
+  assert.doesNotMatch(magSource, /^\s*#(?:IF|ELIF|ELSEIF)\b.*(?:&&|\|\|)/mi);
+
+  const minimalSource = [
+    'ARRAY BYTE DATA[] = {$4D,$38,$41,$00,$01,$01,$49,$49,$49,$49};',
+    'MAIN() BEGIN',
+    '  M8ALOAD(DATA,0,0);',
+    'END;',
+  ].join('\n');
+  for (const width of [40, 80]) {
+    const variantVfs = {
+      ...vfs,
+      'libm8a.asm': m8aSource
+        .replace(/^CALCSPEED\s+EQU\s+0\b/m, 'CALCSPEED\tEQU\t1')
+        .replace(/^M8A_WIDTH\s+EQU\s+40\b/m, `M8A_WIDTH\tEQU\t${width}`),
+    };
+    const compiled = compiler.compile(minimalSource, variantVfs, {
+      defaultOrg: 0x100,
+      codeReadonly: false,
+      defines: { ENV_TYPE: 1 },
+    });
+    assert.equal(compiled.errors.length, 0,
+      `M8A_WIDTH=${width} must compile: ${JSON.stringify(compiled.errors)}`);
+    const assembled = assembler.assemble(compiled.asm, { ENV_TYPE: 1 });
+    assert.equal(assembled.errors.length, 0,
+      `M8A_WIDTH=${width} must assemble: ${JSON.stringify(assembled.errors)}`);
+    const tableAddress = assembled.symbols['M8ALIB.GVRAMADRS_LO'];
+    assert.ok(Number.isInteger(tableAddress), `M8A_WIDTH=${width} must emit its low table`);
+    assert.equal(assembled.bytes[tableAddress - assembled.org + 8], width === 40 ? 0x28 : 0x50,
+      `M8A_WIDTH=${width} must select the matching table payload`);
+  }
+});
+
+test('M8A runtime changes do not affect unused programs or MAGLOAD assembly', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const vfs = loadSlangVfs();
+  for (const [name, source, expectedRuntime] of [
+    ['unused', 'MAIN() BEGIN END;', null],
+    ['MAGLOAD', 'MAIN() BEGIN MAGLOAD("A:X.MAG",0,0); END;', 'MAGLOAD'],
+  ]) {
+    const compiled = compiler.compile(source, vfs, {
+      defaultOrg: 0x100,
+      codeReadonly: false,
+      defines: { ENV_TYPE: 1 },
+    });
+    assert.equal(compiled.errors.length, 0,
+      `${name} control must compile: ${JSON.stringify(compiled.errors)}`);
+    assert.equal(compiled.asm.includes('[M8ALIB]'), false, `${name} must not pull M8ALOAD`);
+    if (expectedRuntime) assert.ok(compiled.asm.includes(expectedRuntime));
+    const assembled = assembler.assemble(compiled.asm, { ENV_TYPE: 1 });
+    assert.equal(assembled.errors.length, 0,
+      `${name} control must assemble: ${JSON.stringify(assembled.errors)}`);
+    assert.ok(assembled.bytes.length > 0);
   }
 });
 


### PR DESCRIPTION
## Summary

- make the M8A runtime conditionals compatible with the browser assembler by replacing unsupported logical tokens with nested directives
- isolate the private M8A width constant and declare the X1WORK dependency required by AT_WIDTH
- document the exact in-memory M8ALOAD contract and add a compact executable fixture
- cover shipped, dormant 40/80-width, unused-runtime, MAGLOAD, packaged-reference, and graphics-VRAM end-to-end paths

## Review

- mandatory opposite-provider plan review: Claude Opus 5, normal policy, round 1 approved
- Secretary review request: d2609d80-2f58-4507-94f7-cfd72c41c4f1
- blocking findings: 0; all medium and low recommendations were incorporated

## Verification

- ./build.sh
- npm run test:automation (14 passed)
- npm run test:mcp (51 passed)
- npm run test:mcp-package (1 passed, verified on a dedicated bridge port because the default local range was occupied)
- node --test tests/x1pen_reference_test.mjs (32 passed)
- node tests/z80asm_test.js (322 passed)
- canonical and generated libm8a.asm copies are byte-identical
- version files and libmag.asm are unchanged

Closes #80
Closes #81
