### PR TITLE
Validate SLANG runtime argument counts

### DIFF
--- a/assets/slang_runtime/core.asm
+++ b/assets/slang_runtime/core.asm
@@ -474,6 +474,7 @@ RET
 
 ; @name RCALL
 ; @alias CALL
+; @param_count 1
 ; @calls GETREG
 PUSH IY
 LD DE,.call1
@@ -497,6 +498,7 @@ RET
 
 
 ; @name GETREG
+; @param_count 0
 PUSH HL
 LD (_IY), IY
 LD (_IX), IX
@@ -616,5 +618,3 @@ ret           ; そのまま戻る
 ; 入れ替える
 ex de,hl
 ret
-
-

--- a/assets/slang_runtime/libx1_base.asm
+++ b/assets/slang_runtime/libx1_base.asm
@@ -20,6 +20,7 @@ JP !VSYNC_PROC
 
 
 ; @name VSYNC
+; @param_count 1
 ; @calls VSYNC_CHECK
 ; HL = WAIT COUNT
 VSYNC_LOOP:
@@ -103,4 +104,3 @@ RET	NZ
 ; INC	C
 LD	(CTCADR),BC
 RET
-

--- a/assets/slang_runtime/runtime.asm
+++ b/assets/slang_runtime/runtime.asm
@@ -474,6 +474,7 @@ RET
 
 ; @name RCALL
 ; @alias CALL
+; @param_count 1
 ; @calls GETREG
 PUSH IY
 LD DE,.call1
@@ -497,6 +498,7 @@ RET
 
 
 ; @name GETREG
+; @param_count 0
 PUSH HL
 LD (_IY), IY
 LD (_IX), IX
@@ -616,5 +618,3 @@ ret           ; そのまま戻る
 ; 入れ替える
 ex de,hl
 ret
-
-

--- a/html/x1pen_slang_compiler.js
+++ b/html/x1pen_slang_compiler.js
@@ -2148,7 +2148,7 @@
             var bn = builtinFuncs[bi][0], bpc = builtinFuncs[bi][1];
             var bpt = []; for (var j = 0; j < bpc; j++) bpt.push(SlangType.Word);
             var bsym = _symbols.define(bn, SymbolKind.MachineFunction, FunctionType(SlangType.Word, bpt));
-            bsym.isGlobal = true; bsym.asmLabel = bn;
+            bsym.isGlobal = true; bsym.asmLabel = bn; bsym.isRuntimeBuiltin = true;
         }
 
         // ---- Visit helpers ----
@@ -4059,9 +4059,24 @@
 
             var isUserFunc = funcSym && funcSym.kind === SymbolKind.Function;
             var isMachine = !isUserFunc;
+            var runtimeFunc = (isMachine && funcName && _irRm
+                && (!funcSym || funcSym.isRuntimeBuiltin)) ? _irRm.getFunction(funcName) : null;
+            var runtimeParamCount = runtimeFunc ? runtimeFunc.paramCount : null;
+            var runtimeArityMismatch = runtimeParamCount !== null
+                && node.arguments.length !== runtimeParamCount;
+            if (runtimeArityMismatch && diagnostics) {
+                diagnostics.error("Runtime function '" + funcName + "' expected "
+                    + runtimeParamCount + (runtimeParamCount === 1 ? ' argument' : ' arguments')
+                    + ', got ' + node.arguments.length, node.span);
+            }
             var machineParamCount = null;
             if (isMachine) {
-                if (funcSym && funcSym.type && funcSym.type.typeClass === 'Function')
+                // Keep rejected calls internally consistent: their IR retains the
+                // number of values actually pushed. Code generation is skipped by
+                // compile() when the diagnostic above is present.
+                if (runtimeArityMismatch)
+                    machineParamCount = node.arguments.length;
+                else if (funcSym && funcSym.type && funcSym.type.typeClass === 'Function')
                     machineParamCount = funcSym.type.parameterTypes.length;
                 else
                     machineParamCount = node.arguments.length;
@@ -4489,7 +4504,7 @@
     // ================================================================
     function RuntimeFunction() {
         return {
-            name: '', paramCount: 0, dependencies: [], code: '',
+            name: '', paramCount: null, dependencies: [], code: '',
             initCode: null, libName: null, sourceFile: '', loadOrder: 0,
             works: null, worksAlignment: 0, calleeCleanup: false, aliases: [],
         };

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1026,6 +1026,65 @@ test('SLANG TATTR writes only the current visible text attribute cell', { timeou
   }
 });
 
+test('SLANG runtime arity is rejected by Validate while valid VSYNC still runs', { timeout: 60_000 }, async () => {
+  const probeAddress = 0x4000;
+  const setSlang = (source) => page.evaluate(async (slang) => {
+    const api = window.X1PenAutomation;
+    const current = api.getProgram();
+    return api.setProgram({
+      sourceMode: 'slang', basic: '', asm: '', slang,
+    }, current.revision, current.revisionEpoch);
+  }, source);
+
+  try {
+    await setSlang([
+      'MAIN() BEGIN',
+      '  VSYNC();',
+      'END;',
+    ].join('\n'));
+    const invalid = await page.evaluate(async () => ({
+      validation: await window.X1PenAutomation.validate(),
+      program: window.X1PenAutomation.getProgram(),
+    }));
+    assert.equal(invalid.validation.ok, false);
+    assert.equal(invalid.validation.diagnostics.length, 1);
+    assert.equal(invalid.validation.diagnostics[0].kind, 'slang');
+    assert.equal(invalid.validation.diagnostics[0].line, 2);
+    assert.match(invalid.validation.diagnostics[0].message, /expected 1 argument, got 0/);
+    assert.equal(invalid.program.asm, '');
+
+    await setSlang([
+      'VSYNC_PROC() BEGIN',
+      'END;',
+      'MAIN() BEGIN',
+      '  MEM[$4000]=$5A;',
+      '  VSYNC(1);',
+      '  MEM[$4001]=$A5;',
+      '  LOOP { }',
+      'END;',
+    ].join('\n'));
+    const valid = await page.evaluate(async () => {
+      const api = window.X1PenAutomation;
+      const validation = await api.validate();
+      if (!validation.ok) {
+        throw new Error(`VSYNC validation failed: ${JSON.stringify(validation.diagnostics)}`);
+      }
+      const run = await api.run();
+      if (!run.ok) throw new Error(`VSYNC run failed: ${JSON.stringify(run)}`);
+      return { validation, run };
+    });
+    assert.equal(valid.validation.ok, true);
+    assert.equal(valid.run.ok, true);
+    assert.equal(valid.run.sourceMode, 'slang');
+    await page.waitForFunction((address) => {
+      const bytes = window.X1PenAutomation.debugger.readMemory(address, 2).bytes;
+      return bytes[0] === 0x5A && bytes[1] === 0xA5;
+    }, probeAddress, { timeout: 5000 });
+  } finally {
+    await page.evaluate(() => window.Module._js_xmil_reset());
+  }
+});
+
 test('automation operations are serialized and stale source modes are cleared', async () => {
   const programs = await page.evaluate(async () => {
     const first = window.X1PenAutomation.setProgram({ sourceMode: 'asm', asm: 'ORG $100\nRET' });

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -535,6 +535,243 @@ test('SLANG catalogs cover the exact runtime and include files loaded by X1Pen',
   );
 });
 
+test('SLANG runtime arity metadata matches the reviewed VFS and compiler builtin catalog', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const x1penSource = readFileSync(join(repoRoot, 'html/x1pen.js'), 'utf8');
+  const compilerSource = readFileSync(join(repoRoot, 'html/x1pen_slang_compiler.js'), 'utf8');
+  const runtimeFiles = extractVfsFiles(x1penSource, 'runtimeFiles');
+  const manager = compiler._RuntimeManager();
+  const definitions = new Map();
+
+  for (const filename of runtimeFiles) {
+    const source = readFileSync(join(repoRoot, 'assets/slang_runtime', filename), 'utf8');
+    const functions = compiler._RuntimeParser.parse(source, filename);
+    manager.loadFromString(source, filename);
+    for (const func of functions) {
+      const key = func.name.toLowerCase();
+      if (!definitions.has(key)) definitions.set(key, []);
+      definitions.get(key).push(func);
+    }
+  }
+
+  const nullable = compiler._RuntimeParser.parse([
+    '; @name LEGACY',
+    '; @alias LEGACY_ALIAS',
+    'RET',
+    '; @name EXPLICIT_ZERO',
+    '; @param_count 0',
+    'RET',
+  ].join('\n'), 'arity-probe.asm');
+  assert.equal(nullable[0].paramCount, null);
+  assert.equal(nullable[0].aliases.join(','), 'LEGACY_ALIAS');
+  assert.equal(nullable[1].paramCount, 0);
+
+  const expectedSignatures = new Map([
+    ['ABS', 1],
+    ['ADECI', 0],
+    ['AT_VRCALC', 1],
+    ['BEEP', 0],
+    ['GETKY_DOINIT', 0],
+    ['GETL', 1],
+    ['GETLIN', 2],
+    ['GETREG', 0],
+    ['INKEY', 1],
+    ['INPUT', 0],
+    ['LINPUT', 2],
+    ['lLOC1', 0],
+    ['LOCATE', 2],
+    ['MULHLDE', 2],
+    ['P10', 1],
+    ['P10to5', 1],
+    ['P10toN', 2],
+    ['PCGDEFS', 3],
+    ['PCR', 1],
+    ['PCR1', 1],
+    ['PCRONE', 0],
+    ['PHEX', 1],
+    ['PHEX2', 1],
+    ['PHEX4', 1],
+    ['PRMODE', 1],
+    ['PRT', 1],
+    ['PSIGN', 1],
+    ['PSPC', 1],
+    ['PSTR', 2],
+    ['PSTR2', 2],
+    ['PTAB', 1],
+    ['RBIT', 2],
+    ['RCALL', 1],
+    ['RESET', 2],
+    ['RND', 1],
+    ['RSET', 2],
+    ['sASC', 0],
+    ['sBOOT', 0],
+    ['sBRKEY', 0],
+    ['sCAP', 0],
+    ['SCREEN', 2],
+    ['sCSR', 0],
+    ['sCTRL', 0],
+    ['SEX', 1],
+    ['sFGETL', 0],
+    ['sFLGET', 0],
+    ['sGETKY', 0],
+    ['sGETL', 0],
+    ['SGN', 1],
+    ['sHEX', 0],
+    ['sHLHEX', 0],
+    ['sINKBF', 0],
+    ['sINKEY', 0],
+    ['sKYBFC', 0],
+    ['sLOC', 0],
+    ['sLPRNT', 0],
+    ['sLPTOF', 0],
+    ['sLPTON', 0],
+    ['sLTNL', 0],
+    ['sMPRNT', 0],
+    ['sMSG', 0],
+    ['sMSX', 0],
+    ['sNL', 0],
+    ['sPAUSE', 0],
+    ['sPCLR', 0],
+    ['sPRINT', 0],
+    ['sPRINTS', 0],
+    ['sPRNT0', 0],
+    ['SRAND', 1],
+    ['sSCRN', 0],
+    ['sSYSTEM', 0],
+    ['STICK', 1],
+    ['STOP', 0],
+    ['sWIDCH', 0],
+    ['sWORK', 0],
+    ['sZPRINT', 0],
+    ['TATTR', 1],
+    ['VSYNC', 1],
+    ['VTOS', 2],
+    ['WIDTH', 1],
+  ].map(([name, count]) => [name.toLowerCase(), count]));
+  const actualSignatures = new Map();
+  for (const func of new Set(Object.values(manager.functions))) {
+    if (func.paramCount !== null) actualSignatures.set(func.name.toLowerCase(), func.paramCount);
+  }
+  assert.deepEqual([...actualSignatures].sort(), [...expectedSignatures].sort());
+
+  for (const [name, funcs] of definitions) {
+    const explicitCounts = new Set(funcs
+      .filter((func) => func.paramCount !== null)
+      .map((func) => func.paramCount));
+    assert.ok(explicitCounts.size <= 1,
+      `${name} has conflicting explicit @param_count values across loaded runtime files`);
+  }
+
+  const builtinBlock = compilerSource.match(/var builtinFuncs = \[([\s\S]*?)\n\s*\];/);
+  assert.ok(builtinBlock);
+  const builtins = [...builtinBlock[1].matchAll(/\['([^']+)',(\d+)\]/g)]
+    .map((match) => [match[1], Number(match[2])]);
+  assert.equal(builtins.length, 21);
+  for (const [name, count] of builtins) {
+    const runtime = manager.getFunction(name);
+    assert.ok(runtime, `${name} compiler builtin must resolve through the bundled runtime`);
+    assert.notEqual(runtime.paramCount, null, `${name} runtime must explicitly declare its arity`);
+    assert.equal(runtime.paramCount, count, `${name} compiler/runtime arity must agree`);
+  }
+});
+
+test('SLANG runtime arity validation rejects typed mismatches and preserves legacy calls', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const vfs = loadSlangVfs();
+  const options = {
+    defaultOrg: 0x100,
+    codeReadonly: false,
+    defines: { ENV_TYPE: 1 },
+  };
+  const compile = (source, customVfs = vfs) => compiler.compile(source, customVfs, options);
+  const assertArityError = (source, expected) => {
+    const result = compile(source);
+    assert.equal(result.asm, '');
+    assert.equal(result.errors.length, 1, JSON.stringify(result.errors));
+    assert.equal(result.errors[0].severity, 'Error');
+    assert.equal(result.errors[0].message, expected);
+    assert.ok(result.errors[0].span.start.line >= 1);
+  };
+
+  assertArityError(
+    'MAIN() BEGIN\n  VSYNC();\nEND;',
+    "Runtime function 'VSYNC' expected 1 argument, got 0",
+  );
+  assertArityError(
+    'MAIN() BEGIN\n  VSYNC(1,2);\nEND;',
+    "Runtime function 'VSYNC' expected 1 argument, got 2",
+  );
+  assertArityError(
+    'MAIN() BEGIN\n  BEEP(1);\nEND;',
+    "Runtime function 'BEEP' expected 0 arguments, got 1",
+  );
+  assertArityError(
+    'MAIN() BEGIN\n  BIT(1);\nEND;',
+    "Runtime function 'BIT' expected 2 arguments, got 1",
+  );
+  assertArityError(
+    'MAIN() BEGIN\n  CALL();\nEND;',
+    "Runtime function 'CALL' expected 1 argument, got 0",
+  );
+
+  const valid = compile([
+    'VSYNC_PROC() BEGIN',
+    'END;',
+    'MAIN() BEGIN',
+    '  MEM[$4000]=$5A;',
+    '  VSYNC(1);',
+    '  MEM[$4001]=$A5;',
+    '  LOOP { }',
+    'END;',
+  ].join('\n'));
+  assert.equal(valid.errors.length, 0, JSON.stringify(valid.errors));
+  const assembled = assembler.assemble(valid.asm, { ENV_TYPE: 1 });
+  assert.equal(assembled.errors.length, 0, JSON.stringify(assembled.errors));
+  assert.ok(assembled.symbols['NAME_SPACE_DEFAULT.SLANG_PROG_END'] < 0x4000);
+  assert.ok(assembled.symbols['NAME_SPACE_DEFAULT.__WORKEND__'] < 0x4000);
+
+  const legacyVfs = {
+    ...vfs,
+    'legacy-untyped.asm': '; @name LEGACY_RUNTIME\nLD HL,$1234\nRET\n',
+  };
+  const legacyRuntime = compile([
+    'MAIN() BEGIN',
+    '  LEGACY_RUNTIME();',
+    '  LEGACY_RUNTIME(1);',
+    '  LEGACY_RUNTIME(1,2);',
+    'END;',
+  ].join('\n'), legacyVfs);
+  assert.equal(legacyRuntime.errors.length, 0, JSON.stringify(legacyRuntime.errors));
+  assert.equal(assembler.assemble(legacyRuntime.asm, { ENV_TYPE: 1 }).errors.length, 0);
+
+  const legacyMachine = compile('MACHINE LEGACY_MACHINE; MAIN() BEGIN LEGACY_MACHINE(1,2); END;');
+  assert.equal(legacyMachine.errors.length, 0, JSON.stringify(legacyMachine.errors));
+
+  const userFunction = [
+    'VSYNC(WORD A, WORD B) BEGIN',
+    '  RETURN(A+B);',
+    'END;',
+  ].join('\n');
+  const userCall = 'MAIN() BEGIN\n  VSYNC(1,2);\nEND;';
+  for (const shadowSource of [
+    `${userFunction}\n${userCall}`,
+    `${userCall}\n${userFunction}`,
+  ]) {
+    const shadow = compile(shadowSource);
+    assert.equal(shadow.errors.length, 0, JSON.stringify(shadow.errors));
+    assert.equal(assembler.assemble(shadow.asm, { ENV_TYPE: 1 }).errors.length, 0);
+  }
+
+  for (const machineShadow of [
+    'MACHINE VSYNC(2);\nMAIN() BEGIN VSYNC(1,2); END;',
+    'MAIN() BEGIN VSYNC(1,2); END;\nMACHINE VSYNC(2);',
+  ]) {
+    const shadow = compile(machineShadow);
+    assert.equal(shadow.errors.length, 0, JSON.stringify(shadow.errors));
+  }
+});
+
 test('SLANG TATTR reference matches the runtime, editor and PCG contract', () => {
   const entries = validateReferenceData().entries;
   const tattr = entries.find((entry) => entry.id === 'slang.x1.text-attribute');


### PR DESCRIPTION
## Summary

- distinguish missing runtime arity metadata from an explicit zero-argument signature
- validate source calls against loaded `@param_count` metadata while preserving metadata-less, user `MACHINE`, and user-function compatibility
- declare `VSYNC(1)`, `RCALL/CALL(1)`, and `GETREG(0)` and add exact catalog/inventory drift coverage
- verify both Automation Validate rejection and successful `VSYNC(1)` execution

Closes #92.

## Premise and scope

PRs #104/#105 only structured MCP source-sync/edit failures, and PRs #107/#108 added STICK/TATTR metadata without compiler arity enforcement. The Issue #92 compiler gap therefore remained. This PR changes neither MCP/Connector behavior nor product/package versions. User-facing VSYNC/VSYNC_PROC timing documentation remains in #93.

Enforcement is opt-in: only a runtime block whose loaded metadata explicitly declares `@param_count` is checked. A missing annotation remains legacy/untyped. User functions and explicit `MACHINE` declarations, including same-name shadows before or after their call sites, retain existing behavior.

## Migration impact

The exact browser VFS exposes 234 effective canonical runtime functions. Before this change 77 had explicit counts; afterward 80 do and 154 remain metadata-less. Existing incorrect calls to any explicitly typed signature now receive `Runtime function '<name>' expected N argument(s), got M` and produce no assembly. Valid calls are unchanged.

All 77 pre-existing effective signatures were audited against their runtime blocks, comments, aliases, and tracked source uses; no stale count was found. The complete post-change 80-signature table and all 21 compiler builtin/runtime overlaps are test-frozen. Repository-wide shipped/reference SLANG call sites already use valid counts.

## Verification

- `node --test tests/x1pen_reference_test.mjs` — 38/38
- `npm run test:mcp` — 74/74
- `node --test tests/x1pen_automation_test.mjs` — 21/21
- `./build.sh` — success before and after commit
- opposite-provider design and implementation reviews — APPROVED

## Real-machine / interactive verification

1. Build this branch and serve `dist/` through the normal local web flow.
2. In X1Pen SLANG mode, enter `MAIN() BEGIN VSYNC(); END;` and run Validate. Confirm one error says the call expected one argument and got zero, and that no ASM is generated/run.
3. Replace it with an empty `VSYNC_PROC()` hook and `MAIN()` that writes a marker, calls `VSYNC(1)`, writes a second marker, then loops.
4. Validate and Run. Confirm both marker bytes are written (or observe the same flow in the debugger) and the emulator remains responsive after the one-frame wait.
5. Optionally verify `BEEP(1)` is rejected while a metadata-less custom runtime call retains its historical permissive behavior.
