### PR TITLE
Add actionable source conflicts and bounded diffs

### DIFF
--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -95,8 +95,9 @@ feature IDは完全一致する不変の契約です。現在は`automation.core
 | `x1pen_get_program` | メタデータと明示指定した完全ソースを取得 |
 | `x1pen_get_source` | 1セクションを行範囲・文字数上限付きで取得 |
 | `x1pen_search_source` | 1セクションをリテラル検索し、限定した前後行を取得 |
-| `x1pen_apply_edits` | revision一致時だけ構造化された行編集を適用 |
-| `x1pen_set_program` | revision一致時だけプログラム全体を更新（新規作成・全置換用） |
+| `x1pen_diff_source` | 保持済みbaselineと現在の1セクションを上限付きline diffで比較 |
+| `x1pen_apply_edits` | revisionEpoch/revision一致時だけ構造化された行編集を適用 |
+| `x1pen_set_program` | revisionEpoch/revision一致時だけプログラム全体を更新（新規作成・全置換用） |
 | `x1pen_validate` | 実行せずにコンパイル、アセンブル、トークナイズ |
 | `x1pen_run` | ユーザーが開いているX1Penで実行 |
 | `x1pen_recover_stalled` | stallしたRun準備を、データ損失確認後のタブ再読込で復旧 |
@@ -116,7 +117,7 @@ feature IDは完全一致する不変の契約です。現在は`automation.core
 | `x1pen_debug_write_vram` | 停止中にVRAMへ連続16進データを書き込み |
 | `x1pen_debug_wait_for_pause` | 条件に一致する停止まで待機 |
 
-AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revision`を要求し、途中で人間が編集していた場合は上書きを拒否します。
+AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revisionEpoch`と`revision`を要求し、途中で人間が編集した場合やタブが再読込された場合は上書きを拒否します。`automation.source-sync`をadvertiseしない旧Connector/X1Penへepoch付き更新をdowngradeすることはありません。
 
 ### エミュレーターへのキー入力
 
@@ -208,7 +209,7 @@ X1ハードウェアについては、Z80のCPUメモリと16bit I/O空間の分
 
 ### 大きなプログラムの扱い
 
-`x1pen_get_program`は引数なしの場合、`sourceMode`、`revision`、各セクションの行数・文字数だけを返します。完全ソースが必要な場合だけ`fields`を明示します。SLANGから生成されたASMは`includeGeneratedAsm: true`を明示しない限り返しません。完全取得には既定で128 KiBの上限があり、超えるソースは`x1pen_get_source`で分割取得します。
+`x1pen_get_program`は引数なしの場合、`sourceMode`、`revisionEpoch`、`revision`、`authoringHash`、各セクションの行数・文字数・UTF-8 byte数・hashを返します。hashはexact UTF-8 byte列の`sha256-utf8-v1`で、改行を正規化しないためLFとCRLFは異なります。完全ソースが必要な場合だけ`fields`を明示します。SLANGから生成されたASMは`generatedContentHash`としてauthoringHashから除外され、`includeGeneratedAsm: true`を明示しない限り本文を返しません。SLANGのRunだけでrevisionと生成ASM hashが変化し、authoringHashが変わらない場合がありますが、自動retryの許可にはなりません。完全取得には既定で128 KiBの上限があり、超えるソースは`x1pen_get_source`で分割取得します。
 
 ```json
 {
@@ -228,11 +229,12 @@ X1ハードウェアについては、Z80のCPUメモリと16bit I/O空間の分
 }
 ```
 
-既存プログラムの変更には、全置換ではなく`x1pen_apply_edits`を使用します。行番号は1始まりで、同一リクエスト内の編集範囲は重複できません。応答には新しいrevisionと変更行数だけが含まれ、完全ソースは返りません。
+既存プログラムの変更には、全置換ではなく`x1pen_apply_edits`を使用します。行番号は1始まりで、同一リクエスト内の編集範囲は重複できません。応答には新しいepoch/revision、hash、変更行数だけが含まれ、完全ソースは返りません。
 
 ```json
 {
   "section": "slang",
+  "expectedRevisionEpoch": "取得時のrevisionEpoch",
   "expectedRevision": 3,
   "edits": [
     {
@@ -243,6 +245,31 @@ X1ハードウェアについては、Z80のCPUメモリと16bit I/O空間の分
   ]
 }
 ```
+
+### 競合時の比較手順
+
+`REVISION_MISMATCH`は同じdocument epoch内の編集競合、`REVISION_EPOCH_MISMATCH`は再読込後の別epoch、`REVISION_EPOCH_REQUIRED`はrevisionだけを送った旧callerを表します。いずれも更新は適用されません。errorには取得可能な場合、競合発生時と再観測時のrevision、現在のepoch、hash、行数が含まれます。競合後にrevisionだけを差し替えて同じsourceを再送しないでください。
+
+1. 直前に保持した`revisionEpoch`、`revision`、section hash、`authoringHash`を確認します。
+2. 同一modeのbaselineなら`x1pen_diff_source`を呼び、人間／Run／別AIの変更を比較します。
+3. 変更を取り込んだ後、最新のepoch/revisionを使って別のguarded requestとして明示的にretryします。
+
+```json
+{
+  "section": "slang",
+  "baseHash": "sha256-utf8-v1:<64 hex>",
+  "baseSourceMode": "slang",
+  "baseRevisionEpoch": "取得時のrevisionEpoch",
+  "baseGenerated": false,
+  "contextLines": 3,
+  "maxHunks": 20,
+  "maxCharacters": 32768
+}
+```
+
+MCP processは観測したsectionを最大256 KiB/entry、合計4 MiB/64 entries、15分TTLのLRU cacheにだけ保持し、disk、browser storage、telemetryへ保存しません。disconnect、process終了、TTL/上限でbaselineが消えた場合は`BASE_SNAPSHOT_UNAVAILABLE`になります。caller自身が保持した`baseSource`をfallbackとして渡せますが、結果の`baseSourceOrigin: caller-supplied`はhashとの自己整合性だけを示し、そのsourceが過去にtabへ存在した証明ではありません。
+
+diffは1 source 256 KiB/20,000行、比較work、hunk数、context、出力文字数を制限します。上限超過は`DIFF_LIMIT_EXCEEDED`、sourceMode変更は`BASE_MODE_MISMATCH`です。前epochとのinformational diffは`epochChanged: true`を返しますが、write guardを緩和しません。SLANG生成ASMは両側とも`includeGeneratedAsm: true`が必要です。hunkはLF表示に統一し、CRLF/LF差はbounded side-band metadata、final newline欠落はmarkerで表します。
 
 SLANG編集中のASMは生成物として読み取り・編集とも既定で保護されます。SLANGへ編集を適用すると古い生成ASMは破棄され、次回の検証・実行時に再生成されます。
 

--- a/extension/compatibility.mjs
+++ b/extension/compatibility.mjs
@@ -2,6 +2,7 @@ export const CONNECTOR_PROTOCOL_VERSION = 2;
 export const CONNECTOR_FEATURES = Object.freeze([
   'automation.core',
   'automation.run-recovery',
+  'automation.source-sync',
   'screen.capture',
   'input.keyboard',
   'input.pad',
@@ -69,13 +70,23 @@ export function assertMcpProtocolSupported(server) {
 
 export function serializeExtensionError(error) {
   const serialized = {
-    message: error?.message || String(error),
+    message: String(error?.message || error).slice(0, 1_024),
   };
-  if (typeof error?.code === 'string') serialized.code = error.code;
+  if (typeof error?.code === 'string') serialized.code = error.code.slice(0, 128);
   if (['mcp', 'connector', 'x1pen'].includes(error?.component)) serialized.component = error.component;
-  if (typeof error?.feature === 'string') serialized.feature = error.feature;
-  if (typeof error?.currentVersion === 'string') serialized.currentVersion = error.currentVersion;
-  if (typeof error?.requiredVersion === 'string') serialized.requiredVersion = error.requiredVersion;
-  if (typeof error?.action === 'string') serialized.action = error.action;
+  if (typeof error?.feature === 'string') serialized.feature = error.feature.slice(0, 64);
+  if (typeof error?.currentVersion === 'string') serialized.currentVersion = error.currentVersion.slice(0, 64);
+  if (typeof error?.requiredVersion === 'string') serialized.requiredVersion = error.requiredVersion.slice(0, 64);
+  if (typeof error?.action === 'string') serialized.action = error.action.slice(0, 512);
+  for (const key of ['expectedRevision', 'currentRevision', 'conflictRevision', 'observedRevision']) {
+    if (Number.isSafeInteger(error?.[key]) && error[key] >= 0) serialized[key] = error[key];
+  }
+  for (const key of [
+    'expectedRevisionEpoch', 'currentRevisionEpoch', 'conflictRevisionEpoch',
+    'observedRevisionEpoch', 'instanceId',
+  ]) {
+    if (typeof error?.[key] === 'string' && error[key].length <= 128) serialized[key] = error[key];
+  }
+  if (typeof error?.metadataAvailable === 'boolean') serialized.metadataAvailable = error.metadataAvailable;
   return serialized;
 }

--- a/extension/page-automation.mjs
+++ b/extension/page-automation.mjs
@@ -114,7 +114,13 @@ export async function invokeX1PenInPage(requestedMethod, requestedParams) {
   if (shouldLock) api.setInteractionLocked(true, lockLabels[requestedMethod]);
   try {
     if (requestedMethod === 'getProgram') return api.getProgram();
-    if (requestedMethod === 'setProgram') return await api.setProgram(requestedParams.program, requestedParams.expectedRevision);
+    if (requestedMethod === 'setProgram') {
+      return await api.setProgram(
+        requestedParams.program,
+        requestedParams.expectedRevision,
+        requestedParams.expectedRevisionEpoch,
+      );
+    }
     if (requestedMethod === 'validate') return await api.validate();
     if (requestedMethod === 'run') {
       const result = await api.run({ origin: 'mcp', queueTimeoutMs: requestedParams.queueTimeoutMs });

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -27,6 +27,7 @@ function sessionFromStatus(status, base = {}) {
     title: status.title,
     url: status.url,
     revision: status.revision,
+    revisionEpoch: status.revisionEpoch,
     x1pen: normalizeX1PenDescriptor(status),
   };
 }
@@ -38,6 +39,7 @@ function bridgeSession(session) {
     url: session.url,
     active: !!session.active,
     revision: session.revision,
+    revisionEpoch: session.revisionEpoch,
     x1pen: session.x1pen,
   };
 }

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -50,6 +50,15 @@ window.__X1PEN_MODE = true;
             return 'x1pen-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
         }
     })();
+    // instanceId identifies the tab session and intentionally survives reloads.
+    // revisionEpoch binds the in-memory revision counter to this document load.
+    var automationRevisionEpoch = (function() {
+        try {
+            return crypto.randomUUID();
+        } catch(e) {
+            return 'epoch-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        }
+    })();
 
     function markProgramChanged() {
         automationRevision++;
@@ -1488,6 +1497,7 @@ window.__X1PEN_MODE = true;
             slang: slang,
             sourceMode: inferSourceMode(basic.trim(), asm.trim(), slang.trim()),
             revision: automationRevision,
+            revisionEpoch: automationRevisionEpoch,
             instanceId: automationInstanceId
         };
     }
@@ -1532,9 +1542,42 @@ window.__X1PEN_MODE = true;
         return { basic: basic, asm: asm, slang: slang, sourceMode: sourceMode };
     }
 
-    function setAutomationProgram(program, expectedRevision) {
+    function createProgramConflictError(code, message, details) {
+        var error = new Error(message);
+        error.code = code;
+        error.component = 'x1pen';
+        error.action = code === 'REVISION_EPOCH_REQUIRED'
+            ? 'Call getProgram again and retry with both expectedRevisionEpoch and expectedRevision.'
+            : 'Call getProgram, compare the current source identity, and reconcile changes before retrying.';
+        Object.keys(details || {}).forEach(function(key) { error[key] = details[key]; });
+        return error;
+    }
+
+    function setAutomationProgram(program, expectedRevision, expectedRevisionEpoch) {
+        if (expectedRevision !== undefined && expectedRevisionEpoch === undefined) {
+            throw createProgramConflictError(
+                'REVISION_EPOCH_REQUIRED',
+                'A revision epoch is required with expectedRevision',
+                { expectedRevision: expectedRevision, currentRevision: automationRevision,
+                    currentRevisionEpoch: automationRevisionEpoch, instanceId: automationInstanceId }
+            );
+        }
+        if (expectedRevisionEpoch !== undefined && expectedRevisionEpoch !== automationRevisionEpoch) {
+            throw createProgramConflictError(
+                'REVISION_EPOCH_MISMATCH',
+                'Revision epoch conflict: the program was reloaded after the caller read it',
+                { expectedRevision: expectedRevision, expectedRevisionEpoch: expectedRevisionEpoch,
+                    currentRevision: automationRevision, currentRevisionEpoch: automationRevisionEpoch,
+                    instanceId: automationInstanceId }
+            );
+        }
         if (expectedRevision !== undefined && expectedRevision !== automationRevision) {
-            throw new Error('Revision conflict: expected ' + expectedRevision + ', current ' + automationRevision);
+            throw createProgramConflictError(
+                'REVISION_MISMATCH',
+                'Revision conflict: expected ' + expectedRevision + ', current ' + automationRevision,
+                { expectedRevision: expectedRevision, currentRevision: automationRevision,
+                    currentRevisionEpoch: automationRevisionEpoch, instanceId: automationInstanceId }
+            );
         }
         if (!basicEditor || !asmEditor || !slangEditor) {
             throw new Error('X1Pen editors are not ready');
@@ -2163,7 +2206,7 @@ window.__X1PEN_MODE = true;
     var X1PEN_PRODUCT = window.X1PenBuild || { name: 'x1pen', version: 'unknown' };
 
     function getAutomationFeatures() {
-        var features = ['automation.core', 'automation.run-recovery', 'screen.capture'];
+        var features = ['automation.core', 'automation.run-recovery', 'automation.source-sync', 'screen.capture'];
         if (isAutomationKeyboardAvailable()) {
             features.push('input.keyboard');
         }
@@ -2230,6 +2273,7 @@ window.__X1PEN_MODE = true;
         return {
             instanceId: automationInstanceId,
             revision: automationRevision,
+            revisionEpoch: automationRevisionEpoch,
             ready: automationReadyState === 'ready',
             state: automationReadyState,
             busy: automationPendingOperations > 0,
@@ -2394,10 +2438,10 @@ window.__X1PEN_MODE = true;
             return automationReadyPromise.then(getAutomationStatus);
         },
         getProgram: getAutomationProgram,
-        setProgram: function(program, expectedRevision) {
+        setProgram: function(program, expectedRevision, expectedRevisionEpoch) {
             if (isRunSetupPending()) return Promise.reject(createRunPendingError('Program update'));
             return queueAutomationOperation(function() {
-                return setAutomationProgram(program, expectedRevision);
+                return setAutomationProgram(program, expectedRevision, expectedRevisionEpoch);
             });
         },
         validate: function() {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,7 +40,9 @@ The pairing code changes whenever the MCP server process restarts. One browser e
 
 Connection, session and status results report the versions and effective features of the MCP server, X1Pen Connector and connected X1Pen. Versions are diagnostic; commands are permitted from the exact feature IDs advertised by all required components. Unsupported debugger commands are rejected before they reach an older Connector and return a machine-readable update action.
 
-The current feature contracts are `automation.core`, `automation.run-recovery`, `screen.capture`, `input.keyboard`, `input.pad`, `debugger.cpu` and `debugger.vram`. Feature IDs are immutable. A backward-incompatible successor uses a new ID such as `debugger.vram-v2` rather than changing the meaning of an existing ID.
+The current feature contracts are `automation.core`, `automation.run-recovery`, `automation.source-sync`, `screen.capture`, `input.keyboard`, `input.pad`, `debugger.cpu` and `debugger.vram`. `automation.source-sync` covers epoch-bound guarded writes and structured source conflicts. Feature IDs are immutable. A backward-incompatible successor uses a new ID such as `debugger.vram-v2` rather than changing the meaning of an existing ID.
+
+Program metadata includes exact UTF-8 SHA-256 section hashes, a mode-aware authoring hash, `revisionEpoch`, and `revision`. Retain all of them before editing. `x1pen_set_program` and `x1pen_apply_edits` require the epoch/revision pair and fail closed after a reload or concurrent edit. On conflict, compare hashes or call `x1pen_diff_source`; never update only the revision and resend stale source. Diff baselines are held only in a bounded, expiring in-memory cache. An optional caller-supplied baseline is labeled self-attested, generated SLANG ASM requires explicit opt-in, and all diff inputs/work/hunks/output are bounded.
 
 ## Emulator keyboard input
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -14,7 +14,8 @@
     "x1pen-bridge.mjs",
     "x1pen-compatibility.mjs",
     "x1pen-reference.mjs",
-    "x1pen-server.mjs"
+    "x1pen-server.mjs",
+    "x1pen-source-sync.mjs"
   ],
   "engines": {
     "node": ">=20"

--- a/mcp/x1pen-bridge.mjs
+++ b/mcp/x1pen-bridge.mjs
@@ -152,6 +152,7 @@ export class X1PenBridge {
           url: String(session.url || ''),
           active: !!session.active,
           revision: Number.isInteger(session.revision) ? session.revision : 0,
+          revisionEpoch: typeof session.revisionEpoch === 'string' ? session.revisionEpoch : undefined,
           x1pen: normalizeX1PenDescriptor(session.x1pen),
         });
       }

--- a/mcp/x1pen-compatibility.mjs
+++ b/mcp/x1pen-compatibility.mjs
@@ -1,6 +1,7 @@
 export const FEATURE_IDS = Object.freeze([
   'automation.core',
   'automation.run-recovery',
+  'automation.source-sync',
   'screen.capture',
   'input.keyboard',
   'input.pad',
@@ -19,7 +20,7 @@ const LEGACY_CONNECTOR_FEATURES = Object.freeze({
 
 const METHOD_FEATURES = Object.freeze({
   getProgram: 'automation.core',
-  setProgram: 'automation.core',
+  setProgram: 'automation.source-sync',
   validate: 'automation.core',
   run: 'automation.core',
   recoverStalled: 'automation.run-recovery',
@@ -177,9 +178,19 @@ export function assertMethodCompatible(method, compatibility, components) {
 
 export function deserializeBridgeError(value) {
   if (!value || typeof value !== 'object') return new Error(String(value || 'X1Pen command failed'));
-  const error = new Error(typeof value.message === 'string' ? value.message : 'X1Pen command failed');
+  const error = new Error(typeof value.message === 'string' ? value.message.slice(0, 1_024) : 'X1Pen command failed');
   for (const key of ['code', 'component', 'feature', 'currentVersion', 'requiredVersion', 'action']) {
-    if (typeof value[key] === 'string') error[key] = value[key];
+    if (typeof value[key] === 'string') error[key] = value[key].slice(0, key === 'action' ? 512 : 128);
   }
+  for (const key of ['expectedRevision', 'currentRevision', 'conflictRevision', 'observedRevision']) {
+    if (Number.isSafeInteger(value[key]) && value[key] >= 0) error[key] = value[key];
+  }
+  for (const key of [
+    'expectedRevisionEpoch', 'currentRevisionEpoch', 'conflictRevisionEpoch',
+    'observedRevisionEpoch', 'instanceId',
+  ]) {
+    if (typeof value[key] === 'string' && value[key].length <= 128) error[key] = value[key];
+  }
+  if (typeof value.metadataAvailable === 'boolean') error.metadataAvailable = value.metadataAvailable;
   return error;
 }

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -9,6 +9,17 @@ import * as z from 'zod/v4';
 import { X1PenBridge } from './x1pen-bridge.mjs';
 import { createMcpDescriptor } from './x1pen-compatibility.mjs';
 import {
+  HASH_PATTERN,
+  MAX_BASELINE_BYTES,
+  SourceBaselineCache,
+  SourceSyncError,
+  contentHash,
+  createBoundedLineDiff,
+  sourceByteLength,
+  sourceIdentities,
+  sourceRole,
+} from './x1pen-source-sync.mjs';
+import {
   getReferenceEntries,
   getReferenceManifest,
   searchReference,
@@ -54,6 +65,7 @@ const SERVER_INSTRUCTIONS = [
   'Before writing or substantially editing a program, call x1pen_get_language_profile, search the bundled reference with x1pen_search_reference, and fetch only the needed IDs with x1pen_get_reference.',
   'After editing, call x1pen_validate. Run and inspect the visible emulator when behavior must be confirmed.',
   'Prefer bounded source and reference tools so generated ASM and unrelated manual sections do not consume context.',
+  'Retain revisionEpoch, revision and authoringHash together. On a source conflict, compare before retrying; never replace only the revision and blindly resend stale source.',
   'Connection and status results report MCP, Connector and X1Pen compatibility. Do not retry a feature that reports an update-required error until that component is updated.',
 ].join(' ');
 
@@ -67,7 +79,44 @@ function toolError(error) {
   if (error && typeof error.code === 'string') {
     const details = {};
     for (const key of ['code', 'component', 'feature', 'message', 'currentVersion', 'requiredVersion', 'action']) {
-      if (typeof error[key] === 'string') details[key] = error[key];
+      if (typeof error[key] === 'string') details[key] = error[key].slice(0, 1_024);
+    }
+    for (const key of ['expectedRevision', 'currentRevision', 'conflictRevision', 'observedRevision']) {
+      if (Number.isSafeInteger(error[key]) && error[key] >= 0) details[key] = error[key];
+    }
+    for (const key of [
+      'expectedRevisionEpoch', 'currentRevisionEpoch', 'conflictRevisionEpoch',
+      'observedRevisionEpoch', 'instanceId',
+    ]) {
+      if (typeof error[key] === 'string' && error[key].length <= 128) details[key] = error[key];
+    }
+    for (const key of ['metadataAvailable', 'observedMetadataAvailable']) {
+      if (typeof error[key] === 'boolean') details[key] = error[key];
+    }
+    if (error.current && typeof error.current === 'object') {
+      const current = {};
+      for (const key of ['sourceMode', 'revisionEpoch', 'instanceId', 'authoringHash']) {
+        if (typeof error.current[key] === 'string' && error.current[key].length <= 128) current[key] = error.current[key];
+      }
+      if (Number.isSafeInteger(error.current.revision) && error.current.revision >= 0) {
+        current.revision = error.current.revision;
+      }
+      if (error.current.sections && typeof error.current.sections === 'object') {
+        current.sections = {};
+        for (const section of SOURCE_SECTIONS) {
+          const input = error.current.sections[section];
+          if (!input || typeof input !== 'object') continue;
+          const output = {};
+          for (const key of ['lineCount', 'characterCount', 'byteCount']) {
+            if (Number.isSafeInteger(input[key]) && input[key] >= 0) output[key] = input[key];
+          }
+          for (const key of ['role', 'contentHash', 'generatedContentHash']) {
+            if (typeof input[key] === 'string' && input[key].length <= 96) output[key] = input[key];
+          }
+          current.sections[section] = output;
+        }
+      }
+      details.current = current;
     }
     return {
       isError: true,
@@ -103,6 +152,9 @@ function normalizeProgramSnapshot(value) {
     sourceMode,
     revision: value.revision,
     instanceId: typeof value.instanceId === 'string' ? value.instanceId : undefined,
+    revisionEpoch: typeof value.revisionEpoch === 'string' && value.revisionEpoch.length <= 128
+      ? value.revisionEpoch
+      : undefined,
   };
   for (const section of SOURCE_SECTIONS) {
     if (typeof value[section] !== 'string') throw new Error(`X1Pen returned invalid ${section} source`);
@@ -116,18 +168,26 @@ function sourceLineCount(source) {
 }
 
 function summarizeProgram(snapshot) {
+  const identities = sourceIdentities(snapshot);
   const sections = {};
   for (const section of SOURCE_SECTIONS) {
+    const identity = identities.sections[section];
     sections[section] = {
       lineCount: sourceLineCount(snapshot[section]),
       characterCount: snapshot[section].length,
+      byteCount: sourceByteLength(snapshot[section]),
+      role: identity.role,
+      ...(identity.contentHash ? { contentHash: identity.contentHash } : {}),
+      ...(identity.generatedContentHash ? { generatedContentHash: identity.generatedContentHash } : {}),
     };
   }
   sections.asm.generated = snapshot.sourceMode === 'slang' && snapshot.asm.length > 0;
   return {
     sourceMode: snapshot.sourceMode,
     revision: snapshot.revision,
+    ...(snapshot.revisionEpoch ? { revisionEpoch: snapshot.revisionEpoch } : { guardedWritesReloadSafe: false }),
     ...(snapshot.instanceId ? { instanceId: snapshot.instanceId } : {}),
+    authoringHash: identities.authoringHash,
     sections,
   };
 }
@@ -170,6 +230,8 @@ function getSourceRange(snapshot, section, options) {
     return {
       section,
       revision: snapshot.revision,
+      ...(snapshot.revisionEpoch ? { revisionEpoch: snapshot.revisionEpoch } : {}),
+      contentHash: contentHash(snapshot[section]),
       startLine: 1,
       endLine: 0,
       totalLines: 0,
@@ -202,6 +264,8 @@ function getSourceRange(snapshot, section, options) {
   return {
     section,
     revision: snapshot.revision,
+    ...(snapshot.revisionEpoch ? { revisionEpoch: snapshot.revisionEpoch } : {}),
+    contentHash: contentHash(snapshot[section]),
     startLine: options.startLine,
     endLine,
     totalLines: lines.length,
@@ -257,6 +321,8 @@ function searchSource(snapshot, section, options) {
   return {
     section,
     revision: snapshot.revision,
+    ...(snapshot.revisionEpoch ? { revisionEpoch: snapshot.revisionEpoch } : {}),
+    contentHash: contentHash(snapshot[section]),
     query: options.query,
     totalMatches,
     matches,
@@ -409,16 +475,117 @@ export function createX1PenMcpServer(options = {}) {
     { instructions: SERVER_INSTRUCTIONS },
   );
   const sessionInput = { sessionId: z.string().optional().describe('Connected X1Pen instance ID; omit when one tab is connected') };
+  const baselines = new SourceBaselineCache(options.sourceBaselineOptions);
+
+  function pruneBaselinesToSessions() {
+    const activeInstances = new Set((bridge.listSessions?.() || []).map((session) => session.sessionId));
+    baselines.retainInstances(activeInstances);
+  }
+
+  function observeSnapshot(snapshot) {
+    pruneBaselinesToSessions();
+    baselines.rememberSnapshot(snapshot);
+    return snapshot;
+  }
+
+  async function readProgram(sessionId) {
+    return observeSnapshot(normalizeProgramSnapshot(
+      await bridge.sendCommand('getProgram', {}, sessionId),
+    ));
+  }
+
+  function conflictError(code, details = {}) {
+    let message;
+    if (code === 'REVISION_EPOCH_REQUIRED') {
+      message = 'A revision epoch is required with expectedRevision';
+    } else if (code === 'REVISION_EPOCH_MISMATCH') {
+      message = 'Revision epoch conflict: the program was reloaded after the caller read it';
+    } else {
+      message = `Revision conflict: expected ${details.expectedRevision}, current ${details.currentRevision}`;
+    }
+    const error = new Error(message);
+    Object.assign(error, {
+      code,
+      component: 'x1pen',
+      action: code === 'REVISION_EPOCH_REQUIRED'
+        ? 'Call x1pen_get_program and retry with both expectedRevisionEpoch and expectedRevision.'
+        : 'Call x1pen_diff_source or bounded source reads, reconcile changes, then retry with the newly observed epoch and revision.',
+      ...details,
+    });
+    return error;
+  }
+
+  function normalizeLegacyConflict(error) {
+    if (error?.code) return error;
+    const match = /^Revision conflict: expected (\d+), current (\d+)$/.exec(error?.message || '');
+    if (!match) return error;
+    const expectedRevision = Number(match[1]);
+    const currentRevision = Number(match[2]);
+    if (!Number.isSafeInteger(expectedRevision) || !Number.isSafeInteger(currentRevision)) return error;
+    Object.assign(error, {
+      code: 'REVISION_MISMATCH',
+      component: 'x1pen',
+      expectedRevision,
+      currentRevision,
+      metadataAvailable: false,
+      legacyConflictShape: true,
+      action: 'Call x1pen_get_program and compare the current source before retrying.',
+    });
+    return error;
+  }
+
+  async function enrichConflict(input, sessionId, knownSnapshot) {
+    const error = normalizeLegacyConflict(input);
+    if (!['REVISION_MISMATCH', 'REVISION_EPOCH_MISMATCH', 'REVISION_EPOCH_REQUIRED'].includes(error?.code)) {
+      throw error;
+    }
+    if (Number.isSafeInteger(error.currentRevision)) error.conflictRevision = error.currentRevision;
+    if (typeof error.currentRevisionEpoch === 'string') error.conflictRevisionEpoch = error.currentRevisionEpoch;
+    try {
+      const current = knownSnapshot || await readProgram(sessionId);
+      const summary = summarizeProgram(current);
+      error.metadataAvailable = error.legacyConflictShape !== true;
+      error.observedMetadataAvailable = true;
+      error.observedRevision = current.revision;
+      if (current.revisionEpoch) error.observedRevisionEpoch = current.revisionEpoch;
+      if (current.instanceId) error.instanceId = current.instanceId;
+      error.current = summary;
+      error.action = error.code === 'REVISION_EPOCH_REQUIRED'
+        ? 'Retry with expectedRevisionEpoch and expectedRevision from the current summary.'
+        : 'Compare the retained baseline with the current hashes or x1pen_diff_source before retrying with the observed epoch and revision.';
+    } catch {
+      error.metadataAvailable = false;
+      error.observedMetadataAvailable = false;
+    }
+    throw error;
+  }
+
+  async function sendGuardedProgram(program, expectedRevision, expectedRevisionEpoch, sessionId) {
+    try {
+      return observeSnapshot(normalizeProgramSnapshot(await bridge.sendCommand(
+        'setProgram', { program, expectedRevision, expectedRevisionEpoch }, sessionId,
+      )));
+    } catch (error) {
+      return enrichConflict(error, sessionId);
+    }
+  }
 
   server.registerTool('x1pen_connection_info', {
     description: 'Get the local bridge port and pairing code used by the X1Pen Connector extension.',
     annotations: { readOnlyHint: true, openWorldHint: false },
-  }, handleTool(async () => textResult(bridge.connectionInfo())));
+  }, handleTool(async () => {
+    pruneBaselinesToSessions();
+    return textResult(bridge.connectionInfo());
+  }));
 
   server.registerTool('x1pen_list_sessions', {
     description: 'List X1Pen browser tabs explicitly connected through the extension.',
     annotations: { readOnlyHint: true, openWorldHint: false },
-  }, handleTool(async () => textResult({ sessions: bridge.listSessions() })));
+  }, handleTool(async () => {
+    const sessions = bridge.listSessions();
+    baselines.retainInstances(new Set(sessions.map((session) => session.sessionId)));
+    return textResult({ sessions });
+  }));
 
   server.registerTool('x1pen_select_session', {
     description: 'Select the X1Pen browser tab used by later tool calls. Pad input is released on the previously selected live tab first; force only when that cleanup cannot complete.',
@@ -500,25 +667,24 @@ export function createX1PenMcpServer(options = {}) {
     },
     annotations: { readOnlyHint: true, openWorldHint: false },
   }, handleTool(async ({ sessionId, fields, includeGeneratedAsm, maxCharacters }) => {
-    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    const snapshot = await readProgram(sessionId);
     return textResult(selectProgramFields(snapshot, fields, includeGeneratedAsm, maxCharacters));
   }));
 
   server.registerTool('x1pen_set_program', {
-    description: 'Replace the complete program when expectedRevision still matches the connected X1Pen tab.',
+    description: 'Replace the complete program only when expectedRevisionEpoch and expectedRevision still match. On conflict, compare current hashes/diff before retrying; never refresh only the revision.',
     inputSchema: {
       sessionId: sessionInput.sessionId,
       expectedRevision: z.number().int().min(0),
+      expectedRevisionEpoch: z.string().min(1).max(128),
       sourceMode: z.enum(['basic+asm', 'asm', 'slang']),
       basic: z.string().max(MAX_SOURCE_LENGTH).optional(),
       asm: z.string().max(MAX_SOURCE_LENGTH).optional(),
       slang: z.string().max(MAX_SOURCE_LENGTH).optional(),
     },
     annotations: { destructiveHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId, expectedRevision, ...program }) => {
-    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand(
-      'setProgram', { program, expectedRevision }, sessionId,
-    ));
+  }, handleTool(async ({ sessionId, expectedRevision, expectedRevisionEpoch, ...program }) => {
+    const snapshot = await sendGuardedProgram(program, expectedRevision, expectedRevisionEpoch, sessionId);
     return textResult({ ok: true, ...summarizeProgram(snapshot) });
   }));
 
@@ -534,7 +700,7 @@ export function createX1PenMcpServer(options = {}) {
     },
     annotations: { readOnlyHint: true, openWorldHint: false },
   }, handleTool(async ({ sessionId, section, ...options }) => {
-    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    const snapshot = await readProgram(sessionId);
     return textResult(getSourceRange(snapshot, section, options));
   }));
 
@@ -551,16 +717,134 @@ export function createX1PenMcpServer(options = {}) {
     },
     annotations: { readOnlyHint: true, openWorldHint: false },
   }, handleTool(async ({ sessionId, section, ...options }) => {
-    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    const snapshot = await readProgram(sessionId);
     return textResult(searchSource(snapshot, section, options));
   }));
 
+  server.registerTool('x1pen_diff_source', {
+    description: 'Compare a retained source baseline with the current connected tab using bounded line hunks. Baselines are ephemeral; caller-supplied text is labeled self-attested. Diffs never authorize a write.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      section: z.enum(SOURCE_SECTIONS),
+      baseHash: z.string().regex(HASH_PATTERN),
+      baseSourceMode: z.enum(['basic+asm', 'asm', 'slang']),
+      baseRevisionEpoch: z.string().min(1).max(128),
+      baseGenerated: z.boolean().default(false),
+      baseSource: z.string().max(MAX_SOURCE_LENGTH).optional()
+        .describe('Optional caller-retained fallback when the ephemeral baseline cache no longer has baseHash'),
+      includeGeneratedAsm: z.boolean().default(false),
+      contextLines: z.number().int().min(0).max(5).default(3),
+      maxHunks: z.number().int().min(1).max(100).default(20),
+      maxCharacters: z.number().int().min(1_024).max(64 * 1024).default(32 * 1024),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, handleTool(async ({
+    sessionId, section, baseHash, baseSourceMode, baseRevisionEpoch, baseGenerated,
+    baseSource, includeGeneratedAsm, contextLines, maxHunks, maxCharacters,
+  }) => {
+    const current = await readProgram(sessionId);
+    if (!current.instanceId || !current.revisionEpoch) {
+      throw new SourceSyncError(
+        'FEATURE_UNAVAILABLE',
+        'The connected X1Pen does not report source revision epochs',
+        { component: 'x1pen', feature: 'automation.source-sync', action: 'Update/reload X1Pen and reconnect the tab.' },
+      );
+    }
+    if (baseSourceMode !== current.sourceMode) {
+      throw new SourceSyncError(
+        'BASE_MODE_MISMATCH',
+        `Baseline mode ${baseSourceMode} does not match current mode ${current.sourceMode}`,
+        { action: 'Establish a new baseline after the source-mode change.' },
+      );
+    }
+
+    const requestedRole = baseGenerated ? 'generated' : 'authoring';
+    const currentRole = sourceRole(current.sourceMode, section, current[section]);
+    if (currentRole !== requestedRole) {
+      throw new SourceSyncError(
+        'BASE_ROLE_MISMATCH',
+        `${section} is ${currentRole} in ${current.sourceMode} mode, not ${requestedRole}`,
+        { action: 'Select an authoring section or establish a baseline with matching provenance.' },
+      );
+    }
+    if (requestedRole === 'generated' && !includeGeneratedAsm) {
+      throw new SourceSyncError(
+        'GENERATED_SOURCE_REQUIRES_OPT_IN',
+        'Generated ASM diffs require includeGeneratedAsm=true for both sides',
+        { action: 'Set includeGeneratedAsm=true only when generated output is intentionally needed.' },
+      );
+    }
+
+    let resolvedBaseSource;
+    let baseSourceOrigin;
+    if (baseSource !== undefined) {
+      if (sourceByteLength(baseSource) > MAX_BASELINE_BYTES) {
+        throw new SourceSyncError('DIFF_LIMIT_EXCEEDED', `baseSource exceeds ${MAX_BASELINE_BYTES} UTF-8 bytes`);
+      }
+      const suppliedHash = contentHash(baseSource);
+      if (suppliedHash !== baseHash) {
+        throw new SourceSyncError(
+          'BASE_HASH_MISMATCH',
+          'baseSource does not match baseHash',
+          { action: 'Use the hash returned with the retained source text.' },
+        );
+      }
+      if (sourceRole(baseSourceMode, section, baseSource) !== requestedRole) {
+        throw new SourceSyncError('BASE_ROLE_MISMATCH', 'baseSource provenance does not match baseGenerated');
+      }
+      resolvedBaseSource = baseSource;
+      baseSourceOrigin = 'caller-supplied';
+    } else {
+      const entry = baselines.get({
+        instanceId: current.instanceId,
+        revisionEpoch: baseRevisionEpoch,
+        sourceMode: baseSourceMode,
+        section,
+        role: requestedRole,
+        hash: baseHash,
+      });
+      if (!entry) {
+        throw new SourceSyncError(
+          'BASE_SNAPSHOT_UNAVAILABLE',
+          'The requested baseline is not available in the bounded in-memory cache',
+          { action: 'Supply the retained baseSource with its provenance or establish a new baseline.' },
+        );
+      }
+      resolvedBaseSource = entry.source;
+      baseSourceOrigin = 'cache';
+    }
+
+    const currentHash = contentHash(current[section]);
+    const diff = createBoundedLineDiff(resolvedBaseSource, current[section], {
+      contextLines, maxHunks, maxCharacters,
+    });
+    return textResult({
+      section,
+      sourceMode: current.sourceMode,
+      role: currentRole,
+      baseHash,
+      currentHash,
+      byteIdentityChanged: baseHash !== currentHash,
+      baseRevisionEpoch,
+      currentRevisionEpoch: current.revisionEpoch,
+      epochChanged: baseRevisionEpoch !== current.revisionEpoch,
+      currentRevision: current.revision,
+      instanceId: current.instanceId,
+      baseSourceOrigin,
+      baseSourceAttestation: baseSourceOrigin === 'cache'
+        ? 'observed-by-this-mcp-process'
+        : 'caller-supplied; hash proves self-consistency only',
+      ...diff,
+    });
+  }));
+
   server.registerTool('x1pen_apply_edits', {
-    description: 'Apply non-overlapping line edits to one authoring source when expectedRevision still matches. Line numbers are 1-based.',
+    description: 'Apply non-overlapping line edits only when expectedRevisionEpoch and expectedRevision match. Line numbers are 1-based; compare conflicts before retrying.',
     inputSchema: {
       sessionId: sessionInput.sessionId,
       section: z.enum(SOURCE_SECTIONS),
       expectedRevision: z.number().int().min(0),
+      expectedRevisionEpoch: z.string().min(1).max(128),
       edits: z.array(z.object({
         startLine: z.number().int().min(1),
         deleteLineCount: z.number().int().min(0),
@@ -568,15 +852,36 @@ export function createX1PenMcpServer(options = {}) {
       })).min(1).max(100),
     },
     annotations: { destructiveHint: true, openWorldHint: false },
-  }, handleTool(async ({ sessionId, section, expectedRevision, edits }) => {
+  }, handleTool(async ({ sessionId, section, expectedRevision, expectedRevisionEpoch, edits }) => {
     const replacementSize = edits.reduce((total, edit) => total + edit.text.length, 0);
     if (replacementSize > MAX_SOURCE_LENGTH) {
       throw new Error(`Combined replacement text exceeds ${MAX_SOURCE_LENGTH} characters`);
     }
 
-    const snapshot = normalizeProgramSnapshot(await bridge.sendCommand('getProgram', {}, sessionId));
+    const snapshot = await readProgram(sessionId);
+    if (!snapshot.revisionEpoch) {
+      throw new SourceSyncError(
+        'FEATURE_UNAVAILABLE',
+        'The connected X1Pen does not report source revision epochs',
+        { component: 'x1pen', feature: 'automation.source-sync', action: 'Update/reload X1Pen and reconnect the tab.' },
+      );
+    }
+    if (snapshot.revisionEpoch !== expectedRevisionEpoch) {
+      return enrichConflict(conflictError('REVISION_EPOCH_MISMATCH', {
+        expectedRevision,
+        expectedRevisionEpoch,
+        currentRevision: snapshot.revision,
+        currentRevisionEpoch: snapshot.revisionEpoch,
+        instanceId: snapshot.instanceId,
+      }), sessionId, snapshot);
+    }
     if (snapshot.revision !== expectedRevision) {
-      throw new Error(`Revision conflict: expected ${expectedRevision}, current ${snapshot.revision}`);
+      return enrichConflict(conflictError('REVISION_MISMATCH', {
+        expectedRevision,
+        currentRevision: snapshot.revision,
+        currentRevisionEpoch: snapshot.revisionEpoch,
+        instanceId: snapshot.instanceId,
+      }), sessionId, snapshot);
     }
     assertEditableSection(snapshot, section);
     const applied = applyLineEdits(snapshot[section], edits);
@@ -601,9 +906,7 @@ export function createX1PenMcpServer(options = {}) {
       [section]: applied.source,
     };
     const generatedAsmCleared = section === 'slang' && snapshot.asm.length > 0;
-    const updated = normalizeProgramSnapshot(await bridge.sendCommand(
-      'setProgram', { program, expectedRevision }, sessionId,
-    ));
+    const updated = await sendGuardedProgram(program, expectedRevision, expectedRevisionEpoch, sessionId);
     return textResult({
       ok: true,
       changed: true,
@@ -824,6 +1127,11 @@ export function createX1PenMcpServer(options = {}) {
     };
   }));
 
+  const closeServer = server.close.bind(server);
+  server.close = async () => {
+    baselines.clear();
+    return closeServer();
+  };
   return { server, bridge };
 }
 

--- a/mcp/x1pen-source-sync.mjs
+++ b/mcp/x1pen-source-sync.mjs
@@ -1,0 +1,373 @@
+import { createHash } from 'node:crypto';
+
+export const HASH_PATTERN = /^sha256-utf8-v1:[0-9a-f]{64}$/;
+export const MAX_BASELINE_BYTES = 256 * 1024;
+export const MAX_DIFF_LINES = 20_000;
+export const MAX_DIFF_WORK = 250_000;
+
+const AUTHORING_SECTIONS = Object.freeze({
+  'basic+asm': ['basic', 'asm'],
+  asm: ['asm'],
+  slang: ['slang'],
+});
+
+export class SourceSyncError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = 'SourceSyncError';
+    this.code = code;
+    this.component = 'mcp';
+    Object.assign(this, details);
+  }
+}
+
+export function sourceByteLength(source) {
+  return Buffer.byteLength(source, 'utf8');
+}
+
+export function contentHash(source) {
+  return `sha256-utf8-v1:${createHash('sha256').update(source, 'utf8').digest('hex')}`;
+}
+
+function updateLengthPrefixed(hash, value) {
+  const bytes = Buffer.from(value, 'utf8');
+  const length = Buffer.allocUnsafe(4);
+  length.writeUInt32BE(bytes.length);
+  hash.update(length);
+  hash.update(bytes);
+}
+
+export function authoringHash(snapshot) {
+  const hash = createHash('sha256');
+  hash.update('x1pen-authoring-v1\0', 'utf8');
+  updateLengthPrefixed(hash, snapshot.sourceMode);
+  for (const section of AUTHORING_SECTIONS[snapshot.sourceMode]) {
+    updateLengthPrefixed(hash, section);
+    updateLengthPrefixed(hash, snapshot[section]);
+  }
+  return `sha256-authoring-v1:${hash.digest('hex')}`;
+}
+
+export function sourceRole(sourceMode, section, source) {
+  if (sourceMode === 'slang' && section === 'asm') {
+    return source.length > 0 ? 'generated' : 'inactive';
+  }
+  return AUTHORING_SECTIONS[sourceMode].includes(section) ? 'authoring' : 'inactive';
+}
+
+export function sourceIdentities(snapshot) {
+  const sections = {};
+  for (const section of ['basic', 'asm', 'slang']) {
+    const role = sourceRole(snapshot.sourceMode, section, snapshot[section]);
+    const hash = contentHash(snapshot[section]);
+    sections[section] = role === 'generated'
+      ? { role, generatedContentHash: hash }
+      : { role, contentHash: hash };
+  }
+  return { authoringHash: authoringHash(snapshot), sections };
+}
+
+function baselineKey(value) {
+  return [
+    value.instanceId,
+    value.revisionEpoch,
+    value.sourceMode,
+    value.section,
+    value.role,
+    value.hash,
+  ].join('\u0000');
+}
+
+export class SourceBaselineCache {
+  constructor(options = {}) {
+    this.maxEntryBytes = options.maxEntryBytes ?? MAX_BASELINE_BYTES;
+    this.maxTotalBytes = options.maxTotalBytes ?? (4 * 1024 * 1024);
+    this.maxEntries = options.maxEntries ?? 64;
+    this.ttlMs = options.ttlMs ?? (15 * 60 * 1000);
+    this.now = options.now || (() => Date.now());
+    this.entries = new Map();
+    this.totalBytes = 0;
+  }
+
+  rememberSnapshot(snapshot) {
+    if (!snapshot.instanceId || !snapshot.revisionEpoch) return;
+    const identities = sourceIdentities(snapshot);
+    for (const section of ['basic', 'asm', 'slang']) {
+      const source = snapshot[section];
+      const bytes = sourceByteLength(source);
+      if (bytes > this.maxEntryBytes) continue;
+      const identity = identities.sections[section];
+      const hash = identity.contentHash || identity.generatedContentHash;
+      const entry = {
+        instanceId: snapshot.instanceId,
+        revisionEpoch: snapshot.revisionEpoch,
+        revision: snapshot.revision,
+        sourceMode: snapshot.sourceMode,
+        section,
+        role: identity.role,
+        hash,
+        source,
+        bytes,
+        touchedAt: this.now(),
+      };
+      const key = baselineKey(entry);
+      const previous = this.entries.get(key);
+      if (previous) this.totalBytes -= previous.bytes;
+      this.entries.delete(key);
+      this.entries.set(key, entry);
+      this.totalBytes += bytes;
+    }
+    this.prune();
+  }
+
+  get(provenance) {
+    this.prune();
+    const key = baselineKey(provenance);
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    this.entries.delete(key);
+    entry.touchedAt = this.now();
+    this.entries.set(key, entry);
+    return { ...entry };
+  }
+
+  retainInstances(instanceIds) {
+    if (!instanceIds || instanceIds.size === 0) {
+      this.clear();
+      return;
+    }
+    for (const [key, entry] of this.entries) {
+      if (!instanceIds.has(entry.instanceId)) this.delete(key, entry);
+    }
+  }
+
+  prune() {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [key, entry] of this.entries) {
+      if (entry.touchedAt < cutoff) this.delete(key, entry);
+    }
+    while (this.entries.size > this.maxEntries || this.totalBytes > this.maxTotalBytes) {
+      const first = this.entries.entries().next().value;
+      if (!first) break;
+      this.delete(first[0], first[1]);
+    }
+  }
+
+  delete(key, entry) {
+    this.entries.delete(key);
+    this.totalBytes -= entry.bytes;
+  }
+
+  clear() {
+    this.entries.clear();
+    this.totalBytes = 0;
+  }
+}
+
+function parseLines(source) {
+  if (source.length === 0) return [];
+  const parts = source.split('\n');
+  const count = source.endsWith('\n') ? parts.length - 1 : parts.length;
+  const lines = [];
+  for (let index = 0; index < count; index++) {
+    const hasLf = index < parts.length - 1;
+    const raw = parts[index];
+    const crlf = hasLf && raw.endsWith('\r');
+    lines.push({
+      content: crlf ? raw.slice(0, -1) : raw,
+      terminator: hasLf ? (crlf ? 'crlf' : 'lf') : 'none',
+    });
+  }
+  return lines;
+}
+
+function createOperations(baseLines, currentLines, maxWork, deadline) {
+  let prefix = 0;
+  while (prefix < baseLines.length && prefix < currentLines.length &&
+      baseLines[prefix].content === currentLines[prefix].content) prefix++;
+
+  let suffix = 0;
+  while (suffix < baseLines.length - prefix && suffix < currentLines.length - prefix &&
+      baseLines[baseLines.length - 1 - suffix].content === currentLines[currentLines.length - 1 - suffix].content) suffix++;
+
+  const baseMiddle = baseLines.slice(prefix, baseLines.length - suffix);
+  const currentMiddle = currentLines.slice(prefix, currentLines.length - suffix);
+  const work = baseMiddle.length * currentMiddle.length;
+  if (work > maxWork) {
+    throw new SourceSyncError(
+      'DIFF_LIMIT_EXCEEDED',
+      `Diff requires ${work} comparison cells, exceeding the ${maxWork} work limit`,
+      { action: 'Compare smaller source sections or establish a closer baseline.' },
+    );
+  }
+
+  const columns = currentMiddle.length + 1;
+  const matrix = new Uint32Array((baseMiddle.length + 1) * columns);
+  for (let left = baseMiddle.length - 1; left >= 0; left--) {
+    if ((left & 31) === 0 && Date.now() > deadline) {
+      throw new SourceSyncError(
+        'DIFF_LIMIT_EXCEEDED',
+        'Diff exceeded its elapsed-time budget',
+        { action: 'Compare smaller source sections or establish a closer baseline.' },
+      );
+    }
+    for (let right = currentMiddle.length - 1; right >= 0; right--) {
+      const offset = left * columns + right;
+      matrix[offset] = baseMiddle[left].content === currentMiddle[right].content
+        ? matrix[(left + 1) * columns + right + 1] + 1
+        : Math.max(matrix[(left + 1) * columns + right], matrix[left * columns + right + 1]);
+    }
+  }
+
+  const operations = [];
+  let oldLine = 1;
+  let newLine = 1;
+  function push(type, oldValue, newValue) {
+    operations.push({ type, oldLine, newLine, oldValue, newValue });
+    if (type !== 'insert') oldLine++;
+    if (type !== 'delete') newLine++;
+  }
+  for (let index = 0; index < prefix; index++) push('equal', baseLines[index], currentLines[index]);
+
+  let left = 0;
+  let right = 0;
+  while (left < baseMiddle.length || right < currentMiddle.length) {
+    if (left < baseMiddle.length && right < currentMiddle.length &&
+        baseMiddle[left].content === currentMiddle[right].content) {
+      push('equal', baseMiddle[left++], currentMiddle[right++]);
+    } else if (right < currentMiddle.length &&
+        (left === baseMiddle.length || matrix[left * columns + right + 1] >= matrix[(left + 1) * columns + right])) {
+      push('insert', null, currentMiddle[right++]);
+    } else {
+      push('delete', baseMiddle[left++], null);
+    }
+  }
+
+  for (let index = suffix; index > 0; index--) {
+    const baseIndex = baseLines.length - index;
+    const currentIndex = currentLines.length - index;
+    push('equal', baseLines[baseIndex], currentLines[currentIndex]);
+  }
+  return operations;
+}
+
+function hunkRanges(operations, contextLines) {
+  const changed = [];
+  for (let index = 0; index < operations.length; index++) {
+    if (operations[index].type !== 'equal') changed.push(index);
+  }
+  if (changed.length === 0) return [];
+  const ranges = [];
+  let start = Math.max(0, changed[0] - contextLines);
+  let end = Math.min(operations.length, changed[0] + contextLines + 1);
+  for (const index of changed.slice(1)) {
+    const nextStart = Math.max(0, index - contextLines);
+    const nextEnd = Math.min(operations.length, index + contextLines + 1);
+    if (nextStart <= end) end = Math.max(end, nextEnd);
+    else {
+      ranges.push([start, end]);
+      start = nextStart;
+      end = nextEnd;
+    }
+  }
+  ranges.push([start, end]);
+  return ranges;
+}
+
+function renderHunk(operations, start, end) {
+  const selected = operations.slice(start, end);
+  const oldStart = selected[0]?.oldLine || 1;
+  const newStart = selected[0]?.newLine || 1;
+  const oldCount = selected.filter((entry) => entry.type !== 'insert').length;
+  const newCount = selected.filter((entry) => entry.type !== 'delete').length;
+  const lines = [`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`];
+  for (const entry of selected) {
+    const value = entry.type === 'insert' ? entry.newValue : entry.oldValue;
+    const prefix = entry.type === 'insert' ? '+' : (entry.type === 'delete' ? '-' : ' ');
+    lines.push(prefix + value.content);
+    if (entry.type !== 'equal' && value.terminator === 'none') {
+      lines.push('\\ No newline at end of file');
+    }
+  }
+  return lines.join('\n');
+}
+
+export function createBoundedLineDiff(baseSource, currentSource, options = {}) {
+  const maxSourceBytes = options.maxSourceBytes ?? MAX_BASELINE_BYTES;
+  const maxLines = options.maxLines ?? MAX_DIFF_LINES;
+  const maxWork = options.maxWork ?? MAX_DIFF_WORK;
+  const maxElapsedMs = options.maxElapsedMs ?? 50;
+  const contextLines = options.contextLines ?? 3;
+  const maxHunks = options.maxHunks ?? 20;
+  const maxCharacters = options.maxCharacters ?? (32 * 1024);
+  const baseBytes = sourceByteLength(baseSource);
+  const currentBytes = sourceByteLength(currentSource);
+  if (baseBytes > maxSourceBytes || currentBytes > maxSourceBytes) {
+    throw new SourceSyncError(
+      'DIFF_LIMIT_EXCEEDED',
+      `Diff inputs exceed the ${maxSourceBytes} byte per-source limit`,
+      { action: 'Use bounded source reads to compare the relevant region.' },
+    );
+  }
+
+  const baseLines = parseLines(baseSource);
+  const currentLines = parseLines(currentSource);
+  if (baseLines.length > maxLines || currentLines.length > maxLines) {
+    throw new SourceSyncError(
+      'DIFF_LIMIT_EXCEEDED',
+      `Diff inputs exceed the ${maxLines} line per-source limit`,
+      { action: 'Use bounded source reads to compare the relevant region.' },
+    );
+  }
+
+  const operations = createOperations(baseLines, currentLines, maxWork, Date.now() + maxElapsedMs);
+  const lineEndingChanges = [];
+  let totalLineEndingChanges = 0;
+  let addedLines = 0;
+  let deletedLines = 0;
+  for (const entry of operations) {
+    if (entry.type === 'insert') addedLines++;
+    if (entry.type === 'delete') deletedLines++;
+    if (entry.type === 'equal' && entry.oldValue.terminator !== entry.newValue.terminator) {
+      totalLineEndingChanges++;
+      if (lineEndingChanges.length < 100) {
+        lineEndingChanges.push({
+          oldLine: entry.oldLine,
+          newLine: entry.newLine,
+          oldTerminator: entry.oldValue.terminator,
+          newTerminator: entry.newValue.terminator,
+        });
+      }
+    }
+  }
+
+  const ranges = hunkRanges(operations, contextLines);
+  const rendered = [];
+  let characters = 0;
+  let truncated = ranges.length > maxHunks;
+  for (const [start, end] of ranges.slice(0, maxHunks)) {
+    const hunk = renderHunk(operations, start, end);
+    const separator = rendered.length === 0 ? 0 : 1;
+    if (characters + separator + hunk.length > maxCharacters) {
+      truncated = true;
+      break;
+    }
+    rendered.push(hunk);
+    characters += separator + hunk.length;
+  }
+
+  return {
+    diff: rendered.join('\n'),
+    baseLineCount: baseLines.length,
+    currentLineCount: currentLines.length,
+    addedLines,
+    deletedLines,
+    lineEndingChanges,
+    totalLineEndingChanges,
+    lineEndingChangesTruncated: totalLineEndingChanges > lineEndingChanges.length,
+    hunkCount: rendered.length,
+    totalHunks: ranges.length,
+    truncated,
+    limits: { maxSourceBytes, maxLines, maxWork, maxElapsedMs, contextLines, maxHunks, maxCharacters },
+  };
+}

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -122,7 +122,7 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
     name: 'x1pen',
     version: '0.8.1',
     automationApiVersion: 2,
-    features: ['automation.core', 'automation.run-recovery', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
+    features: ['automation.core', 'automation.run-recovery', 'automation.source-sync', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
   });
   assert.equal(ready.capabilities.debugger.available, true);
   assert.equal(ready.capabilities.debugger.version, 2);
@@ -188,12 +188,13 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   };
   const loaded = await page.evaluate((value) => {
     const current = window.X1PenAutomation.getProgram();
-    return window.X1PenAutomation.setProgram(value, current.revision);
+    return window.X1PenAutomation.setProgram(value, current.revision, current.revisionEpoch);
   }, program);
   assert.equal(loaded.basic, program.basic);
   assert.equal(loaded.sourceMode, program.sourceMode);
   assert.equal(loaded.revision, 1);
   assert.equal(typeof loaded.instanceId, 'string');
+  assert.equal(typeof loaded.revisionEpoch, 'string');
 
   const validation = await page.evaluate(() => window.X1PenAutomation.validate());
   assert.equal(validation.ok, true);
@@ -606,7 +607,7 @@ test('keyboard input changes captured guest screens for character entry and PRES
       ].join('\n'),
       asm: '',
       slang: '',
-    }, current.revision);
+    }, current.revision, current.revisionEpoch);
     const validation = await api.validate();
     if (!validation.ok) throw new Error('Acceptance program did not validate');
     const run = await api.run();
@@ -654,7 +655,11 @@ test('pad input drives guest JOY edges and independent ports in captured screens
     const loadAndRun = async (basic) => {
       api.releasePads();
       const current = api.getProgram();
-      await api.setProgram({ sourceMode: 'basic+asm', basic, asm: '', slang: '' }, current.revision);
+      await api.setProgram(
+        { sourceMode: 'basic+asm', basic, asm: '', slang: '' },
+        current.revision,
+        current.revisionEpoch,
+      );
       const validation = await api.validate();
       if (!validation.ok) throw new Error('Pad acceptance program did not validate');
       const run = await api.run();
@@ -771,16 +776,85 @@ test('automation program updates persist across page reloads', { timeout: 60_000
 
 test('revision conflicts prevent stale AI updates', async () => {
   const result = await page.evaluate(async () => {
-    const stale = window.X1PenAutomation.getProgram().revision;
+    const stale = window.X1PenAutomation.getProgram();
     await window.X1PenAutomation.setProgram({ sourceMode: 'basic+asm', basic: '10 PRINT "HUMAN"' });
     try {
-      await window.X1PenAutomation.setProgram({ sourceMode: 'basic+asm', basic: '10 PRINT "AI"' }, stale);
+      await window.X1PenAutomation.setProgram(
+        { sourceMode: 'basic+asm', basic: '10 PRINT "AI"' },
+        stale.revision,
+        stale.revisionEpoch,
+      );
       return null;
     } catch (error) {
-      return error.message;
+      return {
+        message: error.message,
+        code: error.code,
+        expectedRevision: error.expectedRevision,
+        currentRevision: error.currentRevision,
+        revisionEpoch: error.currentRevisionEpoch,
+        source: window.X1PenAutomation.getProgram().basic,
+      };
     }
   });
-  assert.match(result, /Revision conflict/);
+  assert.match(result.message, /Revision conflict/);
+  assert.equal(result.code, 'REVISION_MISMATCH');
+  assert.equal(result.expectedRevision + 1, result.currentRevision);
+  assert.equal(typeof result.revisionEpoch, 'string');
+  assert.equal(result.source, '10 PRINT "HUMAN"');
+});
+
+test('reload epoch prevents colliding stale revisions from mutating source', async () => {
+  await page.reload();
+  await page.evaluate(() => window.X1PenAutomation.ready());
+  const stale = await page.evaluate(() => window.X1PenAutomation.getProgram());
+  await page.evaluate(() => window.X1PenAutomation.setProgram({
+    sourceMode: 'basic+asm', basic: '10 PRINT "HUMAN"',
+  }));
+  await page.reload();
+  await page.evaluate(() => window.X1PenAutomation.ready());
+
+  const result = await page.evaluate(async (baseline) => {
+    const before = window.X1PenAutomation.getProgram();
+    try {
+      await window.X1PenAutomation.setProgram(
+        { sourceMode: 'basic+asm', basic: '10 PRINT "STALE AI"' },
+        baseline.revision,
+        baseline.revisionEpoch,
+      );
+      return null;
+    } catch (error) {
+      return {
+        code: error.code,
+        before,
+        after: window.X1PenAutomation.getProgram(),
+        observedEpoch: error.currentRevisionEpoch,
+      };
+    }
+  }, stale);
+  assert.equal(result.code, 'REVISION_EPOCH_MISMATCH');
+  assert.equal(result.before.instanceId, stale.instanceId);
+  assert.notEqual(result.before.revisionEpoch, stale.revisionEpoch);
+  assert.equal(result.before.revision, stale.revision);
+  assert.equal(result.observedEpoch, result.before.revisionEpoch);
+  assert.equal(result.after.basic, '10 PRINT "HUMAN"');
+});
+
+test('revision-only guarded writes fail closed with migration guidance', async () => {
+  const result = await page.evaluate(async () => {
+    const current = window.X1PenAutomation.getProgram();
+    try {
+      await window.X1PenAutomation.setProgram(
+        { sourceMode: 'basic+asm', basic: '10 PRINT "NO EPOCH"' },
+        current.revision,
+      );
+      return null;
+    } catch (error) {
+      return { code: error.code, action: error.action, after: window.X1PenAutomation.getProgram().basic };
+    }
+  });
+  assert.equal(result.code, 'REVISION_EPOCH_REQUIRED');
+  assert.match(result.action, /expectedRevisionEpoch/);
+  assert.equal(result.after, '10 PRINT "HUMAN"');
 });
 
 test('connection state and AI interaction lock are visible', async () => {
@@ -1314,7 +1388,7 @@ test('embedded M8A data assembles and draws into graphics VRAM', { timeout: 60_0
           '  LOOP VSYNC1();',
           'END;',
         ].join('\n'),
-      }, current.revision);
+      }, current.revision, current.revisionEpoch);
       validation = await api.validate();
       if (!validation.ok) {
         throw new Error(`Embedded M8A validation failed: ${JSON.stringify(validation.diagnostics)}`);

--- a/tests/x1pen_bridge_test.mjs
+++ b/tests/x1pen_bridge_test.mjs
@@ -67,9 +67,13 @@ test('bridge pairs an extension and routes commands to one X1Pen tab', async () 
   const socket = await connectExtension(bridge);
   socket.send(JSON.stringify({
     type: 'sessions',
-    sessions: [{ sessionId: 'tab-a', title: 'X1Pen A', url: 'https://example.test/x1pen', active: true, revision: 4 }],
+    sessions: [{
+      sessionId: 'tab-a', title: 'X1Pen A', url: 'https://example.test/x1pen',
+      active: true, revision: 4, revisionEpoch: 'epoch-a',
+    }],
   }));
   await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(bridge.listSessions()[0].revisionEpoch, 'epoch-a');
 
   const commandMessage = waitForMessage(socket, (message) => message.type === 'command');
   const commandPromise = bridge.sendCommand('getProgram');
@@ -93,7 +97,7 @@ test('bridge negotiates component metadata and computes effective capabilities',
     extensionVersion: '1.3.0',
     connector: {
       name: 'x1pen-connector', version: '1.3.0', protocolVersion: 2,
-      features: ['automation.core', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
+      features: ['automation.core', 'automation.source-sync', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
     },
   });
   assert.equal(socket.pairedMessage.protocolVersion, 2);
@@ -102,10 +106,10 @@ test('bridge negotiates component metadata and computes effective capabilities',
   socket.send(JSON.stringify({
     type: 'sessions',
     sessions: [{
-      sessionId: 'tab-a', title: 'X1Pen', revision: 1,
+      sessionId: 'tab-a', title: 'X1Pen', revision: 1, revisionEpoch: 'epoch-a',
       x1pen: {
         version: '0.8.0', automationApiVersion: 2,
-        features: ['automation.core', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
+        features: ['automation.core', 'automation.source-sync', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
       },
     }],
   }));
@@ -117,6 +121,8 @@ test('bridge negotiates component metadata and computes effective capabilities',
   assert.equal(info.compatibility.capabilities['debugger.vram'].state, 'available');
   const [session] = bridge.listSessions();
   assert.equal(session.x1pen.version, '0.8.0');
+  assert.equal(session.revisionEpoch, 'epoch-a');
+  assert.equal(session.compatibility.capabilities['automation.source-sync'].available, true);
   assert.equal(session.compatibility.capabilities['debugger.cpu'].available, true);
 });
 

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -42,6 +42,10 @@ function createAutomationApi() {
       },
     }),
     getProgram: () => ({ revision: 1 }),
+    setProgram: async (program, expectedRevision, expectedRevisionEpoch) => {
+      calls.push({ setProgram: { program, expectedRevision, expectedRevisionEpoch } });
+      return { ...program, revision: expectedRevision + 1, revisionEpoch: expectedRevisionEpoch };
+    },
     run: async (options) => {
       calls.push({ run: options });
       return { ok: false, code: 'RUN_IN_PROGRESS', retryable: true, retryAfterMs: 500 };
@@ -103,6 +107,19 @@ test('page bridge allowlists debugger operations and retries Run setup races', a
   globalThis.window = { X1PenAutomation: api };
 
   assert.deepEqual(await invokeX1PenInPage('getProgram', {}), { revision: 1 });
+  const updated = await invokeX1PenInPage('setProgram', {
+    program: { sourceMode: 'basic+asm', basic: '10 END' },
+    expectedRevision: 1,
+    expectedRevisionEpoch: 'epoch-a',
+  });
+  assert.equal(updated.revisionEpoch, 'epoch-a');
+  assert.deepEqual(calls.at(-1), {
+    setProgram: {
+      program: { sourceMode: 'basic+asm', basic: '10 END' },
+      expectedRevision: 1,
+      expectedRevisionEpoch: 'epoch-a',
+    },
+  });
   const paused = await invokeX1PenInPage('debuggerPause', {});
   assert.equal(paused.runState, 'paused');
   assert.deepEqual(calls.filter((call) => call === 'pause'), ['pause', 'pause']);
@@ -110,7 +127,7 @@ test('page bridge allowlists debugger operations and retries Run setup races', a
     { locked: true, label: 'AI is pausing the debugger...' },
     { locked: false, label: undefined },
   ]);
-  assert.deepEqual(timeline, ['lock:on', 'pause:done', 'lock:off']);
+  assert.deepEqual(timeline.slice(-3), ['lock:on', 'pause:done', 'lock:off']);
 
   const stepped = await invokeX1PenInPage('debuggerStep', { count: 3 });
   assert.equal(stepped.stepsExecuted, 3);
@@ -297,11 +314,33 @@ test('connector serializes machine-readable errors without copying arbitrary fie
   Object.assign(error, {
     code: 'X1PEN_UPDATE_REQUIRED', component: 'x1pen', feature: 'debugger.vram',
     requiredVersion: '0.8.0', action: 'Reload X1Pen', secret: 'discard',
+    expectedRevision: 3, currentRevision: 4,
+    expectedRevisionEpoch: 'epoch-a', currentRevisionEpoch: 'epoch-b',
+    instanceId: 'tab-a', metadataAvailable: true,
   });
   assert.deepEqual(serializeExtensionError(error), {
     message: 'Update X1Pen', code: 'X1PEN_UPDATE_REQUIRED', component: 'x1pen',
     feature: 'debugger.vram', requiredVersion: '0.8.0', action: 'Reload X1Pen',
+    expectedRevision: 3, currentRevision: 4,
+    expectedRevisionEpoch: 'epoch-a', currentRevisionEpoch: 'epoch-b',
+    instanceId: 'tab-a', metadataAvailable: true,
   });
+});
+
+test('connector bounds structured error strings and drops invalid revision fields', () => {
+  const error = new Error('M'.repeat(2_000));
+  Object.assign(error, {
+    code: 'C'.repeat(200), action: 'A'.repeat(1_000),
+    expectedRevision: -1, currentRevision: Number.POSITIVE_INFINITY,
+    expectedRevisionEpoch: 'E'.repeat(200),
+  });
+  const serialized = serializeExtensionError(error);
+  assert.equal(serialized.message.length, 1_024);
+  assert.equal(serialized.code.length, 128);
+  assert.equal(serialized.action.length, 512);
+  assert.equal(serialized.expectedRevision, undefined);
+  assert.equal(serialized.currentRevision, undefined);
+  assert.equal(serialized.expectedRevisionEpoch, undefined);
 });
 
 test('extension update waits for active operations before disconnecting and reloading', async () => {

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -55,6 +55,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'x1pen-compatibility.mjs',
       'x1pen-reference.mjs',
       'x1pen-server.mjs',
+      'x1pen-source-sync.mjs',
     ]);
 
     const installRoot = join(tempRoot, 'consumer');
@@ -78,6 +79,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       command: process.execPath,
       args: [serverPath],
       cwd: installRoot,
+      env: { ...process.env, X1PEN_BRIDGE_PORT: '0' },
       stderr: 'pipe',
     });
     client = new Client({ name: 'x1pen-package-test', version: '1.0.0' });
@@ -87,8 +89,9 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(client.getInstructions(), /x1pen_search_reference/);
 
     const tools = await client.listTools();
-    assert.equal(tools.tools.length, 29);
+    assert.equal(tools.tools.length, 30);
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
+    assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_diff_source'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_get_state'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_read_vram'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_search_reference'));
@@ -101,7 +104,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(info.pairingCode, /^\d{6}$/);
     assert.equal(info.components.mcp.version, '2.7.0');
     assert.deepEqual(info.components.mcp.features,
-      ['automation.core', 'automation.run-recovery', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram']);
+      ['automation.core', 'automation.run-recovery', 'automation.source-sync', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram']);
     assert.equal(info.components.connector, null);
 
     const reference = await client.callTool({

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -10,6 +10,7 @@ const initialProgram = {
   asm: '',
   slang: '',
   revision: 3,
+  revisionEpoch: 'epoch-a',
   instanceId: 'tab-a',
 };
 const calls = [];
@@ -85,12 +86,31 @@ const fakeBridge = {
     if (compatibilityFailure && method === compatibilityFailure.method) throw compatibilityFailure.error;
     if (method === 'getProgram') return clone(currentProgram);
     if (method === 'setProgram') {
+      if (params.expectedRevisionEpoch !== currentProgram.revisionEpoch) {
+        const error = new Error('Revision epoch conflict');
+        Object.assign(error, {
+          code: 'REVISION_EPOCH_MISMATCH', component: 'x1pen',
+          expectedRevision: params.expectedRevision,
+          expectedRevisionEpoch: params.expectedRevisionEpoch,
+          currentRevision: currentProgram.revision,
+          currentRevisionEpoch: currentProgram.revisionEpoch,
+          instanceId: currentProgram.instanceId,
+        });
+        throw error;
+      }
       if (params.expectedRevision !== currentProgram.revision) {
-        throw new Error(`Revision conflict: expected ${params.expectedRevision}, current ${currentProgram.revision}`);
+        const error = new Error(`Revision conflict: expected ${params.expectedRevision}, current ${currentProgram.revision}`);
+        Object.assign(error, {
+          code: 'REVISION_MISMATCH', component: 'x1pen',
+          expectedRevision: params.expectedRevision, currentRevision: currentProgram.revision,
+          currentRevisionEpoch: currentProgram.revisionEpoch, instanceId: currentProgram.instanceId,
+        });
+        throw error;
       }
       currentProgram = {
         ...normalizeProgram(params.program),
         revision: currentProgram.revision + 1,
+        revisionEpoch: currentProgram.revisionEpoch,
         instanceId: currentProgram.instanceId,
       };
       return clone(currentProgram);
@@ -216,6 +236,7 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_debug_step',
     'x1pen_debug_wait_for_pause',
     'x1pen_debug_write_vram',
+    'x1pen_diff_source',
     'x1pen_get_language_profile',
     'x1pen_get_program',
     'x1pen_get_reference',
@@ -395,6 +416,7 @@ test('get_program defaults to metadata only and excludes generated ASM', async (
     asm: generatedAsm,
     slang: 'main() BEGIN\n  PRINT("MCP");\nEND;',
     revision: 8,
+    revisionEpoch: 'epoch-a',
     instanceId: 'tab-a',
   };
 
@@ -404,8 +426,12 @@ test('get_program defaults to metadata only and excludes generated ASM', async (
   assert.equal(selected.asm, undefined);
   assert.deepEqual(selected.includedFields, []);
   assert.equal(selected.sections.asm.generated, true);
+  assert.equal(selected.revisionEpoch, 'epoch-a');
+  assert.match(selected.authoringHash, /^sha256-authoring-v1:[0-9a-f]{64}$/);
+  assert.match(selected.sections.slang.contentHash, /^sha256-utf8-v1:[0-9a-f]{64}$/);
+  assert.match(selected.sections.asm.generatedContentHash, /^sha256-utf8-v1:[0-9a-f]{64}$/);
   assert.equal(selected.sections.asm.lineCount, 20_000);
-  assert.ok(defaultResult.content[0].text.length < 500, 'metadata-only response must stay small even with huge generated ASM');
+  assert.ok(defaultResult.content[0].text.length < 1_500, 'metadata-only response must stay bounded even with huge generated ASM');
   assert.equal(defaultResult.structuredContent, undefined);
 
   const slangResult = await client.callTool({
@@ -451,7 +477,8 @@ test('get_source returns a bounded line range and protects generated ASM', async
   assert.equal(range.truncated, true);
 
   currentProgram = {
-    sourceMode: 'slang', basic: '', asm: 'generated', slang: 'main() BEGIN\nEND;', revision: 4, instanceId: 'tab-a',
+    sourceMode: 'slang', basic: '', asm: 'generated', slang: 'main() BEGIN\nEND;', revision: 4,
+    revisionEpoch: 'epoch-a', instanceId: 'tab-a',
   };
   const protectedResult = await client.callTool({
     name: 'x1pen_get_source',
@@ -486,19 +513,133 @@ test('search_source finds literal text with bounded context', async () => {
   assert.deepEqual(search.matches[0].context.map((line) => line.line), [1, 2, 3]);
 });
 
-test('set_program forwards expected revision but returns only a compact summary', async () => {
+test('diff_source compares a cached baseline with bounded hunks', async () => {
+  const baseline = jsonContent(await client.callTool({ name: 'x1pen_get_program', arguments: {} }));
+  const baseHash = baseline.sections.basic.contentHash;
+  currentProgram.basic = '10 PRINT "MCP"\n15 PRINT "USER"\n20 END';
+  currentProgram.revision++;
+
+  const result = jsonContent(await client.callTool({
+    name: 'x1pen_diff_source',
+    arguments: {
+      section: 'basic', baseHash, baseSourceMode: 'basic+asm',
+      baseRevisionEpoch: 'epoch-a', contextLines: 1,
+    },
+  }));
+  assert.equal(result.baseSourceOrigin, 'cache');
+  assert.equal(result.epochChanged, false);
+  assert.equal(result.addedLines, 1);
+  assert.equal(result.deletedLines, 0);
+  assert.match(result.diff, /\+15 PRINT "USER"/);
+  assert.equal(result.truncated, false);
+});
+
+test('diff_source resolves a cached baseline from an older epoch by full provenance', async () => {
+  const baseline = jsonContent(await client.callTool({ name: 'x1pen_get_program', arguments: {} }));
+  currentProgram = {
+    ...currentProgram,
+    basic: '10 PRINT "AFTER RELOAD"\n20 END',
+    revision: 3,
+    revisionEpoch: 'epoch-b',
+  };
+  const result = jsonContent(await client.callTool({
+    name: 'x1pen_diff_source',
+    arguments: {
+      section: 'basic', baseHash: baseline.sections.basic.contentHash,
+      baseSourceMode: 'basic+asm', baseRevisionEpoch: 'epoch-a',
+    },
+  }));
+  assert.equal(result.baseSourceOrigin, 'cache');
+  assert.equal(result.epochChanged, true);
+  assert.equal(result.baseRevisionEpoch, 'epoch-a');
+  assert.equal(result.currentRevisionEpoch, 'epoch-b');
+  assert.match(result.diff, /AFTER RELOAD/);
+});
+
+test('diff_source labels caller-attested and cross-epoch baselines', async () => {
+  const baseSource = initialProgram.basic;
+  const baseline = jsonContent(await client.callTool({ name: 'x1pen_get_program', arguments: {} }));
+  currentProgram = {
+    ...currentProgram,
+    basic: '10 PRINT "RELOADED"\n20 END',
+    revision: 3,
+    revisionEpoch: 'epoch-b',
+  };
+  const result = jsonContent(await client.callTool({
+    name: 'x1pen_diff_source',
+    arguments: {
+      section: 'basic', baseHash: baseline.sections.basic.contentHash,
+      baseSourceMode: 'basic+asm', baseRevisionEpoch: 'epoch-a', baseSource,
+    },
+  }));
+  assert.equal(result.baseSourceOrigin, 'caller-supplied');
+  assert.match(result.baseSourceAttestation, /self-consistency only/);
+  assert.equal(result.epochChanged, true);
+  assert.equal(result.currentRevisionEpoch, 'epoch-b');
+});
+
+test('diff_source reports unavailable and mode-mismatched baselines', async () => {
+  const missing = await client.callTool({
+    name: 'x1pen_diff_source',
+    arguments: {
+      section: 'basic', baseHash: `sha256-utf8-v1:${'0'.repeat(64)}`,
+      baseSourceMode: 'basic+asm', baseRevisionEpoch: 'missing',
+    },
+  });
+  assert.equal(jsonContent(missing).error.code, 'BASE_SNAPSHOT_UNAVAILABLE');
+
+  currentProgram.sourceMode = 'slang';
+  currentProgram.basic = '';
+  currentProgram.slang = 'main() BEGIN\nEND;';
+  const mismatch = await client.callTool({
+    name: 'x1pen_diff_source',
+    arguments: {
+      section: 'basic', baseHash: `sha256-utf8-v1:${'0'.repeat(64)}`,
+      baseSourceMode: 'basic+asm', baseRevisionEpoch: 'epoch-a',
+    },
+  });
+  assert.equal(jsonContent(mismatch).error.code, 'BASE_MODE_MISMATCH');
+});
+
+test('set_program forwards the guarded epoch and revision but returns only a compact summary', async () => {
   const result = await client.callTool({
     name: 'x1pen_set_program',
-    arguments: { sourceMode: 'basic+asm', basic: '10 PRINT "UPDATED"', expectedRevision: 3 },
+    arguments: {
+      sourceMode: 'basic+asm', basic: '10 PRINT "UPDATED"',
+      expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
   });
   const response = jsonContent(result);
   assert.equal(result.isError, undefined);
   assert.equal(calls.at(-1).method, 'setProgram');
   assert.equal(calls.at(-1).params.expectedRevision, 3);
+  assert.equal(calls.at(-1).params.expectedRevisionEpoch, 'epoch-a');
   assert.equal(calls.at(-1).params.program.basic, '10 PRINT "UPDATED"');
   assert.equal(response.revision, 4);
   assert.equal(response.basic, undefined);
   assert.equal(response.sections.basic.lineCount, 1);
+});
+
+test('set_program maps the exact legacy conflict message to bounded structured output', async () => {
+  compatibilityFailure = {
+    method: 'setProgram',
+    error: new Error('Revision conflict: expected 2, current 3'),
+  };
+  const result = await client.callTool({
+    name: 'x1pen_set_program',
+    arguments: {
+      sourceMode: 'basic+asm', basic: '10 END',
+      expectedRevision: 2, expectedRevisionEpoch: 'epoch-a',
+    },
+  });
+  const error = jsonContent(result).error;
+  assert.equal(error.code, 'REVISION_MISMATCH');
+  assert.equal(error.expectedRevision, 2);
+  assert.equal(error.conflictRevision, 3);
+  assert.equal(error.metadataAvailable, false);
+  assert.equal(error.observedMetadataAvailable, true);
+  assert.equal(error.observedRevisionEpoch, 'epoch-a');
+  assert.equal(error.current.basic, undefined);
 });
 
 test('apply_edits updates one section and preserves the other authoring source', async () => {
@@ -508,6 +649,7 @@ test('apply_edits updates one section and preserves the other authoring source',
     arguments: {
       section: 'basic',
       expectedRevision: 3,
+      expectedRevisionEpoch: 'epoch-a',
       edits: [
         { startLine: 1, deleteLineCount: 1, text: '10 PRINT "START"' },
         { startLine: 2, deleteLineCount: 1, text: '20 PRINT "EDITED"\n30 END' },
@@ -531,17 +673,22 @@ test('apply_edits rejects stale revisions and overlapping edits', async () => {
   const stale = await client.callTool({
     name: 'x1pen_apply_edits',
     arguments: {
-      section: 'basic', expectedRevision: 2, edits: [{ startLine: 1, deleteLineCount: 1, text: '10 END' }],
+      section: 'basic', expectedRevision: 2, expectedRevisionEpoch: 'epoch-a',
+      edits: [{ startLine: 1, deleteLineCount: 1, text: '10 END' }],
     },
   });
   assert.equal(stale.isError, true);
-  assert.match(stale.content[0].text, /Revision conflict/);
+  assert.equal(jsonContent(stale).error.code, 'REVISION_MISMATCH');
+  assert.equal(jsonContent(stale).error.expectedRevision, 2);
+  assert.equal(jsonContent(stale).error.observedRevision, 3);
+  assert.match(jsonContent(stale).error.current.authoringHash, /^sha256-authoring-v1:/);
 
   const overlapping = await client.callTool({
     name: 'x1pen_apply_edits',
     arguments: {
       section: 'basic',
       expectedRevision: 3,
+      expectedRevisionEpoch: 'epoch-a',
       edits: [
         { startLine: 1, deleteLineCount: 2, text: '10 END' },
         { startLine: 2, deleteLineCount: 1, text: '20 END' },
@@ -552,14 +699,32 @@ test('apply_edits rejects stale revisions and overlapping edits', async () => {
   assert.match(overlapping.content[0].text, /overlap/);
 });
 
+test('apply_edits rejects a colliding revision from another epoch', async () => {
+  const before = currentProgram.basic;
+  const result = await client.callTool({
+    name: 'x1pen_apply_edits',
+    arguments: {
+      section: 'basic', expectedRevision: 3, expectedRevisionEpoch: 'epoch-before-reload',
+      edits: [{ startLine: 1, deleteLineCount: 1, text: '10 PRINT "STALE"' }],
+    },
+  });
+  const error = jsonContent(result).error;
+  assert.equal(error.code, 'REVISION_EPOCH_MISMATCH');
+  assert.equal(error.expectedRevisionEpoch, 'epoch-before-reload');
+  assert.equal(error.observedRevisionEpoch, 'epoch-a');
+  assert.equal(currentProgram.basic, before);
+});
+
 test('apply_edits clears generated ASM when editing SLANG', async () => {
   currentProgram = {
-    sourceMode: 'slang', basic: '', asm: 'generated asm', slang: 'main() BEGIN\nEND;', revision: 9, instanceId: 'tab-a',
+    sourceMode: 'slang', basic: '', asm: 'generated asm', slang: 'main() BEGIN\nEND;', revision: 9,
+    revisionEpoch: 'epoch-a', instanceId: 'tab-a',
   };
   const result = await client.callTool({
     name: 'x1pen_apply_edits',
     arguments: {
-      section: 'slang', expectedRevision: 9, edits: [{ startLine: 2, deleteLineCount: 0, text: '  PRINT("MCP");' }],
+      section: 'slang', expectedRevision: 9, expectedRevisionEpoch: 'epoch-a',
+      edits: [{ startLine: 2, deleteLineCount: 0, text: '  PRINT("MCP");' }],
     },
   });
   const response = jsonContent(result);

--- a/tests/x1pen_source_sync_test.mjs
+++ b/tests/x1pen_source_sync_test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+import {
+  SourceBaselineCache,
+  contentHash,
+  createBoundedLineDiff,
+  sourceIdentities,
+} from '../mcp/x1pen-source-sync.mjs';
+
+test('content hashes use exact UTF-8 bytes without newline normalization', () => {
+  for (const source of ['', 'A', '日本語', 'A\n', 'A\r\n', 'A\0B']) {
+    const expected = createHash('sha256').update(Buffer.from(source, 'utf8')).digest('hex');
+    assert.equal(contentHash(source), `sha256-utf8-v1:${expected}`);
+  }
+  assert.notEqual(contentHash('A\n'), contentHash('A\r\n'));
+});
+
+test('SLANG generated ASM does not change authoringHash', () => {
+  const snapshot = {
+    sourceMode: 'slang', basic: '', asm: 'ORG $100\nRET', slang: 'main() BEGIN\nEND;',
+    revision: 1, revisionEpoch: 'epoch-a', instanceId: 'tab-a',
+  };
+  const first = sourceIdentities(snapshot);
+  const generatedChanged = sourceIdentities({ ...snapshot, asm: 'ORG $200\nRET', revision: 2 });
+  const authoringChanged = sourceIdentities({ ...snapshot, slang: 'main() BEGIN\n  PRINT("X");\nEND;', revision: 2 });
+  assert.equal(first.authoringHash, generatedChanged.authoringHash);
+  assert.notEqual(first.sections.asm.generatedContentHash, generatedChanged.sections.asm.generatedContentHash);
+  assert.notEqual(first.authoringHash, authoringChanged.authoringHash);
+});
+
+test('bounded diff reports line content and line-ending-only changes deterministically', () => {
+  const content = createBoundedLineDiff('A\r\nB', 'A\nX\nB\n', { contextLines: 1 });
+  assert.equal(content.addedLines, 1);
+  assert.equal(content.deletedLines, 0);
+  assert.match(content.diff, /\+X/);
+  assert.deepEqual(content.lineEndingChanges, [
+    { oldLine: 1, newLine: 1, oldTerminator: 'crlf', newTerminator: 'lf' },
+    { oldLine: 2, newLine: 3, oldTerminator: 'none', newTerminator: 'lf' },
+  ]);
+  assert.equal(content.truncated, false);
+
+  const finalNewline = createBoundedLineDiff('A', 'A\n');
+  assert.equal(finalNewline.diff, '');
+  assert.equal(finalNewline.totalLineEndingChanges, 1);
+  assert.equal(finalNewline.lineEndingChanges[0].oldTerminator, 'none');
+  assert.equal(finalNewline.lineEndingChanges[0].newTerminator, 'lf');
+});
+
+test('bounded diff fails before excessive quadratic work', () => {
+  const left = Array.from({ length: 600 }, (_, index) => `A${index}`).join('\n');
+  const right = Array.from({ length: 600 }, (_, index) => `B${index}`).join('\n');
+  assert.throws(
+    () => createBoundedLineDiff(left, right),
+    (error) => error.code === 'DIFF_LIMIT_EXCEEDED',
+  );
+});
+
+test('baseline cache is epoch-aware, bounded, and expires entries', () => {
+  let now = 1_000;
+  const cache = new SourceBaselineCache({
+    maxEntryBytes: 20, maxTotalBytes: 20, maxEntries: 3, ttlMs: 100,
+    now: () => now,
+  });
+  const snapshot = {
+    sourceMode: 'basic+asm', basic: '10 END', asm: '', slang: '',
+    revision: 1, revisionEpoch: 'epoch-a', instanceId: 'tab-a',
+  };
+  cache.rememberSnapshot(snapshot);
+  const hash = contentHash(snapshot.basic);
+  assert.equal(cache.get({
+    instanceId: 'tab-a', revisionEpoch: 'epoch-a', sourceMode: 'basic+asm',
+    section: 'basic', role: 'authoring', hash,
+  }).source, snapshot.basic);
+  assert.equal(cache.get({
+    instanceId: 'tab-a', revisionEpoch: 'epoch-b', sourceMode: 'basic+asm',
+    section: 'basic', role: 'authoring', hash,
+  }), null);
+  now += 101;
+  assert.equal(cache.get({
+    instanceId: 'tab-a', revisionEpoch: 'epoch-a', sourceMode: 'basic+asm',
+    section: 'basic', role: 'authoring', hash,
+  }), null);
+});


### PR DESCRIPTION
## Summary
- add epoch-bound, machine-readable source conflict errors for #87
- add stable source/authoring hashes, bounded ephemeral baselines, and `x1pen_diff_source` for #88
- preserve structured conflict metadata across X1Pen, Connector, bridge, and MCP boundaries
- document compare-before-retry behavior and keep all release versions unchanged

## Verification
- `./build.sh`
- full browser automation suite: 16 passed
- MCP/bridge/extension/reference/source-sync suites: 86 passed
- final focused regression suite: 53 passed
- packed MCP install/serve test: passed
- post-implementation Secretary plan review round 3: APPROVED (Claude Opus 5, normal policy, no host override)

Closes #87
Closes #88