### PR TITLE
feat: X1Pen project diskを永続化する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set_property(TARGET xmillennium PROPERTY LINK_DEPENDS
     ${CMAKE_SOURCE_DIR}/html/drive_integration.js
     ${CMAKE_SOURCE_DIR}/html/disk_container.js
     ${CMAKE_SOURCE_DIR}/html/disk_fs.js
+    ${CMAKE_SOURCE_DIR}/html/project_disk.js
     ${CMAKE_SOURCE_DIR}/html/disk_editor.js
     ${CMAKE_SOURCE_DIR}/html/config.example.js
     ${CMAKE_SOURCE_DIR}/html/x1pen.html
@@ -237,6 +238,8 @@ add_custom_command(TARGET xmillennium POST_BUILD
     ${CMAKE_SOURCE_DIR}/html/disk_container.js ${CMAKE_BINARY_DIR}/disk_container.js
     COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_SOURCE_DIR}/html/disk_fs.js ${CMAKE_BINARY_DIR}/disk_fs.js
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_SOURCE_DIR}/html/project_disk.js ${CMAKE_BINARY_DIR}/project_disk.js
     COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_SOURCE_DIR}/html/disk_editor.js ${CMAKE_BINARY_DIR}/disk_editor.js
     COMMAND ${CMAKE_COMMAND} -E copy

--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,7 @@ cp "${SCRIPT_DIR}/html/storage.js"           ./storage.js
 cp "${SCRIPT_DIR}/html/drive_integration.js" ./drive_integration.js
 cp "${SCRIPT_DIR}/html/disk_container.js"   ./disk_container.js
 cp "${SCRIPT_DIR}/html/disk_fs.js"          ./disk_fs.js
+cp "${SCRIPT_DIR}/html/project_disk.js"     ./project_disk.js
 cp "${SCRIPT_DIR}/html/disk_editor.js"      ./disk_editor.js
 cp "${SCRIPT_DIR}/html/library.css"        ./library.css
 cp "${SCRIPT_DIR}/html/ui_fragments.js"   ./ui_fragments.js
@@ -165,6 +166,7 @@ cp ./storage.js           "${DIST_DIR}/"
 cp ./drive_integration.js "${DIST_DIR}/"
 cp ./disk_container.js   "${DIST_DIR}/"
 cp ./disk_fs.js          "${DIST_DIR}/"
+cp ./project_disk.js     "${DIST_DIR}/"
 cp ./disk_editor.js      "${DIST_DIR}/"
 cp ./library.css          "${DIST_DIR}/"
 cp ./ui_fragments.js      "${DIST_DIR}/"

--- a/docs/X1PEN.md
+++ b/docs/X1PEN.md
@@ -68,9 +68,9 @@ ORG 0C000h
 - ASM のルーチンが `&HC000` に配置され、BASIC の `USR(&HC000)` で呼び出されます
 - FuzzyBASIC では `USR` の戻り値は HL レジスタに入れます
 
-## PROGRAM ディスクと AUTORUN.BAS
+## PROGRAM ディスク、project disk、AUTORUN.BAS
 
-ASM タブに内容がある状態で RUN すると、FDD0 に「(PROGRAM)」ディスクがマウントされます。
+FDD0に通常のライブラリディスクをマウントしていない状態でRUNすると、従来どおり一時的な「(PROGRAM)」ディスクがマウントされます。
 このディスクには以下が含まれます:
 
 | ファイル | 内容 |
@@ -87,10 +87,25 @@ BASIC プログラムから自由に利用できます:
 | `PSGAKG.BIN` | Arkos Tracker AKG 形式の再生ドライバ |
 | `PSGAKM.BIN` | Arkos Tracker AKM 形式の再生ドライバ |
 
+### FDD0をproject diskとして使う
+
+書き込み可能なLSX-Dodgers形式のD88/2DディスクをライブラリからFDD0へマウントしてRUNすると、初回だけ確認後に`<元の名前>-X1Pen`という別のworking copyを作成します。同名時は連番が付きます。元ディスクへX1Pen管理ファイルを書き込まず、working copyへ`PROG.COM`、`PROGRAM.BIN`、`AUTORUN.BAS`、`AUTOEXEC.BAT`を更新します。
+
+- working copyにはproject metadataが付くため、X1Penを閉じて再度マウントしてもコピーは増えません
+- guestによるディスク書き込みとRUN結果はライブラリへ自動保存されます
+- FDD1は変更・イジェクトされず、2枚目のデータディスクとして利用できます
+- multi-disk D88、HuBASICなどLSX-Dodgers以外の形式、write-protectedまたは異常のあるディスクは拒否します
+- 検査するのはファイルシステム構造だけです。正常なbootやプログラム開始は保証しません
+- project diskのRUNは通常のcold power-onを行うため、現在のエミュレータRAMは消去されます
+
+MCP/Automationから通常ディスクを初めて使う場合は`PROJECT_DISK_SETUP_REQUIRED`になります。X1Pen画面で一度RUNしてworking copy作成を承認した後に再実行してください。
+
 ### ディスクイメージのダウンロード
 
-エミュレータ下部のコントロールバーで **FDD** → FDD0 の **Save** ボタンをクリックすると、
+一時PROGRAMディスクは、エミュレータ下部のコントロールバーで **FDD** → FDD0 の **Save** ボタンをクリックすると、
 `PROGRAM.d88` としてディスクイメージをダウンロードできます。
+
+project diskはRUNとguest writeのたびライブラリへ自動保存されます。外部D88として保存する場合はライブラリ一覧の **Download** を使用してください。
 
 このディスクには LSX-Dodgers と FuzzyBASIC が含まれており、そのままブートできる起動ディスクです。
 X millennium Web 本体のエミュレータで FDD にマウントして起動すれば、AUTORUN.BAS が自動実行されます。

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -309,6 +309,8 @@ Runボタン、Ctrl+Enter、Share自動実行、Automation API、MCPの`x1pen_ru
 
 既存の`ok: true`は従来どおり「Run準備とコマンドキー注入が完了した」ことを示し、X1プログラムが実際に開始したことの確認までは含みません。Run準備中はpause/resume/step、プログラム更新、検証、デバッガ書込みを拒否または待機し、起動用キー注入への割込みを防ぎます。
 
+通常のライブラリディスクがFDD0にある場合、最初のMCP Runは`PROJECT_DISK_SETUP_REQUIRED`を返します。X1Pen画面で一度RUNし、別名のpersistent project copy作成を承認してください。metadata付きproject copyに対するRunは、managed fileのcommitとcold power-onが成功すると`committed: true`、`poweredOn: true`、`verification: "filesystem-only"`、`bootVerified: false`、`executionVerified: false`を返します。これはbootやguest program実行の確認ではありません。
+
 Run準備が`stalled`になった場合、`x1pen_get_status`は`runAdmission`のphase/origin/経過時間を返します。`x1pen_recover_stalled`を確認なしで呼ぶと警告を返し、`confirmDataLoss: true`でのみ再読込します。エディターの現在値は保存されますが、エミュレーターRAMと未永続化のディスク変更は失われます。
 
 Share機能はユーザーが開いているX1Pen自身から実行するため、本番X1Pen上では既存のShare APIと公開URLをそのまま利用できます。

--- a/html/disk_editor.js
+++ b/html/disk_editor.js
@@ -14,6 +14,11 @@
     var editorDisclaimerShown = false;
 
     async function openEditor(libraryKey) {
+        if (window.XmilLibrary && window.XmilLibrary.isProjectDiskTransactionActive &&
+            window.XmilLibrary.isProjectDiskTransactionActive()) {
+            alert('X1Pen project disk update is in progress');
+            return;
+        }
         if (!window.XmilCore || !window.XmilStorage) {
             alert('ストレージが初期化されていません');
             return;

--- a/html/disk_editor.js
+++ b/html/disk_editor.js
@@ -16,7 +16,7 @@
     async function openEditor(libraryKey) {
         if (window.XmilLibrary && window.XmilLibrary.isProjectDiskTransactionActive &&
             window.XmilLibrary.isProjectDiskTransactionActive()) {
-            alert('X1Pen project disk update is in progress');
+            alert('X1Penプロジェクトディスクの更新中はディスクを編集できません');
             return;
         }
         if (!window.XmilCore || !window.XmilStorage) {

--- a/html/pre.js
+++ b/html/pre.js
@@ -962,14 +962,6 @@
         if (settings.dip2hd) dip |= 0x04;
         if (module._js_set_dip_sw) module._js_set_dip_sw(dip);
         if (module._js_set_sound_sw) module._js_set_sound_sw(settings.fmEnable ? 1 : 0);
-        var activeModel = module._js_get_rom_type();
-        if (activeModel !== modelValue) {
-            throw projectDiskFailure(
-                'PROJECT_DISK_MACHINE_MISMATCH',
-                '現在、プロジェクトディスクは起動中と異なるMODELへ切り替えてRUNできません。MODELを元に戻してください',
-                { mismatchKind: 'model', requestedModel: modelValue, activeModel: activeModel }
-            );
-        }
         var activeDip = module._js_get_dip_sw ? module._js_get_dip_sw() : dip;
         if (activeDip !== dip) {
             throw projectDiskFailure(
@@ -995,7 +987,7 @@
         }
         isRunning = true;
         updatePowerBtn();
-        return { model: modelValue, dip: dip };
+        return { model: module._js_get_rom_type(), requestedModel: modelValue, dip: dip };
     }
 
     // ライブラリから削除

--- a/html/pre.js
+++ b/html/pre.js
@@ -202,7 +202,7 @@
     // ----------------------------------------------------------------
 
     async function createEmm(slotNum, sizeBytes) {
-        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
+        if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         if (slotNum < 0 || slotNum > 9) return;
         if (sizeBytes <= 0 || sizeBytes > 16 * 1024 * 1024) return;
         // 256B 境界に丸める
@@ -465,7 +465,7 @@
 
     // ファイルをライブラリに追加 (OPFS + localStorage メタ)
     async function addToLibrary(file) {
-        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
+        if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         var type = detectFileType(file.name);
         if (!type) {
             alert('不明なファイル形式です: ' + file.name + '\n対応: D88/2D/88D (FDD), HDD/HD (HDD), CAS/CMT/TAP/BAS/BIN (CMT)');
@@ -520,7 +520,7 @@
 
     // ライブラリからスロットにマウント
     async function mountFromLibrary(key, slotName) {
-        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
+        if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         var entry = getLibrary().find(function(e) { return e.key === key; });
         if (!entry) { alert('ファイルが見つかりません'); return; }
 
@@ -599,7 +599,7 @@
 
     // スロットをeject (ファイルはライブラリに保持)
     async function ejectSlot(slotName) {
-        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
+        if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         if (!slotState[slotName]) return;
 
         // 順序が重要:
@@ -700,7 +700,7 @@
         var serialized = JSON.stringify(library);
         localStorage.setItem(LS_LIBRARY, serialized);
         if (localStorage.getItem(LS_LIBRARY) !== serialized) {
-            throw projectDiskFailure('PROJECT_DISK_METADATA_SAVE_FAILED', 'Project disk metadata could not be verified');
+            throw projectDiskFailure('PROJECT_DISK_METADATA_SAVE_FAILED', 'プロジェクトディスクのメタデータを保存後に確認できませんでした');
         }
     }
 
@@ -708,7 +708,7 @@
         var serialized = JSON.stringify(slotState);
         localStorage.setItem(LS_MOUNT_STATE, serialized);
         if (localStorage.getItem(LS_MOUNT_STATE) !== serialized) {
-            throw projectDiskFailure('PROJECT_DISK_MOUNT_STATE_SAVE_FAILED', 'Project disk mount state could not be verified');
+            throw projectDiskFailure('PROJECT_DISK_MOUNT_STATE_SAVE_FAILED', 'プロジェクトディスクのマウント状態を保存後に確認できませんでした');
         }
     }
 
@@ -723,7 +723,7 @@
         var entry = mountedDrive0Entry();
         if (!entry || !window.XmilStorage) return null;
         var bytes = await window.XmilStorage.read(entry.key);
-        if (!bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', 'Could not read the mounted FDD0 image');
+        if (!bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', 'FDD0にマウントされたディスクイメージを読み込めませんでした');
         return { entry: entry, bytes: bytes };
     }
 
@@ -732,7 +732,7 @@
             if (slotName !== 'drive0' && slotState[slotName] === key) {
                 throw projectDiskFailure(
                     'PROJECT_DISK_ALIAS_CONFLICT',
-                    'The same disk is also mounted in ' + slotName + '; eject it there before Run',
+                    '同じディスクが' + slotName + 'にもマウントされています。RUNの前に取り出してください',
                     { conflictingSlot: slotName }
                 );
             }
@@ -780,10 +780,10 @@
 
     async function beginProjectDiskTransaction() {
         if (projectDiskTransaction) {
-            throw projectDiskFailure('PROJECT_DISK_BUSY', 'Another project disk update is already running');
+            throw projectDiskFailure('PROJECT_DISK_BUSY', '別のプロジェクトディスク更新が実行中です');
         }
         var entry = mountedDrive0Entry();
-        if (!entry) throw projectDiskFailure('PROJECT_DISK_NOT_MOUNTED', 'Mount an LSX-Dodgers disk in FDD0 first');
+        if (!entry) throw projectDiskFailure('PROJECT_DISK_NOT_MOUNTED', '先にLSX-DodgersディスクをFDD0へマウントしてください');
         assertNoProjectDiskAlias(entry.key);
         var tx = {
             key: entry.key,
@@ -805,11 +805,11 @@
             updatePowerBtn();
             await flushAllDirty({ strict: true });
             if (slotState.drive0 !== tx.key || slotDirty.drive0) {
-                throw projectDiskFailure('PROJECT_DISK_CHANGED', 'FDD0 changed or became dirty during project disk capture');
+                throw projectDiskFailure('PROJECT_DISK_CHANGED', 'プロジェクトディスクの取得中にFDD0の状態が変化しました');
             }
             assertNoProjectDiskAlias(tx.key);
             tx.bytes = await window.XmilStorage.read(tx.key);
-            if (!tx.bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', 'Could not capture the flushed FDD0 image');
+            if (!tx.bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', '保存済みのFDD0ディスクイメージを取得できませんでした');
             tx.hash = await sha256Hex(tx.bytes);
             tx.otherSlots = {};
             for (var slotName in slotState) {
@@ -876,7 +876,7 @@
 
     async function commitProjectDiskTransaction(tx, newBytes, projectMode) {
         if (!tx || projectDiskTransaction !== tx || !tx.detached) {
-            throw projectDiskFailure('PROJECT_DISK_TRANSACTION_INVALID', 'Project disk transaction is not active');
+            throw projectDiskFailure('PROJECT_DISK_TRANSACTION_INVALID', 'プロジェクトディスクの更新処理が開始されていません');
         }
         var bytes = newBytes instanceof ArrayBuffer
             ? newBytes.slice(0)
@@ -884,7 +884,7 @@
         var library = getLibrary().map(cloneLibraryEntry);
         var liveSource = library.find(function(entry) { return entry.key === tx.key; });
         if (!liveSource || JSON.stringify(liveSource) !== JSON.stringify(tx.entry)) {
-            throw projectDiskFailure('PROJECT_DISK_LIBRARY_CHANGED', 'The project disk library entry changed during Run');
+            throw projectDiskFailure('PROJECT_DISK_LIBRARY_CHANGED', 'RUNの途中でプロジェクトディスクのライブラリ情報が変更されました');
         }
         var targetEntry;
         if (tx.entry.x1penProject) {
@@ -918,7 +918,7 @@
             tx.committed = true;
             var readBack = await window.XmilStorage.read(targetEntry.key);
             if (!buffersEqual(bytes, readBack)) {
-                throw projectDiskFailure('PROJECT_DISK_VERIFY_FAILED', 'Stored project disk did not match the prepared image');
+                throw projectDiskFailure('PROJECT_DISK_VERIFY_FAILED', '保存したプロジェクトディスクが作成内容と一致しません');
             }
             for (var i = 0; i < library.length; i++) {
                 if (library[i].key === targetEntry.key) { library[i] = targetEntry; break; }
@@ -928,7 +928,7 @@
             await mountProjectDiskBytes(targetEntry.key, targetEntry, readBack);
             var mounted = module && module.FS ? module.FS.readFile(slotVfsPath.drive0) : null;
             if (slotState.drive0 !== targetEntry.key || !mounted || !buffersEqual(readBack, mounted.buffer.slice(mounted.byteOffset, mounted.byteOffset + mounted.byteLength))) {
-                throw projectDiskFailure('PROJECT_DISK_MOUNT_VERIFY_FAILED', 'Mounted FDD0 did not match the committed project disk');
+                throw projectDiskFailure('PROJECT_DISK_MOUNT_VERIFY_FAILED', 'FDD0の内容が保存済みプロジェクトディスクと一致しません');
             }
             return cloneLibraryEntry(targetEntry);
         } catch (error) {
@@ -953,7 +953,7 @@
 
     function coldPowerOnProjectDisk(modelValue, expectedOtherSlots) {
         if (!module || !module._js_xmil_power_on || !module._js_set_rom_type || !module._js_get_rom_type) {
-            throw projectDiskFailure('PROJECT_DISK_MACHINE_UNAVAILABLE', 'Normal project disk power-on is unavailable');
+            throw projectDiskFailure('PROJECT_DISK_MACHINE_UNAVAILABLE', 'プロジェクトディスクを通常起動するための機能を利用できません');
         }
         module._js_set_rom_type(modelValue);
         var settings = window.XmilControls ? window.XmilControls.getSettings() : {};
@@ -963,7 +963,7 @@
         if (module._js_set_dip_sw) module._js_set_dip_sw(dip);
         if (module._js_set_sound_sw) module._js_set_sound_sw(settings.fmEnable ? 1 : 0);
         if (module._js_get_rom_type() !== modelValue || (module._js_get_dip_sw && module._js_get_dip_sw() !== dip)) {
-            throw projectDiskFailure('PROJECT_DISK_MACHINE_MISMATCH', 'Project disk machine settings could not be applied');
+            throw projectDiskFailure('PROJECT_DISK_MACHINE_MISMATCH', 'プロジェクトディスク用の本体設定を適用できませんでした');
         }
         if (module._js_xmil_power_off) module._js_xmil_power_off();
         module._js_xmil_power_on();
@@ -975,7 +975,7 @@
                 updatePowerBtn();
                 throw projectDiskFailure(
                     'PROJECT_DISK_OTHER_SLOT_CHANGED',
-                    slotName + ' changed during project disk power-on',
+                    'プロジェクトディスクの起動中に' + slotName + 'の状態が変化しました',
                     { conflictingSlot: slotName }
                 );
             }
@@ -987,7 +987,7 @@
 
     // ライブラリから削除
     async function deleteFromLibrary(key) {
-        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
+        if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         var entry = getLibrary().find(function(e) { return e.key === key; });
         if (!entry) return;
         if (!confirm('"' + entry.name + '" をライブラリから削除しますか？\nマウント中の場合は自動的にイジェクトされます。')) return;

--- a/html/pre.js
+++ b/html/pre.js
@@ -962,8 +962,21 @@
         if (settings.dip2hd) dip |= 0x04;
         if (module._js_set_dip_sw) module._js_set_dip_sw(dip);
         if (module._js_set_sound_sw) module._js_set_sound_sw(settings.fmEnable ? 1 : 0);
-        if (module._js_get_rom_type() !== modelValue || (module._js_get_dip_sw && module._js_get_dip_sw() !== dip)) {
-            throw projectDiskFailure('PROJECT_DISK_MACHINE_MISMATCH', 'プロジェクトディスク用の本体設定を適用できませんでした');
+        var activeModel = module._js_get_rom_type();
+        if (activeModel !== modelValue) {
+            throw projectDiskFailure(
+                'PROJECT_DISK_MACHINE_MISMATCH',
+                '現在、プロジェクトディスクは起動中と異なるMODELへ切り替えてRUNできません。MODELを元に戻してください',
+                { mismatchKind: 'model', requestedModel: modelValue, activeModel: activeModel }
+            );
+        }
+        var activeDip = module._js_get_dip_sw ? module._js_get_dip_sw() : dip;
+        if (activeDip !== dip) {
+            throw projectDiskFailure(
+                'PROJECT_DISK_MACHINE_MISMATCH',
+                'プロジェクトディスク用の本体設定を適用できませんでした',
+                { mismatchKind: 'dip', requestedDip: dip, activeDip: activeDip }
+            );
         }
         if (module._js_xmil_power_off) module._js_xmil_power_off();
         module._js_xmil_power_on();

--- a/html/pre.js
+++ b/html/pre.js
@@ -26,6 +26,7 @@
     const slotDirtyPages = {};     // slotName → Set<pageIndex> (64KB pages for OPFS partial write)
     const slotDirtyEpoch = {};     // slotName → number (incremented per write, for safe dirty clearing)
     const PAGE_SIZE = 65536;       // 64KB
+    let projectDiskTransaction = null;
 
     var emmImportSlot = -1;       // インポート対象スロット番号
     var emmImportInput = null;    // 隠し file input (init() で生成)
@@ -201,6 +202,7 @@
     // ----------------------------------------------------------------
 
     async function createEmm(slotNum, sizeBytes) {
+        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
         if (slotNum < 0 || slotNum > 9) return;
         if (sizeBytes <= 0 || sizeBytes > 16 * 1024 * 1024) return;
         // 256B 境界に丸める
@@ -463,6 +465,7 @@
 
     // ファイルをライブラリに追加 (OPFS + localStorage メタ)
     async function addToLibrary(file) {
+        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
         var type = detectFileType(file.name);
         if (!type) {
             alert('不明なファイル形式です: ' + file.name + '\n対応: D88/2D/88D (FDD), HDD/HD (HDD), CAS/CMT/TAP/BAS/BIN (CMT)');
@@ -517,6 +520,7 @@
 
     // ライブラリからスロットにマウント
     async function mountFromLibrary(key, slotName) {
+        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
         var entry = getLibrary().find(function(e) { return e.key === key; });
         if (!entry) { alert('ファイルが見つかりません'); return; }
 
@@ -595,6 +599,7 @@
 
     // スロットをeject (ファイルはライブラリに保持)
     async function ejectSlot(slotName) {
+        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
         if (!slotState[slotName]) return;
 
         // 順序が重要:
@@ -666,8 +671,323 @@
         URL.revokeObjectURL(url);
     }
 
+    function projectDiskFailure(code, message, details) {
+        var error = new Error(message);
+        error.code = code;
+        Object.keys(details || {}).forEach(function(key) { error[key] = details[key]; });
+        return error;
+    }
+
+    async function sha256Hex(arrayBuffer) {
+        var digest = await crypto.subtle.digest('SHA-256', arrayBuffer);
+        return Array.from(new Uint8Array(digest)).map(function(value) {
+            return value.toString(16).padStart(2, '0');
+        }).join('');
+    }
+
+    function buffersEqual(left, right) {
+        if (!left || !right || left.byteLength !== right.byteLength) return false;
+        var a = new Uint8Array(left), b = new Uint8Array(right);
+        for (var i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+        return true;
+    }
+
+    function cloneLibraryEntry(entry) {
+        return entry ? JSON.parse(JSON.stringify(entry)) : null;
+    }
+
+    function saveProjectLibraryStrict(library) {
+        var serialized = JSON.stringify(library);
+        localStorage.setItem(LS_LIBRARY, serialized);
+        if (localStorage.getItem(LS_LIBRARY) !== serialized) {
+            throw projectDiskFailure('PROJECT_DISK_METADATA_SAVE_FAILED', 'Project disk metadata could not be verified');
+        }
+    }
+
+    function saveProjectMountStateStrict() {
+        var serialized = JSON.stringify(slotState);
+        localStorage.setItem(LS_MOUNT_STATE, serialized);
+        if (localStorage.getItem(LS_MOUNT_STATE) !== serialized) {
+            throw projectDiskFailure('PROJECT_DISK_MOUNT_STATE_SAVE_FAILED', 'Project disk mount state could not be verified');
+        }
+    }
+
+    function mountedDrive0Entry() {
+        var key = slotState.drive0;
+        if (!key || key === '__x1pen_temp__') return null;
+        var entry = getLibrary().find(function(candidate) { return candidate.key === key; });
+        return entry ? cloneLibraryEntry(entry) : null;
+    }
+
+    async function inspectMountedProjectDisk() {
+        var entry = mountedDrive0Entry();
+        if (!entry || !window.XmilStorage) return null;
+        var bytes = await window.XmilStorage.read(entry.key);
+        if (!bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', 'Could not read the mounted FDD0 image');
+        return { entry: entry, bytes: bytes };
+    }
+
+    function assertNoProjectDiskAlias(key) {
+        for (var slotName in slotState) {
+            if (slotName !== 'drive0' && slotState[slotName] === key) {
+                throw projectDiskFailure(
+                    'PROJECT_DISK_ALIAS_CONFLICT',
+                    'The same disk is also mounted in ' + slotName + '; eject it there before Run',
+                    { conflictingSlot: slotName }
+                );
+            }
+        }
+    }
+
+    function uniqueProjectDiskName(sourceName, library) {
+        var dot = sourceName.lastIndexOf('.');
+        var stem = dot > 0 ? sourceName.slice(0, dot) : sourceName;
+        var ext = dot > 0 ? sourceName.slice(dot) : '.d88';
+        var used = {};
+        library.forEach(function(entry) { used[String(entry.name || '').toLowerCase()] = true; });
+        var candidate = stem + '-X1Pen' + ext;
+        var index = 2;
+        while (used[candidate.toLowerCase()]) candidate = stem + '-X1Pen-' + index++ + ext;
+        return candidate;
+    }
+
+    function clearDrive0Bookkeeping() {
+        slotState.drive0 = null;
+        slotVfsPath.drive0 = null;
+        slotDirty.drive0 = false;
+        slotDirtyPages.drive0 = null;
+        fddDiskType[0] = null;
+        saveProjectMountStateStrict();
+        updateSlotUI('drive0', null);
+        renderLibraryList();
+    }
+
+    async function mountProjectDiskBytes(key, entry, bytes) {
+        var ext = entry.ext != null ? entry.ext : (entry.name.split('.').pop() || 'd88');
+        var vfsPath = slotToVfsPath('drive0', ext);
+        writeFileToVFS(vfsPath, new Uint8Array(bytes));
+        if (module) module.ccall('js_insert_disk', null, ['string', 'number'], [vfsPath, 0]);
+        var arr = new Uint8Array(bytes);
+        fddDiskType[0] = (arr.length > 0x1C && arr[0x1B] === 0x20) ? '2hd' : '2d';
+        slotState.drive0 = key;
+        slotVfsPath.drive0 = vfsPath;
+        slotDirty.drive0 = false;
+        slotDirtyPages.drive0 = null;
+        saveProjectMountStateStrict();
+        updateSlotUI('drive0', entry.name);
+        renderLibraryList();
+    }
+
+    async function beginProjectDiskTransaction() {
+        if (projectDiskTransaction) {
+            throw projectDiskFailure('PROJECT_DISK_BUSY', 'Another project disk update is already running');
+        }
+        var entry = mountedDrive0Entry();
+        if (!entry) throw projectDiskFailure('PROJECT_DISK_NOT_MOUNTED', 'Mount an LSX-Dodgers disk in FDD0 first');
+        assertNoProjectDiskAlias(entry.key);
+        var tx = {
+            key: entry.key,
+            entry: entry,
+            library: getLibrary().map(cloneLibraryEntry),
+            wasRunning: isRunning,
+            detached: false,
+            committed: false,
+            restored: false,
+            writeAttempted: false,
+            metadataWriteAttempted: false,
+            targetKey: null,
+            targetEntry: null
+        };
+        projectDiskTransaction = tx;
+        try {
+            if (module && module._js_xmil_stop) module._js_xmil_stop();
+            isRunning = false;
+            updatePowerBtn();
+            await flushAllDirty({ strict: true });
+            if (slotState.drive0 !== tx.key || slotDirty.drive0) {
+                throw projectDiskFailure('PROJECT_DISK_CHANGED', 'FDD0 changed or became dirty during project disk capture');
+            }
+            assertNoProjectDiskAlias(tx.key);
+            tx.bytes = await window.XmilStorage.read(tx.key);
+            if (!tx.bytes) throw projectDiskFailure('PROJECT_DISK_READ_FAILED', 'Could not capture the flushed FDD0 image');
+            tx.hash = await sha256Hex(tx.bytes);
+            tx.otherSlots = {};
+            for (var slotName in slotState) {
+                if (slotName === 'drive0' || !slotState[slotName]) continue;
+                tx.otherSlots[slotName] = {
+                    key: slotState[slotName],
+                    vfsPath: slotVfsPath[slotName]
+                };
+            }
+            if (module && module._js_eject_disk) module._js_eject_disk(0);
+            tx.detached = true;
+            clearDrive0Bookkeeping();
+            return tx;
+        } catch (error) {
+            if (tx.detached && tx.bytes) {
+                try { await mountProjectDiskBytes(tx.key, tx.entry, tx.bytes); }
+                catch (rollbackError) {
+                    error.rollbackFailed = true;
+                    error.rollbackMessage = rollbackError.message;
+                }
+            }
+            projectDiskTransaction = null;
+            if (tx.wasRunning && module && module._js_xmil_start) {
+                module._js_xmil_start();
+                isRunning = true;
+                updatePowerBtn();
+            }
+            throw error;
+        }
+    }
+
+    async function restoreProjectDiskTransaction(tx) {
+        if (!tx || projectDiskTransaction !== tx || tx.restored) return;
+        try {
+            if (tx.targetKey && tx.targetKey !== tx.key) {
+                await window.XmilStorage.remove(tx.targetKey);
+            }
+            if (tx.writeAttempted && tx.targetKey === tx.key) {
+                await window.XmilStorage.write(tx.key, tx.bytes);
+            }
+            if (tx.metadataWriteAttempted) {
+                var library = getLibrary().map(cloneLibraryEntry);
+                if (tx.targetKey !== tx.key) {
+                    library = library.filter(function(entry) { return entry.key !== tx.targetKey; });
+                } else {
+                    var restoredEntry = false;
+                    for (var i = 0; i < library.length; i++) {
+                        if (library[i].key === tx.key) {
+                            library[i] = cloneLibraryEntry(tx.entry);
+                            restoredEntry = true;
+                            break;
+                        }
+                    }
+                    if (!restoredEntry) library.push(cloneLibraryEntry(tx.entry));
+                }
+                saveProjectLibraryStrict(library);
+            }
+            await mountProjectDiskBytes(tx.key, tx.entry, tx.bytes);
+            tx.restored = true;
+        } finally {
+            tx.committed = false;
+        }
+    }
+
+    async function commitProjectDiskTransaction(tx, newBytes, projectMode) {
+        if (!tx || projectDiskTransaction !== tx || !tx.detached) {
+            throw projectDiskFailure('PROJECT_DISK_TRANSACTION_INVALID', 'Project disk transaction is not active');
+        }
+        var bytes = newBytes instanceof ArrayBuffer
+            ? newBytes.slice(0)
+            : newBytes.buffer.slice(newBytes.byteOffset, newBytes.byteOffset + newBytes.byteLength);
+        var library = getLibrary().map(cloneLibraryEntry);
+        var liveSource = library.find(function(entry) { return entry.key === tx.key; });
+        if (!liveSource || JSON.stringify(liveSource) !== JSON.stringify(tx.entry)) {
+            throw projectDiskFailure('PROJECT_DISK_LIBRARY_CHANGED', 'The project disk library entry changed during Run');
+        }
+        var targetEntry;
+        if (tx.entry.x1penProject) {
+            targetEntry = cloneLibraryEntry(tx.entry);
+        } else {
+            var name = uniqueProjectDiskName(tx.entry.name, library);
+            targetEntry = {
+                key: makeLibraryKey('fdd', name),
+                name: name,
+                type: 'fdd',
+                ext: name.split('.').pop(),
+                size: bytes.byteLength,
+                addedAt: new Date().toISOString(),
+                favorite: false,
+                x1penProject: true,
+                sourceKey: tx.entry.key,
+                sourceHash: tx.hash,
+                projectCreatedAt: new Date().toISOString()
+            };
+            library.push(targetEntry);
+        }
+        targetEntry.size = bytes.byteLength;
+        targetEntry.projectMode = projectMode;
+        targetEntry.projectUpdatedAt = new Date().toISOString();
+        tx.targetKey = targetEntry.key;
+        tx.targetEntry = targetEntry;
+        try {
+            await window.XmilStorage.ensureCapacity(bytes.byteLength);
+            tx.writeAttempted = true;
+            await window.XmilStorage.write(targetEntry.key, bytes);
+            tx.committed = true;
+            var readBack = await window.XmilStorage.read(targetEntry.key);
+            if (!buffersEqual(bytes, readBack)) {
+                throw projectDiskFailure('PROJECT_DISK_VERIFY_FAILED', 'Stored project disk did not match the prepared image');
+            }
+            for (var i = 0; i < library.length; i++) {
+                if (library[i].key === targetEntry.key) { library[i] = targetEntry; break; }
+            }
+            tx.metadataWriteAttempted = true;
+            saveProjectLibraryStrict(library);
+            await mountProjectDiskBytes(targetEntry.key, targetEntry, readBack);
+            var mounted = module && module.FS ? module.FS.readFile(slotVfsPath.drive0) : null;
+            if (slotState.drive0 !== targetEntry.key || !mounted || !buffersEqual(readBack, mounted.buffer.slice(mounted.byteOffset, mounted.byteOffset + mounted.byteLength))) {
+                throw projectDiskFailure('PROJECT_DISK_MOUNT_VERIFY_FAILED', 'Mounted FDD0 did not match the committed project disk');
+            }
+            return cloneLibraryEntry(targetEntry);
+        } catch (error) {
+            try { await restoreProjectDiskTransaction(tx); }
+            catch (rollbackError) {
+                error.rollbackFailed = true;
+                error.rollbackMessage = rollbackError.message;
+            }
+            throw error;
+        }
+    }
+
+    function finishProjectDiskTransaction(tx, resumePrevious) {
+        if (!tx || projectDiskTransaction !== tx) return;
+        projectDiskTransaction = null;
+        if (resumePrevious && tx.wasRunning && module && module._js_xmil_start) {
+            module._js_xmil_start();
+            isRunning = true;
+            updatePowerBtn();
+        }
+    }
+
+    function coldPowerOnProjectDisk(modelValue, expectedOtherSlots) {
+        if (!module || !module._js_xmil_power_on || !module._js_set_rom_type || !module._js_get_rom_type) {
+            throw projectDiskFailure('PROJECT_DISK_MACHINE_UNAVAILABLE', 'Normal project disk power-on is unavailable');
+        }
+        module._js_set_rom_type(modelValue);
+        var settings = window.XmilControls ? window.XmilControls.getSettings() : {};
+        var dip = 0;
+        if (!settings.dipHighres) dip |= 0x01;
+        if (settings.dip2hd) dip |= 0x04;
+        if (module._js_set_dip_sw) module._js_set_dip_sw(dip);
+        if (module._js_set_sound_sw) module._js_set_sound_sw(settings.fmEnable ? 1 : 0);
+        if (module._js_get_rom_type() !== modelValue || (module._js_get_dip_sw && module._js_get_dip_sw() !== dip)) {
+            throw projectDiskFailure('PROJECT_DISK_MACHINE_MISMATCH', 'Project disk machine settings could not be applied');
+        }
+        if (module._js_xmil_power_off) module._js_xmil_power_off();
+        module._js_xmil_power_on();
+        for (var slotName in (expectedOtherSlots || {})) {
+            var expected = expectedOtherSlots[slotName];
+            if (slotState[slotName] !== expected.key || slotVfsPath[slotName] !== expected.vfsPath) {
+                if (module._js_xmil_stop) module._js_xmil_stop();
+                isRunning = false;
+                updatePowerBtn();
+                throw projectDiskFailure(
+                    'PROJECT_DISK_OTHER_SLOT_CHANGED',
+                    slotName + ' changed during project disk power-on',
+                    { conflictingSlot: slotName }
+                );
+            }
+        }
+        isRunning = true;
+        updatePowerBtn();
+        return { model: modelValue, dip: dip };
+    }
+
     // ライブラリから削除
     async function deleteFromLibrary(key) {
+        if (projectDiskTransaction) throw new Error('Media changes are locked during X1Pen project disk update');
         var entry = getLibrary().find(function(e) { return e.key === key; });
         if (!entry) return;
         if (!confirm('"' + entry.name + '" をライブラリから削除しますか？\nマウント中の場合は自動的にイジェクトされます。')) return;
@@ -3141,6 +3461,7 @@
     }
 
     function toggleFavorite(key) {
+        if (projectDiskTransaction) return;
         var lib = getLibrary();
         var entry = lib.find(function(e) { return e.key === key; });
         if (!entry) return;
@@ -3431,6 +3752,7 @@
                 return raw ? JSON.parse(raw) : {};
             } catch(e) { return {}; }
         },
+        coldPowerOnProjectDisk: coldPowerOnProjectDisk,
 
         // ROM/Font 管理
         onRomFileChange: onRomFileChange,
@@ -3559,6 +3881,12 @@
         toggleFavorite: toggleFavorite,
         renderLibraryList: renderLibraryList,
         autoRestoreMounts: autoRestoreMounts,
+        inspectMountedProjectDisk: inspectMountedProjectDisk,
+        beginProjectDiskTransaction: beginProjectDiskTransaction,
+        commitProjectDiskTransaction: commitProjectDiskTransaction,
+        restoreProjectDiskTransaction: restoreProjectDiskTransaction,
+        finishProjectDiskTransaction: finishProjectDiskTransaction,
+        isProjectDiskTransactionActive: function() { return !!projectDiskTransaction; },
         setSearch: function(v) { currentLibrarySearch = v; },
         setSort:   function(v) { currentLibrarySort = v; },
         setFavoritesOnly: function(v) { currentFavoritesOnly = v; },

--- a/html/project_disk.js
+++ b/html/project_disk.js
@@ -1,0 +1,212 @@
+// project_disk.js - X1Pen project disk validation and mutation
+(function() {
+    'use strict';
+
+    var MANAGED_FILES = ['PROG.COM', 'PROGRAM.BIN', 'AUTORUN.BAS'];
+    var MODE_LAUNCH = { lsx: 'PROG', fuzzybasic: 'FZBASIC' };
+
+    function ProjectDiskError(code, message, details) {
+        this.name = 'ProjectDiskError';
+        this.code = code;
+        this.message = message;
+        if (Error.captureStackTrace) Error.captureStackTrace(this, ProjectDiskError);
+        var self = this;
+        Object.keys(details || {}).forEach(function(key) { self[key] = details[key]; });
+    }
+    ProjectDiskError.prototype = Object.create(Error.prototype);
+    ProjectDiskError.prototype.constructor = ProjectDiskError;
+
+    function fail(code, message, details) {
+        throw new ProjectDiskError(code, message, details);
+    }
+
+    function splitName(fullName) {
+        var dot = fullName.lastIndexOf('.');
+        return dot < 0
+            ? { name: fullName, ext: '' }
+            : { name: fullName.slice(0, dot), ext: fullName.slice(dot + 1) };
+    }
+
+    function cloneBytes(value) {
+        if (value instanceof ArrayBuffer) return value.slice(0);
+        if (ArrayBuffer.isView(value)) {
+            return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+        }
+        fail('PROJECT_DISK_INVALID_BYTES', 'Project disk data must be an ArrayBuffer or typed array');
+    }
+
+    function openValidated(arrayBuffer, filename) {
+        var bytes = cloneBytes(arrayBuffer);
+        var container = window.XmilDiskContainer.openContainer(bytes, filename || 'project.d88', 'fdd');
+        if (!container) fail('PROJECT_DISK_UNSUPPORTED_CONTAINER', 'FDD0 is not a supported D88 or raw 2D image');
+        if (container.isMultiDisk) fail('PROJECT_DISK_MULTI_D88', 'Multi-disk D88 images are not supported as X1Pen project disks');
+        if (container.protect) fail('PROJECT_DISK_WRITE_PROTECTED', 'The selected disk image is write-protected');
+
+        var fs = window.XmilDiskFS.detectFilesystem(container);
+        if (!fs || fs.fsType !== 'LSX-Dodgers') {
+            fail('PROJECT_DISK_NOT_LSX', 'The selected disk is not an LSX-Dodgers filesystem');
+        }
+        var info = fs.getInfo();
+        if (info.readOnly) fail('PROJECT_DISK_READ_ONLY', info.readOnlyReason || 'The selected filesystem is read-only');
+        if (info.anomaly) fail('PROJECT_DISK_ANOMALY', 'The selected filesystem has allocation anomalies');
+        return { container: container, fs: fs, info: info };
+    }
+
+    function firstToken(line) {
+        var text = String(line || '').trim();
+        while (text.charAt(0) === '@') text = text.slice(1).trim();
+        if (!text || text.slice(0, 2) === '::') return '';
+        var token = text.split(/[\s=]+/, 1)[0].toUpperCase();
+        return token;
+    }
+
+    function isPreludeLine(line) {
+        var text = String(line || '').trim();
+        if (!text || text.slice(0, 2) === '::') return true;
+        var token = firstToken(text);
+        if (token === 'REM' || token === 'PATH' || token === 'SET' || token === 'PROMPT' ||
+            token === 'ECHO' || token === 'CD' || token === 'CHDIR') return true;
+        return /^[A-Z]:$/i.test(token);
+    }
+
+    function decodeAutoexec(bytes) {
+        if (!bytes) return { lines: [], newline: '\r\n' };
+        var end = bytes.length;
+        for (var i = 0; i < bytes.length; i++) {
+            if (bytes[i] === 0x1A || bytes[i] === 0x00) { end = i; break; }
+        }
+        var text = '';
+        for (var j = 0; j < end; j++) text += String.fromCharCode(bytes[j] & 0x7F);
+        var newline = text.indexOf('\r\n') >= 0 ? '\r\n' : '\n';
+        var lines = text ? text.split(/\r?\n/) : [];
+        while (lines.length && lines[lines.length - 1] === '') lines.pop();
+        return { lines: lines, newline: newline };
+    }
+
+    function encodeAutoexec(lines, newline) {
+        var text = lines.join(newline || '\r\n') + (newline || '\r\n');
+        var out = new Uint8Array(text.length + 1);
+        for (var i = 0; i < text.length; i++) out[i] = text.charCodeAt(i) & 0x7F;
+        out[out.length - 1] = 0x1A;
+        return out;
+    }
+
+    function updateAutoexec(existingBytes, mode) {
+        var launch = MODE_LAUNCH[mode];
+        if (!launch) fail('PROJECT_DISK_MODE_INVALID', 'Unsupported project disk mode: ' + mode);
+        var decoded = decodeAutoexec(existingBytes);
+        var launchLine = launch;
+        var retained = [];
+        for (var i = 0; i < decoded.lines.length; i++) {
+            var token = firstToken(decoded.lines[i]);
+            if (token === 'PROG' || token === 'FZBASIC') {
+                if (token === launch && launchLine === launch) launchLine = decoded.lines[i].trim();
+                continue;
+            }
+            retained.push(decoded.lines[i]);
+        }
+        var insertAt = 0;
+        while (insertAt < retained.length && isPreludeLine(retained[insertAt])) insertAt++;
+        var followingCommand = insertAt < retained.length ? retained[insertAt].trim() : null;
+        retained.splice(insertAt, 0, launchLine);
+        return {
+            bytes: encodeAutoexec(retained, decoded.newline),
+            insertedAt: insertAt,
+            followingCommand: followingCommand,
+            launch: launchLine,
+            lines: retained
+        };
+    }
+
+    function replaceFile(fs, fullName, data) {
+        var parts = splitName(fullName);
+        var existing = fs.findByName(parts.name, parts.ext);
+        if (existing) fs.deleteFile(existing);
+        fs.addFile(parts.name, parts.ext, data instanceof Uint8Array ? data : new Uint8Array(data));
+    }
+
+    function deleteFile(fs, fullName) {
+        var parts = splitName(fullName);
+        var existing = fs.findByName(parts.name, parts.ext);
+        if (existing) fs.deleteFile(existing);
+    }
+
+    function inspect(arrayBuffer, filename, mode) {
+        var opened = openValidated(arrayBuffer, filename);
+        var warnings = [];
+        if (!opened.fs.findByName('LD', 'BIN')) warnings.push('LD.BIN is missing; the disk may not boot LSX-Dodgers');
+        if (mode === 'fuzzybasic' && !opened.fs.findByName('FZBASIC', 'COM')) {
+            warnings.push('FZBASIC.COM is missing; FuzzyBASIC cannot start from this disk');
+        }
+        return {
+            fsType: opened.fs.fsType,
+            format: opened.info.format,
+            freeBytes: opened.info.freeBytes,
+            warnings: warnings,
+            bootVerified: false
+        };
+    }
+
+    function prepare(arrayBuffer, filename, options) {
+        options = options || {};
+        var mode = options.mode;
+        var opened = openValidated(arrayBuffer, filename);
+        var fs = opened.fs;
+        var warnings = [];
+        if (!fs.findByName('LD', 'BIN')) warnings.push('LD.BIN is missing; the disk may not boot LSX-Dodgers');
+        if (mode === 'fuzzybasic' && !fs.findByName('FZBASIC', 'COM')) {
+            warnings.push('FZBASIC.COM is missing; FuzzyBASIC cannot start from this disk');
+        }
+
+        MANAGED_FILES.forEach(function(name) { deleteFile(fs, name); });
+        var files = options.files || [];
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
+            if (file.replaceOnly) {
+                var parts = splitName(file.name);
+                if (!fs.findByName(parts.name, parts.ext)) continue;
+            }
+            replaceFile(fs, file.name, file.data);
+        }
+
+        var autoEntry = fs.findByName('AUTOEXEC', 'BAT');
+        var autoBytes = autoEntry ? fs.readFile(autoEntry) : null;
+        var autoexec = updateAutoexec(autoBytes, mode);
+        replaceFile(fs, 'AUTOEXEC.BAT', autoexec.bytes);
+
+        var output = opened.container.toArrayBuffer();
+        var verified = openValidated(output, filename);
+        var required = mode === 'lsx' ? ['PROG.COM'] : ['AUTORUN.BAS'];
+        for (var r = 0; r < required.length; r++) {
+            var requiredParts = splitName(required[r]);
+            if (!verified.fs.findByName(requiredParts.name, requiredParts.ext)) {
+                fail('PROJECT_DISK_VERIFY_FAILED', 'Managed file is missing after serialization: ' + required[r]);
+            }
+        }
+        var verifiedAuto = verified.fs.findByName('AUTOEXEC', 'BAT');
+        if (!verifiedAuto) fail('PROJECT_DISK_VERIFY_FAILED', 'AUTOEXEC.BAT is missing after serialization');
+        var verifiedText = decodeAutoexec(verified.fs.readFile(verifiedAuto)).lines;
+        if (verifiedText.map(firstToken).indexOf(MODE_LAUNCH[mode]) < 0) {
+            fail('PROJECT_DISK_VERIFY_FAILED', 'AUTOEXEC.BAT does not contain the expected launch command');
+        }
+
+        return {
+            bytes: output,
+            mode: mode,
+            warnings: warnings,
+            autoexec: autoexec,
+            bootVerified: false,
+            executionVerified: false,
+            verification: 'filesystem-only'
+        };
+    }
+
+    window.X1PenProjectDisk = Object.freeze({
+        ProjectDiskError: ProjectDiskError,
+        inspect: inspect,
+        prepare: prepare,
+        updateAutoexec: updateAutoexec,
+        _decodeAutoexec: decodeAutoexec,
+        _firstToken: firstToken
+    });
+})();

--- a/html/project_disk.js
+++ b/html/project_disk.js
@@ -32,23 +32,23 @@
         if (ArrayBuffer.isView(value)) {
             return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
         }
-        fail('PROJECT_DISK_INVALID_BYTES', 'Project disk data must be an ArrayBuffer or typed array');
+        fail('PROJECT_DISK_INVALID_BYTES', 'プロジェクトディスクのデータはArrayBufferまたはTypedArrayで指定してください');
     }
 
     function openValidated(arrayBuffer, filename) {
         var bytes = cloneBytes(arrayBuffer);
         var container = window.XmilDiskContainer.openContainer(bytes, filename || 'project.d88', 'fdd');
-        if (!container) fail('PROJECT_DISK_UNSUPPORTED_CONTAINER', 'FDD0 is not a supported D88 or raw 2D image');
-        if (container.isMultiDisk) fail('PROJECT_DISK_MULTI_D88', 'Multi-disk D88 images are not supported as X1Pen project disks');
-        if (container.protect) fail('PROJECT_DISK_WRITE_PROTECTED', 'The selected disk image is write-protected');
+        if (!container) fail('PROJECT_DISK_UNSUPPORTED_CONTAINER', 'FDD0のディスクは対応するD88またはraw 2D形式ではありません');
+        if (container.isMultiDisk) fail('PROJECT_DISK_MULTI_D88', '複数ディスクを含むD88はX1Penプロジェクトディスクとして使用できません');
+        if (container.protect) fail('PROJECT_DISK_WRITE_PROTECTED', '選択したディスクイメージは書き込み禁止です');
 
         var fs = window.XmilDiskFS.detectFilesystem(container);
         if (!fs || fs.fsType !== 'LSX-Dodgers') {
-            fail('PROJECT_DISK_NOT_LSX', 'The selected disk is not an LSX-Dodgers filesystem');
+            fail('PROJECT_DISK_NOT_LSX', '選択したディスクはLSX-Dodgers形式ではありません');
         }
         var info = fs.getInfo();
-        if (info.readOnly) fail('PROJECT_DISK_READ_ONLY', info.readOnlyReason || 'The selected filesystem is read-only');
-        if (info.anomaly) fail('PROJECT_DISK_ANOMALY', 'The selected filesystem has allocation anomalies');
+        if (info.readOnly) fail('PROJECT_DISK_READ_ONLY', '選択したファイルシステムは読み取り専用です');
+        if (info.anomaly) fail('PROJECT_DISK_ANOMALY', '選択したファイルシステムの領域割り当てに異常があります');
         return { container: container, fs: fs, info: info };
     }
 
@@ -93,7 +93,7 @@
 
     function updateAutoexec(existingBytes, mode) {
         var launch = MODE_LAUNCH[mode];
-        if (!launch) fail('PROJECT_DISK_MODE_INVALID', 'Unsupported project disk mode: ' + mode);
+        if (!launch) fail('PROJECT_DISK_MODE_INVALID', '未対応のプロジェクトディスクモードです: ' + mode);
         var decoded = decodeAutoexec(existingBytes);
         var launchLine = launch;
         var retained = [];
@@ -134,9 +134,9 @@
     function inspect(arrayBuffer, filename, mode) {
         var opened = openValidated(arrayBuffer, filename);
         var warnings = [];
-        if (!opened.fs.findByName('LD', 'BIN')) warnings.push('LD.BIN is missing; the disk may not boot LSX-Dodgers');
+        if (!opened.fs.findByName('LD', 'BIN')) warnings.push('LD.BINがありません。LSX-Dodgersを起動できない可能性があります');
         if (mode === 'fuzzybasic' && !opened.fs.findByName('FZBASIC', 'COM')) {
-            warnings.push('FZBASIC.COM is missing; FuzzyBASIC cannot start from this disk');
+            warnings.push('FZBASIC.COMがありません。このディスクからFuzzyBASICを起動できません');
         }
         return {
             fsType: opened.fs.fsType,
@@ -153,9 +153,9 @@
         var opened = openValidated(arrayBuffer, filename);
         var fs = opened.fs;
         var warnings = [];
-        if (!fs.findByName('LD', 'BIN')) warnings.push('LD.BIN is missing; the disk may not boot LSX-Dodgers');
+        if (!fs.findByName('LD', 'BIN')) warnings.push('LD.BINがありません。LSX-Dodgersを起動できない可能性があります');
         if (mode === 'fuzzybasic' && !fs.findByName('FZBASIC', 'COM')) {
-            warnings.push('FZBASIC.COM is missing; FuzzyBASIC cannot start from this disk');
+            warnings.push('FZBASIC.COMがありません。このディスクからFuzzyBASICを起動できません');
         }
 
         MANAGED_FILES.forEach(function(name) { deleteFile(fs, name); });
@@ -180,14 +180,14 @@
         for (var r = 0; r < required.length; r++) {
             var requiredParts = splitName(required[r]);
             if (!verified.fs.findByName(requiredParts.name, requiredParts.ext)) {
-                fail('PROJECT_DISK_VERIFY_FAILED', 'Managed file is missing after serialization: ' + required[r]);
+                fail('PROJECT_DISK_VERIFY_FAILED', '保存後のディスクに管理対象ファイルがありません: ' + required[r]);
             }
         }
         var verifiedAuto = verified.fs.findByName('AUTOEXEC', 'BAT');
-        if (!verifiedAuto) fail('PROJECT_DISK_VERIFY_FAILED', 'AUTOEXEC.BAT is missing after serialization');
+        if (!verifiedAuto) fail('PROJECT_DISK_VERIFY_FAILED', '保存後のディスクにAUTOEXEC.BATがありません');
         var verifiedText = decodeAutoexec(verified.fs.readFile(verifiedAuto)).lines;
         if (verifiedText.map(firstToken).indexOf(MODE_LAUNCH[mode]) < 0) {
-            fail('PROJECT_DISK_VERIFY_FAILED', 'AUTOEXEC.BAT does not contain the expected launch command');
+            fail('PROJECT_DISK_VERIFY_FAILED', 'AUTOEXEC.BATに必要な起動コマンドがありません');
         }
 
         return {

--- a/html/shell.html
+++ b/html/shell.html
@@ -1864,6 +1864,7 @@
 <script src="drive_integration.js"></script>
 <script src="disk_container.js"></script>
 <script src="disk_fs.js"></script>
+<script src="project_disk.js"></script>
 <script src="disk_editor.js"></script>
 {{{ SCRIPT }}}
 </body>

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -835,6 +835,7 @@
     <script src="x1pen.js"></script>
     <script src="disk_container.js"></script>
     <script src="disk_fs.js"></script>
+    <script src="project_disk.js"></script>
     <script src="disk_editor.js"></script>
     <!-- Emscripten バンドル (pre.js 内蔵) -->
     <script src="xmillennium.js"></script>

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -33,6 +33,7 @@ window.__X1PEN_MODE = true;
     var automationInputEpoch = 0;
     window.__X1PEN_SYNTHETIC_INPUT_LOCKED = false;
     var runAdmission = null;
+    var lastRunDetails = null;
     var RUN_QUEUE_TIMEOUT_MS = 20000;
     var RUN_STALL_WARNING_MS = 30000;
     var automationRevision = 0;
@@ -1024,6 +1025,7 @@ window.__X1PEN_MODE = true;
         if (retryable !== undefined) result.retryable = !!retryable;
         if (retryAfterMs !== undefined) result.retryAfterMs = retryAfterMs;
         if (!ok && runAdmission) result.activeOrigin = runAdmission.origin;
+        if (lastRunDetails) Object.keys(lastRunDetails).forEach(function(key) { result[key] = lastRunDetails[key]; });
         return result;
     }
 
@@ -1040,6 +1042,7 @@ window.__X1PEN_MODE = true;
     async function executeReservedRun(token) {
         if (!transitionRunToExecuting(token)) return makeRunBusyResult();
         try {
+            lastRunDetails = null;
             var ok = await performRun(token);
             return makeRunResult(ok);
         } finally {
@@ -1169,6 +1172,17 @@ window.__X1PEN_MODE = true;
             return false;
         }
 
+        var mountedProjectSelection = null;
+        if (window.XmilLibrary && window.XmilLibrary.inspectMountedProjectDisk) {
+            try {
+                mountedProjectSelection = await window.XmilLibrary.inspectMountedProjectDisk();
+            } catch(e) {
+                elStatus.textContent = e.message;
+                lastRunDetails = { code: e.code || 'PROJECT_DISK_READ_FAILED' };
+                return false;
+            }
+        }
+
         // 衝突チェック (Conflict check オプション ON 時のみ)
         var overlapChk = document.getElementById('ec-addr-overlap-check');
         if (runtime.relocAddrs && overlapChk && overlapChk.checked) {
@@ -1189,21 +1203,25 @@ window.__X1PEN_MODE = true;
         var actualColdState = runtime.coldState;
         var actualBootDisk = runtime.bootDisk;
 
-        var stateData = await loadRuntimeAsset(runtime.coldState);
-        if (!stateData && !isLsxMode && runtime.coldState !== COLD_STATE_FILE) {
-            // FuzzyBASIC モードのみ fallback（LSX モードでは fallback しない）
-            console.warn('[x1pen] Fallback to current cold state');
-            stateData = await loadRuntimeAsset(COLD_STATE_FILE);
-            if (stateData) actualColdState = COLD_STATE_FILE;
-        }
-        var bootData = await loadRuntimeAsset(runtime.bootDisk);
-        if (!bootData && !isLsxMode && runtime.bootDisk !== BOOT_DISK_FILE) {
-            console.warn('[x1pen] Fallback to current boot disk');
-            bootData = await loadRuntimeAsset(BOOT_DISK_FILE);
-            if (bootData) actualBootDisk = BOOT_DISK_FILE;
+        var stateData = null;
+        var bootData = null;
+        if (!mountedProjectSelection) {
+            stateData = await loadRuntimeAsset(runtime.coldState);
+            if (!stateData && !isLsxMode && runtime.coldState !== COLD_STATE_FILE) {
+                // FuzzyBASIC モードのみ fallback（LSX モードでは fallback しない）
+                console.warn('[x1pen] Fallback to current cold state');
+                stateData = await loadRuntimeAsset(COLD_STATE_FILE);
+                if (stateData) actualColdState = COLD_STATE_FILE;
+            }
+            bootData = await loadRuntimeAsset(runtime.bootDisk);
+            if (!bootData && !isLsxMode && runtime.bootDisk !== BOOT_DISK_FILE) {
+                console.warn('[x1pen] Fallback to current boot disk');
+                bootData = await loadRuntimeAsset(BOOT_DISK_FILE);
+                if (bootData) actualBootDisk = BOOT_DISK_FILE;
+            }
         }
 
-        if (!stateData) {
+        if (!stateData && !mountedProjectSelection) {
             elStatus.textContent = 'Failed to load cold state';
             return false;
         }
@@ -1259,6 +1277,135 @@ window.__X1PEN_MODE = true;
             }
         }
 
+        var asmBytes = (asmResult && asmResult.bytes.length > 0) ? asmResult.bytes : null;
+
+        // LSX モードで ASM バイナリが 0 byte なら実行不可
+        if (isLsxMode && !asmBytes) {
+            elStatus.textContent = 'Nothing to run (ASM produced no bytes)';
+            return false;
+        }
+
+        // Library-backed FDD0: fork/update the persistent X1Pen project copy,
+        // then boot it normally. No cold state or temporary disk is used here.
+        if (mountedProjectSelection) {
+            var projectApi = window.X1PenProjectDisk;
+            if (!projectApi) {
+                elStatus.textContent = 'Project disk support is unavailable';
+                lastRunDetails = { code: 'PROJECT_DISK_UNAVAILABLE' };
+                return false;
+            }
+            var preview;
+            try {
+                preview = projectApi.inspect(
+                    mountedProjectSelection.bytes,
+                    mountedProjectSelection.entry.name,
+                    runMode
+                );
+            } catch(e) {
+                elStatus.textContent = e.message;
+                lastRunDetails = { code: e.code || 'PROJECT_DISK_INVALID' };
+                return false;
+            }
+            if (!mountedProjectSelection.entry.x1penProject) {
+                var origin = runAdmission ? runAdmission.origin : 'automation';
+                if (origin !== 'ui' && origin !== 'share') {
+                    elStatus.textContent = 'Run once from the X1Pen UI to create a project copy of the mounted FDD0 disk';
+                    lastRunDetails = {
+                        code: 'PROJECT_DISK_SETUP_REQUIRED',
+                        retryable: false,
+                        action: 'Run once interactively in X1Pen, confirm project-copy creation, then retry.'
+                    };
+                    return false;
+                }
+                var managedNames = isLsxMode ? 'PROG.COM and AUTOEXEC.BAT' :
+                    ((asmBytes ? 'PROGRAM.BIN, ' : '') + 'AUTORUN.BAS and AUTOEXEC.BAT');
+                var warningText = preview.warnings.length
+                    ? '\n\nWarnings:\n- ' + preview.warnings.join('\n- ')
+                    : '';
+                var confirmed = confirm(
+                    'Create a persistent X1Pen project copy of "' + mountedProjectSelection.entry.name + '"?\n\n' +
+                    'The copy will be named <source>-X1Pen (with a number if needed).\n' +
+                    'X1Pen will update ' + managedNames + ' in the copy.\n' +
+                    'Guest writes already made to the source disk are flushed normally before copying.\n' +
+                    'The source is not changed by X1Pen program/AUTOEXEC edits.\n\n' +
+                    'Validation checks the LSX filesystem only; boot and program execution are NOT verified.\n' +
+                    'Starting the copy performs a cold power-on and clears emulator RAM.' + warningText
+                );
+                if (!confirmed) {
+                    elStatus.textContent = 'Project disk setup cancelled';
+                    lastRunDetails = { code: 'PROJECT_DISK_SETUP_CANCELLED', bootVerified: false };
+                    return false;
+                }
+            }
+
+            var transaction = null;
+            try {
+                transaction = await window.XmilLibrary.beginProjectDiskTransaction();
+                var projectFiles = [];
+                if (asmBytes) {
+                    projectFiles.push({
+                        name: isLsxMode ? 'PROG.COM' : 'PROGRAM.BIN',
+                        data: new Uint8Array(asmBytes)
+                    });
+                }
+                if (tokenized) projectFiles.push({ name: 'AUTORUN.BAS', data: tokenized });
+                var relocationFiles = await collectRelocationDiskFiles(runtime.relocAddrs);
+                projectFiles = projectFiles.concat(relocationFiles);
+                var prepared = projectApi.prepare(transaction.bytes, transaction.entry.name, {
+                    mode: runMode,
+                    previousMode: transaction.entry.projectMode || null,
+                    files: projectFiles
+                });
+                var projectEntry = await window.XmilLibrary.commitProjectDiskTransaction(
+                    transaction, prepared.bytes, runMode
+                );
+                var machine = window.XmilControls.coldPowerOnProjectDisk(runtime.model, transaction.otherSlots);
+                if (module._js_debug_resume) module._js_debug_resume();
+                lastUsedRuntime = {
+                    model: machine.model,
+                    coldState: actualColdState,
+                    bootDisk: projectEntry.name,
+                    relocAddrs: runtime.relocAddrs,
+                    runMode: runMode
+                };
+                lastRunWasShared = isSharedRun;
+                updateAddrReference(actualColdState);
+                elStatus.textContent = 'Project disk started (filesystem verified; boot not verified)';
+                lastRunDetails = {
+                    projectDisk: true,
+                    projectDiskName: projectEntry.name,
+                    committed: true,
+                    poweredOn: true,
+                    bootVerified: false,
+                    executionVerified: false,
+                    verification: 'filesystem-only',
+                    warnings: prepared.warnings
+                };
+                window.XmilLibrary.finishProjectDiskTransaction(transaction, false);
+                return true;
+            } catch(e) {
+                if (transaction) {
+                    try { await window.XmilLibrary.restoreProjectDiskTransaction(transaction); }
+                    catch(rollbackError) {
+                        e.rollbackFailed = true;
+                        e.rollbackMessage = rollbackError.message;
+                    }
+                    window.XmilLibrary.finishProjectDiskTransaction(transaction, true);
+                }
+                console.error('[x1pen] Project disk Run failed:', e);
+                elStatus.textContent = e.message || 'Project disk update failed';
+                lastRunDetails = {
+                    code: e.code || 'PROJECT_DISK_UPDATE_FAILED',
+                    committed: false,
+                    poweredOn: false,
+                    bootVerified: false,
+                    executionVerified: false,
+                    rollbackFailed: !!e.rollbackFailed
+                };
+                return false;
+            }
+        }
+
         // 6. コールドステート復元 (runtime 指定のステートを使用)
         if (!restoreColdState(stateData)) {
             elStatus.textContent = 'State restore failed';
@@ -1284,14 +1431,6 @@ window.__X1PEN_MODE = true;
         }
 
         // 7. ディスクイメージ作成 (ASM バイナリ and/or AUTORUN.BAS)
-        var asmBytes = (asmResult && asmResult.bytes.length > 0) ? asmResult.bytes : null;
-
-        // LSX モードで ASM バイナリが 0 byte なら実行不可
-        if (isLsxMode && !asmBytes) {
-            elStatus.textContent = 'Nothing to run (ASM produced no bytes)';
-            return false;
-        }
-
         if (asmBytes || tokenized) {
             if (bootData) {
                 if (!(await mountProgramDisk(asmBytes, tokenized, bootData, runtime.relocAddrs, { mode: runMode }))) {
@@ -1341,6 +1480,35 @@ window.__X1PEN_MODE = true;
     }
 
     // ── PROGRAM ディスク マウント ──
+
+    async function collectRelocationDiskFiles(relocAddresses) {
+        var files = [];
+        if (!relocAddresses) return files;
+        try {
+            var config = await loadRelocConfig();
+            if (!config) return files;
+            for (var key in config.binaries) {
+                var binInfo = config.binaries[key];
+                var relData = await loadREL(binInfo.rel_file);
+                if (!relData) {
+                    console.warn('[x1pen] REL not available: ' + binInfo.rel_file);
+                    continue;
+                }
+                var hasSelf = false;
+                for (var gi = 0; gi < binInfo.groups.length; gi++) {
+                    if (binInfo.groups[gi].name === 'SELF') { hasSelf = true; break; }
+                }
+                files.push({
+                    name: binInfo.output_file,
+                    data: patchREL(relData, binInfo.groups, relocAddresses),
+                    replaceOnly: !hasSelf
+                });
+            }
+        } catch(e) {
+            console.warn('[x1pen] Reloc disk patching failed (continuing):', e);
+        }
+        return files;
+    }
 
     async function mountProgramDisk(programBytes, basicTokenized, diskData, relocAddresses, options) {
         var mode = (options && options.mode) || 'fuzzybasic';

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1290,7 +1290,7 @@ window.__X1PEN_MODE = true;
         if (mountedProjectSelection) {
             var projectApi = window.X1PenProjectDisk;
             if (!projectApi) {
-                elStatus.textContent = 'Project disk support is unavailable';
+                elStatus.textContent = 'プロジェクトディスク機能を利用できません';
                 lastRunDetails = { code: 'PROJECT_DISK_UNAVAILABLE' };
                 return false;
             }
@@ -1309,30 +1309,30 @@ window.__X1PEN_MODE = true;
             if (!mountedProjectSelection.entry.x1penProject) {
                 var origin = runAdmission ? runAdmission.origin : 'automation';
                 if (origin !== 'ui' && origin !== 'share') {
-                    elStatus.textContent = 'Run once from the X1Pen UI to create a project copy of the mounted FDD0 disk';
+                    elStatus.textContent = 'FDD0のディスクから作業用コピーを作成するため、X1Pen画面で一度RUNしてください';
                     lastRunDetails = {
                         code: 'PROJECT_DISK_SETUP_REQUIRED',
                         retryable: false,
-                        action: 'Run once interactively in X1Pen, confirm project-copy creation, then retry.'
+                        action: 'X1Pen画面でRUNし、作業用コピーの作成を承認してから再実行してください。'
                     };
                     return false;
                 }
-                var managedNames = isLsxMode ? 'PROG.COM and AUTOEXEC.BAT' :
-                    ((asmBytes ? 'PROGRAM.BIN, ' : '') + 'AUTORUN.BAS and AUTOEXEC.BAT');
+                var managedNames = isLsxMode ? 'PROG.COMとAUTOEXEC.BAT' :
+                    ((asmBytes ? 'PROGRAM.BIN、' : '') + 'AUTORUN.BASとAUTOEXEC.BAT');
                 var warningText = preview.warnings.length
-                    ? '\n\nWarnings:\n- ' + preview.warnings.join('\n- ')
+                    ? '\n\n警告:\n- ' + preview.warnings.join('\n- ')
                     : '';
                 var confirmed = confirm(
-                    'Create a persistent X1Pen project copy of "' + mountedProjectSelection.entry.name + '"?\n\n' +
-                    'The copy will be named <source>-X1Pen (with a number if needed).\n' +
-                    'X1Pen will update ' + managedNames + ' in the copy.\n' +
-                    'Guest writes already made to the source disk are flushed normally before copying.\n' +
-                    'The source is not changed by X1Pen program/AUTOEXEC edits.\n\n' +
-                    'Validation checks the LSX filesystem only; boot and program execution are NOT verified.\n' +
-                    'Starting the copy performs a cold power-on and clears emulator RAM.' + warningText
+                    '「' + mountedProjectSelection.entry.name + '」からX1Pen用の作業ディスクを作成しますか？\n\n' +
+                    '作業ディスク名は「<元の名前>-X1Pen」になります（同名がある場合は連番を付けます）。\n' +
+                    'X1Penは作業ディスク内の' + managedNames + 'を更新します。\n' +
+                    'コピー前に、元ディスク上でゲストが行った書き込みを通常どおり保存します。\n' +
+                    'X1PenによるプログラムやAUTOEXECの更新で、元ディスクが変更されることはありません。\n\n' +
+                    '検証対象はLSXファイルシステムの構造のみです。起動やプログラム実行は確認されません。\n' +
+                    '作業ディスクの起動時にコールドスタートを行うため、エミュレーターのRAMは消去されます。' + warningText
                 );
                 if (!confirmed) {
-                    elStatus.textContent = 'Project disk setup cancelled';
+                    elStatus.textContent = 'プロジェクトディスクの作成をキャンセルしました';
                     lastRunDetails = { code: 'PROJECT_DISK_SETUP_CANCELLED', bootVerified: false };
                     return false;
                 }
@@ -1370,7 +1370,7 @@ window.__X1PEN_MODE = true;
                 };
                 lastRunWasShared = isSharedRun;
                 updateAddrReference(actualColdState);
-                elStatus.textContent = 'Project disk started (filesystem verified; boot not verified)';
+                elStatus.textContent = 'プロジェクトディスクを起動しました（ファイルシステム検証済み、起動未確認）';
                 lastRunDetails = {
                     projectDisk: true,
                     projectDiskName: projectEntry.name,
@@ -1392,8 +1392,8 @@ window.__X1PEN_MODE = true;
                     }
                     window.XmilLibrary.finishProjectDiskTransaction(transaction, true);
                 }
-                console.error('[x1pen] Project disk Run failed:', e);
-                elStatus.textContent = e.message || 'Project disk update failed';
+                console.error('[x1pen] プロジェクトディスクのRUNに失敗:', e);
+                elStatus.textContent = e.message || 'プロジェクトディスクの更新に失敗しました';
                 lastRunDetails = {
                     code: e.code || 'PROJECT_DISK_UPDATE_FAILED',
                     committed: false,

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1370,7 +1370,7 @@ window.__X1PEN_MODE = true;
                 };
                 lastRunWasShared = isSharedRun;
                 updateAddrReference(actualColdState);
-                elStatus.textContent = 'プロジェクトディスクを起動しました（ファイルシステム検証済み、起動未確認）';
+                elStatus.textContent = 'プロジェクトディスクを起動しました';
                 lastRunDetails = {
                     projectDisk: true,
                     projectDiskName: projectEntry.name,
@@ -1400,7 +1400,12 @@ window.__X1PEN_MODE = true;
                     poweredOn: false,
                     bootVerified: false,
                     executionVerified: false,
-                    rollbackFailed: !!e.rollbackFailed
+                    rollbackFailed: !!e.rollbackFailed,
+                    mismatchKind: e.mismatchKind,
+                    requestedModel: e.requestedModel,
+                    activeModel: e.activeModel,
+                    requestedDip: e.requestedDip,
+                    activeDip: e.activeDip
                 };
                 return false;
             }

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1402,8 +1402,6 @@ window.__X1PEN_MODE = true;
                     executionVerified: false,
                     rollbackFailed: !!e.rollbackFailed,
                     mismatchKind: e.mismatchKind,
-                    requestedModel: e.requestedModel,
-                    activeModel: e.activeModel,
                     requestedDip: e.requestedDip,
                     activeDip: e.activeDip
                 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pages:dev": "wrangler pages dev dist/",
     "pages:deploy": "wrangler pages deploy dist/",
     "test:automation": "node --test tests/x1pen_automation_test.mjs",
+    "test:project-disk": "node --test tests/project_disk_test.mjs",
     "test:bridge": "node --test tests/x1pen_bridge_test.mjs",
     "test:extension-package": "node --test tests/x1pen_extension_package_test.mjs tests/x1pen_extension_bridge_test.mjs",
     "test:mcp": "node --test tests/x1pen_mcp_test.mjs tests/x1pen_reference_test.mjs",

--- a/tests/project_disk_test.mjs
+++ b/tests/project_disk_test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+globalThis.window = globalThis;
+const require = createRequire(import.meta.url);
+require('../html/disk_container.js');
+require('../html/disk_fs.js');
+require('../html/project_disk.js');
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+function asset(name) {
+  const bytes = readFileSync(`${root}/assets/${name}`);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+function openFs(bytes, name = 'project.d88') {
+  const container = XmilDiskContainer.openContainer(bytes, name, 'fdd');
+  return XmilDiskFS.detectFilesystem(container);
+}
+
+function textFile(fs, name, ext) {
+  const entry = fs.findByName(name, ext);
+  assert.ok(entry, `${name}.${ext} must exist`);
+  const bytes = fs.readFile(entry);
+  const end = bytes.indexOf(0x1a);
+  return String.fromCharCode(...bytes.slice(0, end < 0 ? bytes.length : end));
+}
+
+test('inspect accepts shipped LSX disks but does not claim boot verification', () => {
+  const result = X1PenProjectDisk.inspect(asset('lsxdodgers_boot.v1.d88'), 'lsx.d88', 'lsx');
+  assert.equal(result.fsType, 'LSX-Dodgers');
+  assert.equal(result.bootVerified, false);
+  assert.ok(result.freeBytes > 0);
+});
+
+test('LSX preparation replaces PROG and places it before another startup program', () => {
+  const source = asset('lsxdodgers_boot.v1.d88');
+  const before = new Uint8Array(source.slice(0));
+  const opened = openFs(source.slice(0));
+  const auto = opened.findByName('AUTOEXEC', 'BAT');
+  opened.deleteFile(auto);
+  opened.addFile('AUTOEXEC', 'BAT', new TextEncoder().encode('PATH=A:\\\r\nOLDGAME\r\n\x1a'));
+  const custom = opened._container ? opened._container.toArrayBuffer() : null;
+  // LsxDodgersFS intentionally keeps its container private only by convention.
+  const input = custom || source;
+
+  const result = X1PenProjectDisk.prepare(input, 'game.d88', {
+    mode: 'lsx',
+    files: [{ name: 'PROG.COM', data: new Uint8Array([1, 2, 3]) }],
+  });
+  const fs = openFs(result.bytes);
+  assert.deepEqual(Array.from(fs.readFile(fs.findByName('PROG', 'COM'))), [1, 2, 3]);
+  assert.match(textFile(fs, 'AUTOEXEC', 'BAT'), /^PATH=A:\\\r?\nPROG\r?\nOLDGAME/m);
+  assert.deepEqual(new Uint8Array(source), before, 'input/source bytes must not be mutated');
+  assert.equal(result.bootVerified, false);
+  assert.equal(result.executionVerified, false);
+});
+
+test('Fuzzy preparation removes stale LSX managed output and switches launch mode', () => {
+  const lsx = X1PenProjectDisk.prepare(asset('fuzzybasic_boot.v2.d88'), 'project.d88', {
+    mode: 'lsx',
+    files: [{ name: 'PROG.COM', data: new Uint8Array([0xc9]) }],
+  });
+  const fuzzy = X1PenProjectDisk.prepare(lsx.bytes, 'project.d88', {
+    mode: 'fuzzybasic',
+    previousMode: 'lsx',
+    files: [
+      { name: 'PROGRAM.BIN', data: new Uint8Array([9, 8]) },
+      { name: 'AUTORUN.BAS', data: new Uint8Array([7, 6]) },
+    ],
+  });
+  const fs = openFs(fuzzy.bytes);
+  assert.equal(fs.findByName('PROG', 'COM'), null);
+  assert.ok(fs.findByName('PROGRAM', 'BIN'));
+  assert.ok(fs.findByName('AUTORUN', 'BAS'));
+  const auto = textFile(fs, 'AUTOEXEC', 'BAT');
+  assert.match(auto, /(^|\r?\n)FZBASIC(\r?\n|$)/);
+  assert.doesNotMatch(auto, /(^|\r?\n)PROG(\r?\n|$)/);
+});
+
+test('AUTOEXEC is created when missing and existing launch arguments are preserved', () => {
+  const updated = X1PenProjectDisk.updateAutoexec(
+    new TextEncoder().encode('SET FOO=1\nOLDGAME\nPROG /Q\n\x1a'),
+    'lsx',
+  );
+  assert.deepEqual(updated.lines, ['SET FOO=1', 'PROG /Q', 'OLDGAME']);
+
+  const created = X1PenProjectDisk.updateAutoexec(null, 'fuzzybasic');
+  assert.deepEqual(created.lines, ['FZBASIC']);
+  assert.equal(created.bytes.at(-1), 0x1a);
+});
+
+test('multi-member, protected, and non-LSX images are rejected structurally', () => {
+  const first = new Uint8Array(asset('lsxdodgers_boot.v1.d88'));
+  const multi = new Uint8Array(first.length * 2);
+  multi.set(first, 0);
+  multi.set(first, first.length);
+  assert.throws(
+    () => X1PenProjectDisk.inspect(multi.buffer, 'multi.d88', 'lsx'),
+    (error) => error.code === 'PROJECT_DISK_MULTI_D88',
+  );
+
+  const protectedDisk = new Uint8Array(first);
+  protectedDisk[0x1a] = 0x10;
+  assert.throws(
+    () => X1PenProjectDisk.inspect(protectedDisk.buffer, 'protected.d88', 'lsx'),
+    (error) => error.code === 'PROJECT_DISK_WRITE_PROTECTED',
+  );
+
+  assert.throws(
+    () => X1PenProjectDisk.inspect(new ArrayBuffer(327680), 'blank.2d', 'lsx'),
+    (error) => error.code === 'PROJECT_DISK_NOT_LSX',
+  );
+});

--- a/tests/project_disk_test.mjs
+++ b/tests/project_disk_test.mjs
@@ -101,18 +101,18 @@ test('multi-member, protected, and non-LSX images are rejected structurally', ()
   multi.set(first, first.length);
   assert.throws(
     () => X1PenProjectDisk.inspect(multi.buffer, 'multi.d88', 'lsx'),
-    (error) => error.code === 'PROJECT_DISK_MULTI_D88',
+    (error) => error.code === 'PROJECT_DISK_MULTI_D88' && /複数ディスク/.test(error.message),
   );
 
   const protectedDisk = new Uint8Array(first);
   protectedDisk[0x1a] = 0x10;
   assert.throws(
     () => X1PenProjectDisk.inspect(protectedDisk.buffer, 'protected.d88', 'lsx'),
-    (error) => error.code === 'PROJECT_DISK_WRITE_PROTECTED',
+    (error) => error.code === 'PROJECT_DISK_WRITE_PROTECTED' && /書き込み禁止/.test(error.message),
   );
 
   assert.throws(
     () => X1PenProjectDisk.inspect(new ArrayBuffer(327680), 'blank.2d', 'lsx'),
-    (error) => error.code === 'PROJECT_DISK_NOT_LSX',
+    (error) => error.code === 'PROJECT_DISK_NOT_LSX' && /LSX-Dodgers形式ではありません/.test(error.message),
   );
 });

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1916,7 +1916,7 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
     assert.equal(rerun.bootVerified, false);
     assert.equal(rerun.executionVerified, false);
     assert.equal(rerun.verification, 'filesystem-only');
-    assert.match(rerun.status, /ファイルシステム検証済み、起動未確認/);
+    assert.equal(rerun.status, 'プロジェクトディスクを起動しました');
 
     const drive1AfterRerun = await projectPage.evaluate(() => window.XmilCore.getSlotState().drive1);
     assert.equal(drive1AfterRerun, first.data.key);
@@ -1925,6 +1925,15 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
       () => window.XmilCore.getLibrary().filter((entry) => entry.x1penProject).map((entry) => entry.name),
     );
     assert.deepEqual(projectsAfterRerun, [first.project.name], 'metadata must prevent a second project copy');
+
+    await projectPage.evaluate(() => window.XmilControls.setRomType(2));
+    const modelMismatch = await projectPage.evaluate(() => window.X1PenAutomation.run());
+    assert.equal(modelMismatch.ok, false);
+    assert.equal(modelMismatch.code, 'PROJECT_DISK_MACHINE_MISMATCH');
+    assert.equal(modelMismatch.mismatchKind, 'model');
+    assert.equal(modelMismatch.requestedModel, 2);
+    assert.equal(modelMismatch.activeModel, 1);
+    assert.match(modelMismatch.status, /起動中と異なるMODELへ切り替えてRUNできません/);
 
     const rollback = await projectPage.evaluate(async () => {
       const api = window.X1PenAutomation;

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1926,14 +1926,20 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
     );
     assert.deepEqual(projectsAfterRerun, [first.project.name], 'metadata must prevent a second project copy');
 
-    await projectPage.evaluate(() => window.XmilControls.setRomType(2));
-    const modelMismatch = await projectPage.evaluate(() => window.X1PenAutomation.run());
-    assert.equal(modelMismatch.ok, false);
-    assert.equal(modelMismatch.code, 'PROJECT_DISK_MACHINE_MISMATCH');
-    assert.equal(modelMismatch.mismatchKind, 'model');
-    assert.equal(modelMismatch.requestedModel, 2);
-    assert.equal(modelMismatch.activeModel, 1);
-    assert.match(modelMismatch.status, /起動中と異なるMODELへ切り替えてRUNできません/);
+    for (const selectedModel of [2, 3]) {
+      const modelRun = await projectPage.evaluate(async (model) => {
+        window.XmilControls.setRomType(model);
+        return {
+          result: await window.X1PenAutomation.run(),
+          activeModel: window.Module._js_get_rom_type(),
+        };
+      }, selectedModel);
+      assert.equal(modelRun.result.ok, true);
+      assert.equal(modelRun.result.verification, 'filesystem-only');
+      assert.equal(modelRun.result.bootVerified, false);
+      assert.equal(modelRun.result.executionVerified, false);
+      assert.equal(modelRun.activeModel, selectedModel);
+    }
 
     const rollback = await projectPage.evaluate(async () => {
       const api = window.X1PenAutomation;

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1859,13 +1859,22 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
     const setupRequired = await projectPage.evaluate(() => window.X1PenAutomation.run());
     assert.equal(setupRequired.ok, false);
     assert.equal(setupRequired.code, 'PROJECT_DISK_SETUP_REQUIRED');
+    assert.match(setupRequired.status, /X1Pen画面で一度RUNしてください/);
+    assert.match(setupRequired.action, /作業用コピーの作成を承認/);
 
-    projectPage.on('dialog', (dialog) => dialog.accept());
+    const dialogMessages = [];
+    projectPage.on('dialog', (dialog) => {
+      dialogMessages.push(dialog.message());
+      dialog.accept();
+    });
     await projectPage.locator('#btn-run').click();
     await projectPage.waitForFunction(() => {
       const entry = window.XmilCore.getLibrary().find((candidate) => candidate.x1penProject);
       return entry && !window.X1PenAutomation.getStatus().capabilities.debugger.runPending;
     });
+    assert.equal(dialogMessages.length, 1);
+    assert.match(dialogMessages[0], /X1Pen用の作業ディスクを作成しますか/);
+    assert.match(dialogMessages[0], /起動やプログラム実行は確認されません/);
 
     const first = await projectPage.evaluate(async () => {
       const library = window.XmilCore.getLibrary();
@@ -1907,6 +1916,7 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
     assert.equal(rerun.bootVerified, false);
     assert.equal(rerun.executionVerified, false);
     assert.equal(rerun.verification, 'filesystem-only');
+    assert.match(rerun.status, /ファイルシステム検証済み、起動未確認/);
 
     const drive1AfterRerun = await projectPage.evaluate(() => window.XmilCore.getSlotState().drive1);
     assert.equal(drive1AfterRerun, first.data.key);

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1828,3 +1828,131 @@ test('embedded M8A data assembles and draws into graphics VRAM', { timeout: 60_0
   assert.equal(result.run.sourceMode, 'slang');
   assert.deepEqual(result.observed, { blue: 0xFF, red: 0x00, green: 0x00 });
 });
+
+test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90_000 }, async () => {
+  const context = await browser.newContext();
+  const projectPage = await context.newPage();
+  try {
+    await projectPage.goto(`${baseUrl}/x1pen.html`);
+    await projectPage.evaluate(() => window.X1PenAutomation.ready());
+    await projectPage.evaluate(async () => {
+      const response = await fetch('fuzzybasic_boot.v2.d88');
+      const bytes = await response.arrayBuffer();
+      const entry = await window.XmilLibrary.addToLibrary(
+        new File([bytes], 'OWNER.D88', { type: 'application/octet-stream' }),
+      );
+      const dataEntry = await window.XmilLibrary.addToLibrary(
+        new File([bytes], 'DATA.D88', { type: 'application/octet-stream' }),
+      );
+      await window.XmilLibrary.mountFromLibrary(entry.key, 'drive0');
+      await window.XmilLibrary.mountFromLibrary(dataEntry.key, 'drive1');
+      const api = window.X1PenAutomation;
+      const current = api.getProgram();
+      await api.setProgram({
+        sourceMode: 'basic+asm',
+        basic: '10 PRINT "PROJECT DISK"\n20 END',
+        asm: '',
+        slang: '',
+      }, current.revision, current.revisionEpoch);
+    });
+
+    const setupRequired = await projectPage.evaluate(() => window.X1PenAutomation.run());
+    assert.equal(setupRequired.ok, false);
+    assert.equal(setupRequired.code, 'PROJECT_DISK_SETUP_REQUIRED');
+
+    projectPage.on('dialog', (dialog) => dialog.accept());
+    await projectPage.locator('#btn-run').click();
+    await projectPage.waitForFunction(() => {
+      const entry = window.XmilCore.getLibrary().find((candidate) => candidate.x1penProject);
+      return entry && !window.X1PenAutomation.getStatus().capabilities.debugger.runPending;
+    });
+
+    const first = await projectPage.evaluate(async () => {
+      const library = window.XmilCore.getLibrary();
+      const source = library.find((entry) => entry.name === 'OWNER.D88');
+      const data = library.find((entry) => entry.name === 'DATA.D88');
+      const project = library.find((entry) => entry.x1penProject);
+      const slots = window.XmilCore.getSlotState();
+      const bytes = await window.XmilStorage.read(project.key);
+      const container = window.XmilDiskContainer.openContainer(bytes, project.name, 'fdd');
+      const fs = window.XmilDiskFS.detectFilesystem(container);
+      const auto = fs.readFile(fs.findByName('AUTOEXEC', 'BAT'));
+      return {
+        source,
+        data,
+        project,
+        drive0: slots.drive0,
+        drive1: slots.drive1,
+        autorun: !!fs.findByName('AUTORUN', 'BAS'),
+        autoexec: String.fromCharCode(...auto).split(String.fromCharCode(0x1a))[0],
+      };
+    });
+    assert.ok(first.source);
+    assert.ok(first.data);
+    assert.equal(first.source.x1penProject, undefined);
+    assert.match(first.project.name, /^OWNER-X1Pen(?:-\d+)?\.D88$/);
+    assert.equal(first.project.sourceKey, first.source.key);
+    assert.equal(first.project.projectMode, 'fuzzybasic');
+    assert.equal(first.drive0, first.project.key);
+    assert.equal(first.drive1, first.data.key);
+    assert.equal(first.autorun, true);
+    assert.match(first.autoexec, /(^|\r?\n)FZBASIC(\r?\n|$)/);
+
+    const rerun = await projectPage.evaluate(() => window.X1PenAutomation.run());
+    assert.equal(rerun.ok, true);
+    assert.equal(rerun.projectDisk, true);
+    assert.equal(rerun.projectDiskName, first.project.name);
+    assert.equal(rerun.committed, true);
+    assert.equal(rerun.poweredOn, true);
+    assert.equal(rerun.bootVerified, false);
+    assert.equal(rerun.executionVerified, false);
+    assert.equal(rerun.verification, 'filesystem-only');
+
+    const drive1AfterRerun = await projectPage.evaluate(() => window.XmilCore.getSlotState().drive1);
+    assert.equal(drive1AfterRerun, first.data.key);
+
+    const projectsAfterRerun = await projectPage.evaluate(
+      () => window.XmilCore.getLibrary().filter((entry) => entry.x1penProject).map((entry) => entry.name),
+    );
+    assert.deepEqual(projectsAfterRerun, [first.project.name], 'metadata must prevent a second project copy');
+
+    const rollback = await projectPage.evaluate(async () => {
+      const api = window.X1PenAutomation;
+      const project = window.XmilCore.getLibrary().find((entry) => entry.x1penProject);
+      const original = await window.XmilStorage.read(project.key);
+      const originalHash = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', original)))
+        .map((byte) => byte.toString(16).padStart(2, '0')).join('');
+      const savedWrite = window.XmilStorage.write;
+      let failed = false;
+      window.XmilStorage.write = async function(key, bytes) {
+        await savedWrite.call(this, key, bytes);
+        if (key === project.key && !failed) {
+          failed = true;
+          throw new Error('forced post-write failure');
+        }
+      };
+      let result;
+      try {
+        result = await api.run();
+      } finally {
+        window.XmilStorage.write = savedWrite;
+      }
+      const restored = await window.XmilStorage.read(project.key);
+      const restoredHash = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', restored)))
+        .map((byte) => byte.toString(16).padStart(2, '0')).join('');
+      return {
+        result,
+        originalHash,
+        restoredHash,
+        drive0: window.XmilCore.getSlotState().drive0,
+        projectKey: project.key,
+      };
+    });
+    assert.equal(rollback.result.ok, false);
+    assert.equal(rollback.result.rollbackFailed, false);
+    assert.equal(rollback.restoredHash, rollback.originalHash);
+    assert.equal(rollback.drive0, rollback.projectKey);
+  } finally {
+    await context.close();
+  }
+});


### PR DESCRIPTION
## Summary

- FDD0の書き込み可能なLSX D88/2Dを、初回確認後に別名の永続project copyへforkします
- project metadata、連番命名、厳格flush、read-back検証、rollback、media lockを追加します
- Run生成物とAUTOEXECをworking copyだけへ反映し、FDD1は独立したまま通常のcold power-onを行います
- Automation/MCPは初回だけPROJECT_DISK_SETUP_REQUIREDを返し、作成後は同じcopyを再利用します
- filesystem検証のみで、boot/program実行は未検証であることをAPI/UI/docsに明示します
- versionは変更していません

## Verification

- ./build.sh
- npm run test:project-disk — 5 passed
- npm run test:automation — 22 passed
- focused mounted-FDD0 browser test — passed after final FDD1 assertion
- npm run test:bridge — 12 passed
- npm run test:mcp — 74 passed
- npm run test:extension-package — 16 passed
- npm run test:mcp-package — 1 passed
- JS syntax checks and git diff --check
- Secretary opposite-provider plan review Round 4: APPROVED, blocking findings 0

## Manual verification

1. 書き込み可能なLSX-Dodgers D88/2DをLibraryへ追加しFDD0へmountする
2. 必要ならDisk EditorでMAG等のdata fileを追加し、二枚組なら別diskをFDD1へmountする
3. X1PenでRunし、別名project copy作成の確認を承認する
4. Libraryに元名-X1Pen（衝突時は連番）が作られ、FDD0がそのcopyを指すことを確認する
5. 再Runとページ再読込後もcopyが増えず、同じproject diskが使われることを確認する
6. Library Downloadで現在のworking copyを外部保存する

Note: committed/poweredOnはfilesystem commitとpower-on呼出しまでを表し、guest bootやprogram開始を保証しません。

Closes #89