### PR TITLE
feat: MCPからローカルUTF-8ソースファイルを直接反映する

### DIFF
--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -53,6 +53,20 @@ claude mcp list
 }
 ```
 
+### ローカルソースファイルの許可root
+
+`x1pen_set_source_file`でローカルUTF-8ソースを直接反映する場合だけ、MCP起動引数へ許可rootを明示します。未指定時はfilesystem readを拒否します。
+
+```toml
+[mcp_servers.x1pen]
+command = "npx"
+args = ["-y", "x1pen-mcp@latest", "--allow-source-root", "/absolute/path/to/project/sources"]
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+```
+
+複数rootは`--allow-source-root <dir>`を繰り返します。rootは起動時に存在するdirectoryでなければならず、誤ったrootはローカル起動errorに設定値を示してfail fastします。canonical root外、symlink escape、非regular file、invalid UTF-8、NUL、512 KiB超過、読み取り中にidentity/size/mtimeが変わったfileは拒否します。relative pathもMCP processのcwdから解決した後、同じroot境界を適用します。先頭のUTF-8 BOMを1個除去し、CRLFと単独CRをLFへ正規化してからX1Penへ送ります。応答にはhost pathとsource本文を含めず、section、raw fileのbyte数・SHA-256、変更有無、revision/hash metadataだけを返します。section summaryのhashは正規化後に保存されたsourceを表します。
+
 ### 拡張機能
 
 Chrome Web Store版の公開後はストアからインストールする方式を推奨します。ストア審査中または拡張機能を開発する場合は、次の手順でunpacked extensionを読み込みます。
@@ -98,6 +112,7 @@ feature IDは完全一致する不変の契約です。現在は`automation.core
 | `x1pen_diff_source` | full source-sync時に保持済みbaselineと現在の1セクションを上限付きline diffで比較 |
 | `x1pen_apply_edits` | full時はepoch/revision、縮退時はrevisionをguardに構造化された行編集を適用 |
 | `x1pen_set_program` | full時はepoch/revision、縮退時はrevisionをguardにプログラム全体を更新（新規作成・全置換用。sourceModeで非対象のsectionは入力してもclear） |
+| `x1pen_set_source_file` | 許可root内のlocal UTF-8 fileから1つの編集可能sectionをguard付きで置換（path/contentは応答しない） |
 | `x1pen_validate` | 実行せずにコンパイル、アセンブル、トークナイズ（SLANG生成ASMは一時出力でprogramには保持しない） |
 | `x1pen_run` | ユーザーが開いているX1Penで実行 |
 | `x1pen_recover_stalled` | stallしたRun準備を、データ損失確認後のタブ再読込で復旧 |
@@ -117,7 +132,7 @@ feature IDは完全一致する不変の契約です。現在は`automation.core
 | `x1pen_debug_write_vram` | 停止中にVRAMへ連続16進データを書き込み |
 | `x1pen_debug_wait_for_pause` | 条件に一致する停止まで待機 |
 
-AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。MCP・Connector・X1Penの3コンポーネントがすべて`automation.source-sync`をadvertiseする場合、`x1pen_set_program`と`x1pen_apply_edits`は取得済みの`revisionEpoch`と`revision`を要求し、途中の人間編集やタブ再読込を検出して上書きを拒否します。いずれかが旧版または判定不能の場合は従来のnumeric revision guardへ縮退します。読み取り・書き込み結果の`guardedWritesReloadSafe: false` / `writeGuard: "revision-only"`は、再読込後に同じrevision値へ戻る衝突を検出できないことを示します。
+AIによる更新、検証、実行、停止中はエディターとツールバーを一時的にロックします。MCP・Connector・X1Penの3コンポーネントがすべて`automation.source-sync`をadvertiseする場合、`x1pen_set_program`、`x1pen_set_source_file`、`x1pen_apply_edits`は取得済みの`revisionEpoch`と`revision`を要求し、途中の人間編集やタブ再読込を検出して上書きを拒否します。いずれかが旧版または判定不能の場合は従来のnumeric revision guardへ縮退します。読み取り・書き込み結果の`guardedWritesReloadSafe: false` / `writeGuard: "revision-only"`は、再読込後に同じrevision値へ戻る衝突を検出できないことを示します。
 
 縮退時も`get_program`、`get_source`、`search_source`、`set_program`、`apply_edits`は利用できます。`diff_source`だけは3コンポーネントすべてのsource-sync対応が必要です。旧Connector × 新MCP × 新X1Penでは、X1Penがepochを返しても旧Connectorが書き込み時のepochを転送しないため、書き込み結果は必ずrevision-onlyと表示されます。`apply_edits`は最終書き込み直前にもrevision・epoch（取得可能時）・mode・hashを再確認しますが、その再確認から書き込みまでの短い区間はatomicではありません。
 
@@ -247,6 +262,17 @@ X1ハードウェアについては、Z80のCPUメモリと16bit I/O空間の分
       "text": "replacement source"
     }
   ]
+}
+```
+
+ローカルファイル本文をAIへ展開せずに現在modeの1セクションを置換する場合は`x1pen_set_source_file`を使用します。先に`x1pen_get_program`でguardを取得し、設定済みroot内のpathと編集可能なsectionを指定します。BASIC+ASM modeではbasic/asmの他方を保持し、SLANG置換時はRunが生成したASMをclearします。
+
+```json
+{
+  "path": "/absolute/path/to/project/sources/main.slang",
+  "section": "slang",
+  "expectedRevisionEpoch": "取得時のrevisionEpoch",
+  "expectedRevision": 3
 }
 ```
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -27,6 +27,20 @@ claude mcp add --transport stdio --scope user x1pen -- \
 
 Use `claude mcp list` or `/mcp` to check the connection.
 
+## Local source files
+
+`x1pen_set_source_file` can replace one editable BASIC, ASM, or SLANG section directly from a local UTF-8 file without returning its path or content to the model. File access is disabled by default. Add one or more explicit roots when starting the MCP server:
+
+```toml
+[mcp_servers.x1pen]
+command = "npx"
+args = ["-y", "x1pen-mcp@latest", "--allow-source-root", "/absolute/path/to/project/sources"]
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+```
+
+Repeat `--allow-source-root <dir>` to allow multiple source trees. Each root must already exist and be a directory; a bad root fails server startup with its configured value visible in the local startup error. The tool resolves canonical paths, rejects paths and symlinks that escape every root, accepts regular files only, and rejects invalid UTF-8, NUL, files over 512 KiB, and files that change during the read. It strips one leading UTF-8 BOM and normalizes CRLF or lone CR to LF before writing. It applies the same revision/epoch guard as other source writes, preserves the other authoring section, and clears generated ASM when replacing SLANG. Results contain only the section, raw-file byte count and SHA-256, changed state, and program metadata; the section summary hash describes the normalized stored text.
+
 ## Pairing
 
 1. Call `x1pen_connection_info` from the AI client.
@@ -42,7 +56,7 @@ Connection, session and status results report the versions and effective feature
 
 The current feature contracts are `automation.core`, `automation.run-recovery`, `automation.source-sync`, `screen.capture`, `input.keyboard`, `input.pad`, `debugger.cpu` and `debugger.vram`. `automation.source-sync` covers epoch-bound guarded writes and structured source conflicts. Feature IDs are immutable. A backward-incompatible successor uses a new ID such as `debugger.vram-v2` rather than changing the meaning of an existing ID.
 
-Program metadata includes exact UTF-8 SHA-256 section hashes, a mode-aware authoring hash, `revisionEpoch` when available, `revision`, `guardedWritesReloadSafe`, and `writeGuard`. Retain the epoch/revision pair before editing. When MCP, Connector, and X1Pen all advertise `automation.source-sync`, `x1pen_set_program` and `x1pen_apply_edits` require both values and fail closed after reload or concurrent edit. A full-capability snapshot that omits its own epoch fails writes with `REVISION_EPOCH_UNAVAILABLE` instead of asking the caller for an unobtainable value. Older or unknown peers visibly degrade to numeric revision guarding (`guardedWritesReloadSafe: false`, `writeGuard: revision-only`); reads and writes remain available, while `x1pen_diff_source` requires full source-sync support. Bounded source reads accept a present empty string but report `SOURCE_CONTENT_UNAVAILABLE` when the page omits a source field. Degraded `apply_edits` re-reads mode, hashes, epoch, and revision immediately before its whole-program write, but that check and write are not atomic. On conflict, compare hashes (or use diff only in full mode); never update only the revision and resend stale source. Diff baselines are held only in a bounded, expiring in-memory cache. An optional caller-supplied baseline is labeled self-attested, generated SLANG ASM requires explicit opt-in, and all diff inputs/work/hunks/output are bounded.
+Program metadata includes exact UTF-8 SHA-256 section hashes, a mode-aware authoring hash, `revisionEpoch` when available, `revision`, `guardedWritesReloadSafe`, and `writeGuard`. Retain the epoch/revision pair before editing. When MCP, Connector, and X1Pen all advertise `automation.source-sync`, `x1pen_set_program`, `x1pen_set_source_file`, and `x1pen_apply_edits` require both values and fail closed after reload or concurrent edit. A full-capability snapshot that omits its own epoch fails writes with `REVISION_EPOCH_UNAVAILABLE` instead of asking the caller for an unobtainable value. Older or unknown peers visibly degrade to numeric revision guarding (`guardedWritesReloadSafe: false`, `writeGuard: revision-only`); reads and writes remain available, while `x1pen_diff_source` requires full source-sync support. Bounded source reads accept a present empty string but report `SOURCE_CONTENT_UNAVAILABLE` when the page omits a source field. Degraded file replacement and `apply_edits` re-read mode, hashes, epoch, and revision immediately before their whole-program write, but that check and write are not atomic. On conflict, compare hashes (or use diff only in full mode); never replace only the revision and blindly retry a stale write. Diff baselines are held only in a bounded, expiring in-memory cache. An optional caller-supplied baseline is labeled self-attested, generated SLANG ASM requires explicit opt-in, and all diff inputs/work/hunks/output are bounded.
 
 Source validation failures are structured: `EDIT_RANGE_INVALID`, `EDITS_OVERLAP`, `SOURCE_SECTION_NOT_EDITABLE`, `SOURCE_LIMIT_EXCEEDED`, `SOURCE_RANGE_INVALID`, and `GENERATED_SOURCE_REQUIRES_OPT_IN`. Known Connector feature minimums are returned as `requiredVersion` even when the Connector advertises an explicit feature list. Unmapped bridge RPC methods fail closed with `METHOD_FEATURE_UNMAPPED` before transport.
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -13,6 +13,7 @@
     "reference",
     "x1pen-bridge.mjs",
     "x1pen-compatibility.mjs",
+    "x1pen-local-source.mjs",
     "x1pen-reference.mjs",
     "x1pen-server.mjs",
     "x1pen-source-sync.mjs"

--- a/mcp/x1pen-local-source.mjs
+++ b/mcp/x1pen-local-source.mjs
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+import { constants, realpathSync, statSync } from 'node:fs';
+import { open, realpath, stat } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+export const MAX_LOCAL_SOURCE_BYTES = 512 * 1024;
+
+export class LocalSourceError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = 'LocalSourceError';
+    this.code = code;
+    this.component = 'mcp';
+    Object.assign(this, details);
+  }
+}
+
+function sourceError(code, message, details = {}) {
+  return new LocalSourceError(code, message, details);
+}
+
+export function canonicalizeAllowedSourceRoots(rootPaths = []) {
+  const roots = [];
+  for (const rootPath of rootPaths) {
+    if (typeof rootPath !== 'string' || rootPath.length === 0) {
+      throw new Error('Allowed source roots must be non-empty paths');
+    }
+    const canonical = realpathSync(resolve(rootPath));
+    if (!statSync(canonical).isDirectory()) {
+      throw new Error(`Allowed source root is not a directory: ${rootPath}`);
+    }
+    if (!roots.includes(canonical)) roots.push(canonical);
+  }
+  return Object.freeze(roots);
+}
+
+export function assertSourceRootsConfigured(allowedRoots) {
+  if (!Array.isArray(allowedRoots) || allowedRoots.length === 0) {
+    throw sourceError(
+      'SOURCE_ROOT_NOT_CONFIGURED',
+      'Local source-file access is disabled because no allowed source root is configured',
+      { action: 'Restart x1pen-mcp with one or more --allow-source-root options.' },
+    );
+  }
+}
+
+function isWithinRoot(candidate, root) {
+  const child = relative(root, candidate);
+  return child === '' || (!isAbsolute(child) && child !== '..' && !child.startsWith(`..${sep}`));
+}
+
+function sameIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameSnapshot(left, right) {
+  return sameIdentity(left, right) && left.size === right.size && left.mtimeNs === right.mtimeNs;
+}
+
+const DEFAULT_IO = Object.freeze({ open, realpath, stat });
+
+async function canonicalCandidate(filePath, allowedRoots, io) {
+  let candidate;
+  try {
+    candidate = await io.realpath(resolve(filePath));
+  } catch {
+    throw sourceError('SOURCE_FILE_NOT_FOUND', 'The local source file does not exist or cannot be resolved');
+  }
+  if (!allowedRoots.some((root) => isWithinRoot(candidate, root))) {
+    throw sourceError('SOURCE_PATH_NOT_ALLOWED', 'The local source file is outside every allowed source root');
+  }
+  return candidate;
+}
+
+async function readBounded(handle, maxBytes) {
+  const bytes = Buffer.alloc(maxBytes + 1);
+  let offset = 0;
+  while (offset < bytes.length) {
+    const result = await handle.read(bytes, offset, bytes.length - offset, null);
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  if (offset > maxBytes) {
+    throw sourceError(
+      'SOURCE_FILE_TOO_LARGE',
+      `The local source file exceeds the ${maxBytes}-byte limit`,
+      { limit: maxBytes, actual: offset },
+    );
+  }
+  return bytes.subarray(0, offset);
+}
+
+export async function readLocalUtf8Source(filePath, options = {}) {
+  const allowedRoots = options.allowedRoots || [];
+  const maxBytes = options.maxBytes ?? MAX_LOCAL_SOURCE_BYTES;
+  const io = options.io || DEFAULT_IO;
+  assertSourceRootsConfigured(allowedRoots);
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    throw sourceError('SOURCE_PATH_INVALID', 'The local source path must be a non-empty string');
+  }
+
+  const candidate = await canonicalCandidate(filePath, allowedRoots, io);
+  let handle;
+  let before;
+  let after;
+  let bytes;
+  try {
+    handle = await io.open(candidate, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    before = await handle.stat({ bigint: true });
+    if (!before.isFile()) {
+      throw sourceError('SOURCE_FILE_NOT_REGULAR', 'The local source path is not a regular file');
+    }
+    if (before.size > BigInt(maxBytes)) {
+      throw sourceError(
+        'SOURCE_FILE_TOO_LARGE',
+        `The local source file exceeds the ${maxBytes}-byte limit`,
+        { limit: maxBytes, actual: Number(before.size) },
+      );
+    }
+    bytes = await readBounded(handle, maxBytes);
+    after = await handle.stat({ bigint: true });
+  } catch (error) {
+    if (error instanceof LocalSourceError) throw error;
+    throw sourceError('SOURCE_FILE_READ_FAILED', 'The local source file could not be read safely');
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+
+  let finalCandidate;
+  let finalStat;
+  try {
+    finalCandidate = await io.realpath(resolve(filePath));
+    finalStat = await io.stat(candidate, { bigint: true });
+  } catch {
+    throw sourceError('SOURCE_FILE_CHANGED', 'The local source file changed while it was being read');
+  }
+  if (finalCandidate !== candidate || !sameSnapshot(before, after) || !sameIdentity(after, finalStat)) {
+    throw sourceError('SOURCE_FILE_CHANGED', 'The local source file changed while it was being read');
+  }
+
+  let source;
+  try {
+    source = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch {
+    throw sourceError('SOURCE_FILE_INVALID_UTF8', 'The local source file is not valid UTF-8');
+  }
+  if (source.startsWith('\uFEFF')) source = source.slice(1);
+  source = source.replace(/\r\n?/g, '\n');
+  if (source.includes('\0')) {
+    throw sourceError('SOURCE_FILE_CONTAINS_NUL', 'The local source file contains a NUL character');
+  }
+
+  return {
+    source,
+    byteCount: bytes.byteLength,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}

--- a/mcp/x1pen-server.mjs
+++ b/mcp/x1pen-server.mjs
@@ -24,6 +24,11 @@ import {
   getReferenceManifest,
   searchReference,
 } from './x1pen-reference.mjs';
+import {
+  assertSourceRootsConfigured,
+  canonicalizeAllowedSourceRoots,
+  readLocalUtf8Source,
+} from './x1pen-local-source.mjs';
 
 const PACKAGE = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 const MAX_SOURCE_LENGTH = 512 * 1024;
@@ -65,6 +70,7 @@ const SERVER_INSTRUCTIONS = [
   'Before writing or substantially editing a program, call x1pen_get_language_profile, search the bundled reference with x1pen_search_reference, and fetch only the needed IDs with x1pen_get_reference.',
   'After editing, call x1pen_validate. Run and inspect the visible emulator when behavior must be confirmed.',
   'x1pen_set_program is a complete replacement: sections inactive for sourceMode are cleared even when supplied. Use x1pen_apply_edits for bounded edits within the current mode.',
+  'Use x1pen_set_source_file for a local UTF-8 source only when the user configured an allowed source root. The tool returns hashes and metadata, never the local path or source text.',
   'For SLANG, validation output.generatedAsmLines and asmBytes describe temporary compilation output only. Validation does not store generated ASM in the program; Run does.',
   'Prefer bounded source and reference tools so generated ASM and unrelated manual sections do not consume context.',
   'Retain revisionEpoch when offered, revision and authoringHash together. Inspect writeGuard on every source result: revision-epoch is reload-safe, while revision-only is a visible compatibility fallback. On a source conflict, compare before retrying; never replace only the revision and blindly resend stale source.',
@@ -568,6 +574,7 @@ export function createX1PenMcpServer(options = {}) {
   );
   const sessionInput = { sessionId: z.string().optional().describe('Connected X1Pen instance ID; omit when one tab is connected') };
   const baselines = new SourceBaselineCache(options.sourceBaselineOptions);
+  const allowedSourceRoots = canonicalizeAllowedSourceRoots(options.allowedSourceRoots || []);
 
   function pruneBaselinesToSessions() {
     const activeInstances = new Set((bridge.listSessions?.() || []).map((session) => session.sessionId));
@@ -899,6 +906,71 @@ export function createX1PenMcpServer(options = {}) {
     await assertWriteBaseline(context, expectedRevision, expectedRevisionEpoch);
     const snapshot = await sendGuardedProgram(program, expectedRevision, expectedRevisionEpoch, context);
     return textResult({ ok: true, ...summarizeProgram(snapshot) });
+  }));
+
+  server.registerTool('x1pen_set_source_file', {
+    description: 'Replace one editable source section from a local UTF-8 file under an explicitly configured allowed source root. The file content and host path are never returned. The same revision/epoch guard as other source writes applies.',
+    inputSchema: {
+      sessionId: sessionInput.sessionId,
+      path: z.string().min(1).max(4_096),
+      section: z.enum(SOURCE_SECTIONS),
+      expectedRevision: z.number().int().min(0),
+      expectedRevisionEpoch: z.string().min(1).max(128).optional(),
+    },
+    annotations: { destructiveHint: true, openWorldHint: false },
+  }, handleTool(async ({ sessionId, path, section, expectedRevision, expectedRevisionEpoch }) => {
+    assertSourceRootsConfigured(allowedSourceRoots);
+    const context = sourceSyncContext(sessionId);
+    const snapshot = await assertWriteBaseline(
+      context, expectedRevision, expectedRevisionEpoch,
+    );
+    assertEditableSection(snapshot, section);
+    const file = await readLocalUtf8Source(path, { allowedRoots: allowedSourceRoots });
+    if (file.source.length > MAX_SOURCE_LENGTH) {
+      throw new SourceSyncError(
+        'SOURCE_LIMIT_EXCEEDED',
+        `Local ${section} source exceeds ${MAX_SOURCE_LENGTH} characters`,
+        {
+          section,
+          limit: MAX_SOURCE_LENGTH,
+          actual: file.source.length,
+          action: 'Reduce the local source file and retry against the same guarded snapshot.',
+        },
+      );
+    }
+    await assertApplySnapshotUnchanged(context, snapshot, expectedRevisionEpoch);
+    if (file.source === snapshot[section]) {
+      return textResult({
+        ok: true,
+        changed: false,
+        section,
+        byteCount: file.byteCount,
+        sha256: file.sha256,
+        generatedAsmCleared: false,
+        ...summarizeProgram(snapshot),
+      });
+    }
+
+    const program = {
+      sourceMode: snapshot.sourceMode,
+      basic: snapshot.basic,
+      asm: snapshot.asm,
+      slang: snapshot.slang,
+      [section]: file.source,
+    };
+    const generatedAsmCleared = section === 'slang' && snapshot.asm.length > 0;
+    const updated = await sendGuardedProgram(
+      program, expectedRevision, expectedRevisionEpoch, context,
+    );
+    return textResult({
+      ok: true,
+      changed: true,
+      section,
+      byteCount: file.byteCount,
+      sha256: file.sha256,
+      generatedAsmCleared,
+      ...summarizeProgram(updated),
+    });
   }));
 
   server.registerTool('x1pen_get_source', {
@@ -1352,16 +1424,36 @@ export function createX1PenMcpServer(options = {}) {
   return { server, bridge };
 }
 
+export function parseAllowedSourceRootArgs(argv) {
+  const roots = [];
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === '--allow-source-root') {
+      const value = argv[++index];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--allow-source-root requires a directory path');
+      }
+      roots.push(value);
+    } else if (argument.startsWith('--allow-source-root=')) {
+      const value = argument.slice('--allow-source-root='.length);
+      if (!value) throw new Error('--allow-source-root requires a directory path');
+      roots.push(value);
+    }
+  }
+  return roots;
+}
+
 async function main() {
   if (process.argv.includes('--version') || process.argv.includes('-v')) {
     console.log(PACKAGE.version);
     return;
   }
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
-    console.log(`x1pen-mcp ${PACKAGE.version}\n\nLocal stdio MCP server and browser bridge for X1Pen.\n\nOptions:\n  -h, --help     Show this help\n  -v, --version  Show the package version`);
+    console.log(`x1pen-mcp ${PACKAGE.version}\n\nLocal stdio MCP server and browser bridge for X1Pen.\n\nOptions:\n  --allow-source-root <dir>  Allow x1pen_set_source_file to read under dir (repeatable)\n  -h, --help                 Show this help\n  -v, --version              Show the package version`);
     return;
   }
-  const { server, bridge } = createX1PenMcpServer();
+  const allowedSourceRoots = parseAllowedSourceRootArgs(process.argv.slice(2));
+  const { server, bridge } = createX1PenMcpServer({ allowedSourceRoots });
   await bridge.start();
   let closing = false;
   const close = async () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:automation": "node --test tests/x1pen_automation_test.mjs",
     "test:bridge": "node --test tests/x1pen_bridge_test.mjs",
     "test:extension-package": "node --test tests/x1pen_extension_package_test.mjs tests/x1pen_extension_bridge_test.mjs",
-    "test:mcp": "node --test tests/x1pen_mcp_test.mjs tests/x1pen_reference_test.mjs",
+    "test:mcp": "node --test tests/x1pen_mcp_test.mjs tests/x1pen_local_source_test.mjs tests/x1pen_reference_test.mjs",
     "test:mcp-package": "node --test tests/x1pen_mcp_package_test.mjs"
   },
   "allowScripts": {

--- a/tests/x1pen_local_source_test.mjs
+++ b/tests/x1pen_local_source_test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { open, realpath, stat, appendFile, mkdir, mkdtemp, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, test } from 'node:test';
+import {
+  canonicalizeAllowedSourceRoots,
+  readLocalUtf8Source,
+} from '../mcp/x1pen-local-source.mjs';
+
+let tempRoot;
+let allowedRoot;
+let outsideRoot;
+let allowedRoots;
+
+before(async () => {
+  tempRoot = await mkdtemp(join(tmpdir(), 'x1pen-local-source-'));
+  allowedRoot = join(tempRoot, 'allowed');
+  outsideRoot = join(tempRoot, 'outside');
+  await mkdir(allowedRoot);
+  await mkdir(outsideRoot);
+  allowedRoots = canonicalizeAllowedSourceRoots([allowedRoot, allowedRoot]);
+});
+
+after(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+async function errorFrom(path, options = {}) {
+  try {
+    await readLocalUtf8Source(path, { allowedRoots, ...options });
+  } catch (error) {
+    return error;
+  }
+  assert.fail('expected local source read to fail');
+}
+
+test('reads a bounded regular UTF-8 source and returns metadata only', async () => {
+  const path = join(allowedRoot, 'program.bas');
+  await writeFile(path, '10 PRINT "日本語"\n20 END\n');
+  const result = await readLocalUtf8Source(path, { allowedRoots });
+  assert.equal(result.source, '10 PRINT "日本語"\n20 END\n');
+  assert.equal(result.byteCount, Buffer.byteLength(result.source));
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(allowedRoots.length, 1);
+});
+
+test('strips one UTF-8 BOM and normalizes CRLF and lone CR to LF', async () => {
+  const path = join(allowedRoot, 'windows.bas');
+  const raw = Buffer.concat([
+    Buffer.from([0xEF, 0xBB, 0xBF]),
+    Buffer.from('10 PRINT "BOM"\r\n20 PRINT "CR"\r30 END\r\n'),
+  ]);
+  await writeFile(path, raw);
+  const result = await readLocalUtf8Source(path, { allowedRoots });
+  assert.equal(result.source, '10 PRINT "BOM"\n20 PRINT "CR"\n30 END\n');
+  assert.equal(result.byteCount, raw.byteLength);
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+});
+
+test('rejects default-deny, traversal and symlink escapes without disclosing paths', async () => {
+  const outside = join(outsideRoot, 'outside.bas');
+  await writeFile(outside, '10 END\n');
+  const unconfigured = await errorFrom(outside, { allowedRoots: [] });
+  assert.equal(unconfigured.code, 'SOURCE_ROOT_NOT_CONFIGURED');
+
+  const traversal = await errorFrom(join(allowedRoot, '..', 'outside', 'outside.bas'));
+  assert.equal(traversal.code, 'SOURCE_PATH_NOT_ALLOWED');
+  assert.equal(traversal.message.includes(tempRoot), false);
+
+  const link = join(allowedRoot, 'escape.bas');
+  await symlink(outside, link);
+  const escaped = await errorFrom(link);
+  assert.equal(escaped.code, 'SOURCE_PATH_NOT_ALLOWED');
+  assert.equal(escaped.message.includes(outside), false);
+});
+
+test('fails fast when an allowed root is missing or is not a directory', async () => {
+  assert.throws(
+    () => canonicalizeAllowedSourceRoots([join(tempRoot, 'missing')]),
+    /ENOENT/,
+  );
+  const regular = join(tempRoot, 'not-a-directory');
+  await writeFile(regular, 'file');
+  assert.throws(
+    () => canonicalizeAllowedSourceRoots([regular]),
+    /not a directory: .*not-a-directory/,
+  );
+});
+
+test('rejects directories, oversized files, invalid UTF-8 and NUL', async () => {
+  const directory = join(allowedRoot, 'directory');
+  await mkdir(directory);
+  assert.equal((await errorFrom(directory)).code, 'SOURCE_FILE_NOT_REGULAR');
+
+  const oversized = join(allowedRoot, 'oversized.bas');
+  await writeFile(oversized, '123456789');
+  const tooLarge = await errorFrom(oversized, { maxBytes: 8 });
+  assert.equal(tooLarge.code, 'SOURCE_FILE_TOO_LARGE');
+  assert.equal(tooLarge.limit, 8);
+
+  const invalid = join(allowedRoot, 'invalid.bas');
+  await writeFile(invalid, Buffer.from([0xC3, 0x28]));
+  assert.equal((await errorFrom(invalid)).code, 'SOURCE_FILE_INVALID_UTF8');
+
+  const nul = join(allowedRoot, 'nul.bas');
+  await writeFile(nul, '10\0END');
+  assert.equal((await errorFrom(nul)).code, 'SOURCE_FILE_CONTAINS_NUL');
+});
+
+function mutatingIo(mutate) {
+  return {
+    realpath,
+    stat,
+    async open(path, flags) {
+      const handle = await open(path, flags);
+      let mutated = false;
+      return {
+        stat: (...args) => handle.stat(...args),
+        close: () => handle.close(),
+        async read(...args) {
+          const result = await handle.read(...args);
+          if (!mutated && result.bytesRead > 0) {
+            mutated = true;
+            await mutate();
+          }
+          return result;
+        },
+      };
+    },
+  };
+}
+
+test('rejects file growth and identity replacement during a read', async () => {
+  const growing = join(allowedRoot, 'growing.bas');
+  await writeFile(growing, '10 END\n');
+  const growth = await errorFrom(growing, {
+    io: mutatingIo(() => appendFile(growing, '20 END\n')),
+  });
+  assert.equal(growth.code, 'SOURCE_FILE_CHANGED');
+
+  const replaced = join(allowedRoot, 'replaced.bas');
+  const replacement = join(allowedRoot, 'replacement.tmp');
+  await writeFile(replaced, '10 PRINT "OLD"\n');
+  await writeFile(replacement, '10 PRINT "NEW"\n');
+  const changed = await errorFrom(replaced, {
+    io: mutatingIo(() => rename(replacement, replaced)),
+  });
+  assert.equal(changed.code, 'SOURCE_FILE_CHANGED');
+});

--- a/tests/x1pen_mcp_package_test.mjs
+++ b/tests/x1pen_mcp_package_test.mjs
@@ -53,6 +53,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
       'reference/z80asm.json',
       'x1pen-bridge.mjs',
       'x1pen-compatibility.mjs',
+      'x1pen-local-source.mjs',
       'x1pen-reference.mjs',
       'x1pen-server.mjs',
       'x1pen-source-sync.mjs',
@@ -89,7 +90,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.match(client.getInstructions(), /x1pen_search_reference/);
 
     const tools = await client.listTools();
-    assert.equal(tools.tools.length, 30);
+    assert.equal(tools.tools.length, 31);
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_apply_edits'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_diff_source'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_debug_get_state'));
@@ -97,6 +98,7 @@ test('packed x1pen-mcp installs and serves tools without the repository', { time
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_search_reference'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_send_key'));
     assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_set_pad'));
+    assert.ok(tools.tools.some((tool) => tool.name === 'x1pen_set_source_file'));
     const connection = await client.callTool({ name: 'x1pen_connection_info', arguments: {} });
     const info = JSON.parse(connection.content[0].text);
     assert.equal(info.host, '127.0.0.1');

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { after, before, beforeEach, test } from 'node:test';
@@ -9,7 +12,7 @@ import {
   normalizeConnectorPair,
   normalizeX1PenDescriptor,
 } from '../mcp/x1pen-compatibility.mjs';
-import { createX1PenMcpServer } from '../mcp/x1pen-server.mjs';
+import { createX1PenMcpServer, parseAllowedSourceRootArgs } from '../mcp/x1pen-server.mjs';
 
 const initialProgram = {
   sourceMode: 'basic+asm',
@@ -31,6 +34,7 @@ let stripRevisionEpoch;
 let getProgramCount;
 let beforeGetProgram;
 let selectedSessionId;
+let sourceRoot;
 
 const FULL_FEATURES = [
   'automation.core', 'automation.run-recovery', 'automation.source-sync',
@@ -249,7 +253,8 @@ let server;
 let client;
 
 before(async () => {
-  ({ server } = createX1PenMcpServer({ bridge: fakeBridge }));
+  sourceRoot = await mkdtemp(join(tmpdir(), 'x1pen-mcp-source-'));
+  ({ server } = createX1PenMcpServer({ bridge: fakeBridge, allowedSourceRoots: [sourceRoot] }));
   client = new Client({ name: 'x1pen-mcp-test', version: '1.0.0' });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
@@ -272,6 +277,7 @@ beforeEach(() => {
 after(async () => {
   if (client) await client.close();
   if (server) await server.close();
+  await rm(sourceRoot, { recursive: true, force: true });
 });
 
 test('server exposes context-efficient source tools', async () => {
@@ -305,13 +311,172 @@ test('server exposes context-efficient source tools', async () => {
     'x1pen_send_key',
     'x1pen_set_pad',
     'x1pen_set_program',
+    'x1pen_set_source_file',
     'x1pen_stop',
     'x1pen_validate',
   ]);
   const descriptions = Object.fromEntries(tools.tools.map((tool) => [tool.name, tool.description]));
   assert.match(descriptions.x1pen_set_program, /inactive for sourceMode are cleared even when supplied/);
+  assert.match(descriptions.x1pen_set_source_file, /local UTF-8 file/);
   assert.match(descriptions.x1pen_validate, /temporary compilation output/);
   assert.match(descriptions.x1pen_validate, /does not store generated ASM/);
+});
+
+test('allowed source roots accept repeatable CLI forms and reject missing values', () => {
+  assert.deepEqual(parseAllowedSourceRootArgs([
+    '--allow-source-root', '/one', '--allow-source-root=/two', '--version',
+  ]), ['/one', '/two']);
+  assert.throws(
+    () => parseAllowedSourceRootArgs(['--allow-source-root']),
+    /requires a directory path/,
+  );
+  assert.throws(
+    () => parseAllowedSourceRootArgs(['--allow-source-root=']),
+    /requires a directory path/,
+  );
+});
+
+test('set_source_file defaults to deny when no source root is configured', async () => {
+  const { server: deniedServer } = createX1PenMcpServer({ bridge: fakeBridge });
+  const deniedClient = new Client({ name: 'x1pen-mcp-denied-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await deniedServer.connect(serverTransport);
+  await deniedClient.connect(clientTransport);
+  try {
+    const result = await deniedClient.callTool({
+      name: 'x1pen_set_source_file',
+      arguments: {
+        path: join(sourceRoot, 'program.bas'),
+        section: 'basic',
+        expectedRevision: 3,
+        expectedRevisionEpoch: 'epoch-a',
+      },
+    });
+    assert.equal(result.isError, true);
+    assert.equal(jsonContent(result).error.code, 'SOURCE_ROOT_NOT_CONFIGURED');
+    assert.equal(calls.some((call) => call.method === 'getProgram'), false);
+  } finally {
+    await deniedClient.close();
+    await deniedServer.close();
+  }
+});
+
+test('set_source_file replaces one authoring section without returning path or content', async () => {
+  currentProgram.asm = 'ORG $100\nRET';
+  const path = join(sourceRoot, 'program.bas');
+  const source = '10 PRINT "LOCAL FILE"\n20 END\n';
+  await writeFile(path, source);
+  const result = jsonContent(await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path,
+      section: 'basic',
+      expectedRevision: 3,
+      expectedRevisionEpoch: 'epoch-a',
+      sessionId: 'tab-a',
+    },
+  }));
+  assert.equal(result.changed, true);
+  assert.equal(result.section, 'basic');
+  assert.equal(result.byteCount, Buffer.byteLength(source));
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(result.revision, 4);
+  assert.equal(result.basic, undefined);
+  assert.equal(result.path, undefined);
+  assert.equal(JSON.stringify(result).includes(source), false);
+  assert.equal(JSON.stringify(result).includes(sourceRoot), false);
+  assert.equal(currentProgram.basic, source);
+  assert.equal(currentProgram.asm, 'ORG $100\nRET');
+  assert.equal(calls.at(-1).method, 'setProgram');
+  assert.equal(calls.at(-1).sessionId, 'tab-a');
+});
+
+test('set_source_file reports raw file metadata while storing normalized source text', async () => {
+  const path = join(sourceRoot, 'windows.bas');
+  const raw = Buffer.concat([
+    Buffer.from([0xEF, 0xBB, 0xBF]),
+    Buffer.from('10 PRINT "WINDOWS"\r\n20 END\r'),
+  ]);
+  await writeFile(path, raw);
+  const result = jsonContent(await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path, section: 'basic', expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
+  }));
+  assert.equal(result.byteCount, raw.byteLength);
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(currentProgram.basic, '10 PRINT "WINDOWS"\n20 END\n');
+  assert.equal(result.sections.basic.byteCount, Buffer.byteLength(currentProgram.basic));
+});
+
+test('set_source_file handles unchanged, SLANG generated ASM and a representative 63 KiB source', async () => {
+  const unchangedPath = join(sourceRoot, 'unchanged.bas');
+  await writeFile(unchangedPath, currentProgram.basic);
+  let result = jsonContent(await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path: unchangedPath, section: 'basic', expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
+  }));
+  assert.equal(result.changed, false);
+  assert.equal(calls.some((call) => call.method === 'setProgram'), false);
+
+  calls.length = 0;
+  currentProgram = {
+    sourceMode: 'slang', basic: '', asm: 'generated asm', slang: 'MAIN() BEGIN\nEND;', revision: 3,
+    revisionEpoch: 'epoch-a', instanceId: 'tab-a',
+  };
+  const slangPath = join(sourceRoot, 'program.slang');
+  await writeFile(slangPath, 'MAIN() BEGIN\n  PRINT("FILE");\nEND;\n');
+  result = jsonContent(await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path: slangPath, section: 'slang', expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
+  }));
+  assert.equal(result.changed, true);
+  assert.equal(result.generatedAsmCleared, true);
+  assert.equal(currentProgram.asm, '');
+
+  calls.length = 0;
+  currentProgram = clone(initialProgram);
+  const largeSource = `10 REM ${'A'.repeat((63 * 1024) - 11)}\n20 END\n`;
+  const largePath = join(sourceRoot, 'large.bas');
+  await writeFile(largePath, largeSource);
+  result = jsonContent(await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path: largePath, section: 'basic', expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
+  }));
+  assert.equal(result.changed, true);
+  assert.equal(result.byteCount, Buffer.byteLength(largeSource));
+  assert.equal(currentProgram.basic, largeSource);
+});
+
+test('set_source_file pins the session and rejects a program change during the file read window', async () => {
+  const path = join(sourceRoot, 'racy.bas');
+  await writeFile(path, '10 PRINT "RACE"\n20 END\n');
+  getProgramCount = 0;
+  beforeGetProgram = (count) => {
+    if (count === 2) {
+      selectedSessionId = 'tab-b';
+      currentProgram.revision = 4;
+      currentProgram.basic = '10 PRINT "CONCURRENT"\n20 END';
+    }
+  };
+  const result = await client.callTool({
+    name: 'x1pen_set_source_file',
+    arguments: {
+      path, section: 'basic', expectedRevision: 3, expectedRevisionEpoch: 'epoch-a',
+    },
+  });
+  assert.equal(result.isError, true);
+  assert.equal(jsonContent(result).error.code, 'REVISION_MISMATCH');
+  assert.equal(calls.some((call) => call.method === 'setProgram'), false);
+  assert.ok(calls.every((call) => call.sessionId === 'tab-a'));
+  assert.equal(currentProgram.basic, '10 PRINT "CONCURRENT"\n20 END');
 });
 
 test('send_key routes an allowlisted VK with a bounded hold duration', async () => {


### PR DESCRIPTION
## Summary
- add x1pen_set_source_file for guarded local UTF-8 source import
- require explicit repeatable allowed roots and enforce canonical path, regular-file, size, UTF-8, NUL, and replacement checks
- preserve the other authoring section and clear generated ASM for SLANG updates
- document setup, security, BOM/newline normalization, and metadata semantics

## Tests
- npm run test:mcp (86/86)
- npm run test:mcp-package (1/1)

No package version bump is included.

Closes #90