### PR TITLE
docs: document current SLANG runtime contracts

### DIFF
--- a/mcp/reference/slang.json
+++ b/mcp/reference/slang.json
@@ -95,16 +95,47 @@
     "summary": "MACHINE binds a SLANG function name to an external Z80 routine. Argument count controls whether values are passed in registers or on the stack.",
     "syntax": [
       "MACHINE MON(0):$1F8E;",
-      "MACHINE ROUTINE(2):address;",
-      "MACHINE VARARGS():address;"
+      "MACHINE ROUTINE(2):address;"
     ],
     "notes": [
-      "0 arguments: CALL only. 1: HL. 2: HL then DE. 3: HL, DE and BC. 4 or more: stack.",
-      "If the argument count is omitted, arguments go on the stack and HL receives the argument count.",
+      "Use an explicit argument count. 0 arguments: CALL only. 1: HL. 2: HL then DE. 3: HL, DE and BC. For 4 or more, every WORD argument is pushed on the stack left-to-right and the caller removes 2 bytes per argument after return.",
+      "Do not use MACHINE NAME():address with an omitted argument count. This compiler snapshot accepts it but generates unreliable calls; contrary to older guidance, it does not reliably pass a count in HL or clean up the argument stack.",
       "MACHINE functions return WORD only in this compiler snapshot; a FLOAT return annotation is rejected."
     ],
-    "relatedIds": ["slang.functions.typed", "slang.machine.system-access", "slang.preprocessor.includes", "slang.runtime.catalog"],
+    "relatedIds": ["slang.functions.typed", "slang.machine.system-access", "slang.machine.inline-assembly", "slang.preprocessor.includes", "slang.runtime.catalog"],
     "sourceUrls": ["https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md"]
+  },
+  {
+    "id": "slang.machine.inline-assembly",
+    "language": "slang",
+    "kind": "runtime",
+    "title": "Inline Z80 assembly with MACHINE and #ASM",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["MACHINE", "#ASM", "#END", "HL", "DE", "BC", "IX", "IY", "SP"],
+    "aliases": ["inline assembly", "embedded assembler", "Z80 routine", "MACHINE label", "インラインアセンブラ", "埋め込みアセンブラ", "アセンブリ", "マシン語ルーチン"],
+    "summary": "Declare an explicit-arity MACHINE function and place its Z80 target in a #ASM ... #END block to call inline assembly from SLANG.",
+    "syntax": [
+      "MACHINE functionName(explicitArgumentCount):label;",
+      "#ASM\nlabel:\n  ...\n  RET\n#END"
+    ],
+    "notes": [
+      "A numeric MACHINE target calls that absolute address. A symbolic target is resolved in the combined compiler output, so it may name a label in a later #ASM block.",
+      "Explicit counts 0 through 3 pass WORD arguments in no registers, HL, HL then DE, or HL then DE then BC. A WORD result is returned in HL; AF, BC, DE, HL and IX are caller-clobbered.",
+      "For an explicit count of 4 or more, all WORD arguments are pushed left-to-right. At entry to a four-argument callee, after the CALL return address, argument 4 is at SP+2, argument 3 at SP+4, argument 2 at SP+6 and argument 1 at SP+8. After the call returns its WORD in HL, the caller exchanges HL with DE, adjusts SP by 2 bytes per argument through HL, then exchanges DE back into HL; the result is therefore restored to HL after cleanup.",
+      "IX is not a preserved compiler work pointer and may be clobbered; IY must be preserved because the generated program uses it as its work pointer. Restore SP so RET consumes the original return address, restore any alternate registers you touch, return in the normal register bank, and leave interrupt-enable state unchanged. Alternate registers are not a supported argument or result channel.",
+      "Do not omit the MACHINE argument count. MACHINE NAME():label is accepted by this compiler snapshot but generates unreliable calls; use an explicit argument count."
+    ],
+    "examples": [
+      {
+        "title": "Call an inline routine that prints 223",
+        "source": "MACHINE ASMFUNC(1):ASMROUTINE;\n\nMAIN() BEGIN\n  PRINT(ASMFUNC(100), /);\nEND;\n\n#ASM\nASMROUTINE:\n  LD DE,123\n  ADD HL,DE\n  RET\n#END"
+      }
+    ],
+    "relatedIds": ["slang.machine.calling-convention", "slang.machine.system-access", "slang.preprocessor.includes", "z80asm.syntax.source"],
+    "sourceUrls": [
+      "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
+      "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_slang_compiler.js"
+    ]
   },
   {
     "id": "slang.control.flow",
@@ -179,7 +210,7 @@
       "The compiler supports include nesting up to 8 levels.",
       "X1Pen bundles GRAPH.LIB, GRAPHF.LIB, SOROBAN.LIB, CHIPLIB.LIB, SPRLIB.LIB, TILELIB.LIB, TILESPR.LIB and UILIB.LIB. Other local files are not available through the browser VFS."
     ],
-    "relatedIds": ["slang.x1pen.build-profile", "slang.includes.catalog", "slang.machine.calling-convention", "slang.compiler.catalog"],
+    "relatedIds": ["slang.x1pen.build-profile", "slang.includes.catalog", "slang.machine.calling-convention", "slang.machine.inline-assembly", "slang.compiler.catalog"],
     "sourceUrls": [
       "https://github.com/h-o-soft/SLANG-compiler/blob/c9e8f5315d8d44a413368045d78439a4ec8da3fc/docs/SLANG-spec.md",
       "https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen.js"
@@ -240,13 +271,12 @@
     "id": "slang.runtime.lsx-io-files",
     "language": "slang",
     "kind": "x1-extension",
-    "title": "X1Pen LSX input and file runtime",
+    "title": "X1Pen LSX line input and file runtime",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "symbols": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE"],
-    "aliases": ["INKEY", "INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE", "キー入力", "キーボード", "行入力", "ファイル", "ファイルを開く", "ファイルを読む", "ファイルに書く", "ファイル入出力"],
-    "summary": "The X1Pen LSX runtime provides keyboard/line input and LSX file operations in addition to the core SLANG functions.",
+    "symbols": ["INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE"],
+    "aliases": ["INPUT", "GETL", "GETLIN", "LINPUT", "FOPEN", "FSEEK", "FGETC", "FPUTC", "FCLOSE", "FREAD", "FWRITE", "行入力", "ファイル", "ファイルを開く", "ファイルを読む", "ファイルに書く", "ファイル入出力"],
+    "summary": "The X1Pen LSX runtime provides line input and LSX file operations in addition to the core SLANG functions.",
     "syntax": [
-      "INKEY(mode)",
       "INPUT()",
       "GETL(address)",
       "GETLIN(address,length)",
@@ -260,7 +290,7 @@
       "File numbers are 0 through 7. FOPEN returns 255 for an invalid file number; otherwise it returns the LSX operation result.",
       "FOPEN masks mode to two bits. Values below 3 open an existing file; mode 3 creates a file.",
       "FSEEK origin is 0 from the beginning, 1 from the current position, or 2 from the end.",
-      "INKEY takes one mode argument; INPUT takes none; GETL takes one; GETLIN and LINPUT take two."
+      "INPUT takes no arguments; GETL takes one; GETLIN and LINPUT take two. See the related INKEY entry for single-key polling and blocking modes."
     ],
     "examples": [
       {
@@ -268,10 +298,40 @@
         "source": "MAIN() BEGIN\n  VAR RESULT;\n  RESULT=FOPEN(0, \"A:DATA.BIN\", 0);\n  IF RESULT==0 THEN FCLOSE(0);\n  PRINT(RESULT, /);\nEND;"
       }
     ],
-    "relatedIds": ["slang.machine.system-access", "slang.x1.assets-compression", "slang.x1.display-graphics", "slang.runtime.catalog", "x1.io.psg-joystick"],
+    "relatedIds": ["slang.machine.system-access", "slang.x1.inkey", "slang.x1.assets-compression", "slang.x1.display-graphics", "slang.runtime.catalog", "x1.io.psg-joystick"],
     "sourceUrls": [
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_input.asm",
       "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_file.asm"
+    ]
+  },
+  {
+    "id": "slang.x1.inkey",
+    "language": "slang",
+    "kind": "x1-extension",
+    "title": "INKEY polling and blocking keyboard modes",
+    "profiles": ["x1pen-slang-c9e8f53-lsx"],
+    "symbols": ["INKEY"],
+    "aliases": ["INKEY", "non-blocking keyboard", "blocking keyboard", "key code", "keyboard polling", "キー入力", "キーボード", "ノンブロッキング", "キーコード", "押しっぱなし"],
+    "summary": "INKEY(mode) reads one X1 keyboard code: mode 0 polls current key state, mode 1 waits for and consumes a direct-input event, and mode 2 or greater waits by polling until a key is nonzero.",
+    "syntax": ["key=INKEY(0);", "key=INKEY(1);", "key=INKEY(2);"],
+    "notes": [
+      "Mode 0 is non-blocking: it returns 0 when no key is pressed and polls current state, so a held key may be returned on consecutive calls. Use this mode in animation and game loops.",
+      "Mode 1 blocks for one direct-input event and consumes it. One held-key injection satisfies one call; a second call waits for another event.",
+      "Every mode value 2 or greater blocks by repeatedly polling mode-0 state until nonzero. A held key may therefore satisfy consecutive calls.",
+      "In X1Pen's current default base X1 keyboard layout, Right/Left/Up/Down return $1C/$1D/$1E/$1F. F1 is mapped by its X1 physical position and returns lowercase q ($71). These are guest-layout results, not universal host key codes.",
+      "Alphabetic keys use the current guest modifier state; the unshifted A key returns lowercase a ($61). X1Pen maps host keys to JIS physical positions before the X1 keyboard table is read."
+    ],
+    "examples": [
+      {
+        "title": "Poll INKEY without stopping a frame loop",
+        "source": "VAR FRAME;\n\nVSYNC_PROC() BEGIN\n  FRAME=FRAME+1;\nEND;\n\nMAIN() BEGIN\n  VAR KEY;\n  LOOP\n  {\n    KEY=INKEY(0);\n    LOCATE(0,0);\n    PRINT(FRAME, \" KEY=\", KEY, \"   \");\n    VSYNC(1);\n  }\nEND;"
+      }
+    ],
+    "relatedIds": ["slang.runtime.lsx-io-files", "slang.x1.timing", "slang.x1.input", "x1.io.ppi-subcpu"],
+    "sourceUrls": [
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_input.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/liblsx_base.asm",
+      "https://github.com/ho-ogino/xmil-web/blob/main/src/Input.cpp"
     ]
   },
   {
@@ -406,6 +466,7 @@
     ],
     "notes": [
       "Call CHIP_INIT before drawing. Configure offsets, sizes, map and VVRAM dimensions before the main draw loop.",
+      "For animation, call CHIP_ANIM_TICK from the program's VSYNC_PROC. A program that uses VSYNC must define that hook; an empty body is valid when no per-frame CHIP work is needed.",
       "The public declarations specify argument counts; use the bundled CHIPLIB.LIB comments and validation to confirm each argument's units."
     ],
     "relatedIds": ["slang.include.tile-sprite", "slang.x1.pcg-definition", "slang.x1.timing", "slang.includes.catalog"],
@@ -599,16 +660,23 @@
     "kind": "x1-extension",
     "title": "Vertical blank and CTC timing",
     "profiles": ["x1pen-slang-c9e8f53-lsx"],
-    "symbols": ["VSYNC_CHECK", "VSYNC", "VSYNC1", "SETUPCTC"],
+    "symbols": ["VSYNC_CHECK", "VSYNC", "VSYNC_PROC", "VSYNC1", "SETUPCTC"],
     "aliases": ["vertical blank", "frame timing", "CTC", "game loop", "垂直同期", "VBLANK", "フレーム待ち", "タイミング", "ゲームループ", "割り込み"],
     "summary": "The X1 runtime exposes vertical-blank polling/wait helpers and CTC setup used by frame loops and time-based subsystems.",
-    "syntax": ["VSYNC(count);", "VSYNC1();", "VSYNC_CHECK();", "SETUPCTC();"],
+    "syntax": ["VSYNC(frames);", "VSYNC_PROC() BEGIN ... END;", "VSYNC1();", "VSYNC_CHECK();", "SETUPCTC();"],
     "notes": [
-      "VSYNC waits for the requested number of counted vertical blanks and clears its internal counter afterward.",
+      "VSYNC(frames) waits for that many counted vertical blanks and clears its internal counter afterward. It requires exactly one argument; do not write VSYNC().",
+      "A program that links a vertical-blank path which references !VSYNC_PROC must define VSYNC_PROC(). This includes direct VSYNC use and SGL frame synchronization. The runtime calls the hook once for every counted frame; an empty body is valid.",
       "VSYNC1 waits directly for one vertical-blank transition.",
-      "Libraries can install work in the compiler's !VSYNC_PROC hook; use their documented update calls and setup order."
+      "TILE, CHIP and SGL libraries use the same !VSYNC_PROC hook; follow their documented update calls and setup order when composing frame work."
     ],
-    "relatedIds": ["slang.x1.psg", "slang.include.tile-sprite", "slang.include.chiplib", "slang.x1.sgl", "slang.runtime.catalog"],
+    "examples": [
+      {
+        "title": "Wait one frame with the required VSYNC hook",
+        "source": "VSYNC_PROC() BEGIN\nEND;\n\nMAIN() BEGIN\n  VSYNC(1);\nEND;"
+      }
+    ],
+    "relatedIds": ["slang.x1.inkey", "slang.x1.psg", "slang.include.tile-sprite", "slang.include.chiplib", "slang.x1.sgl", "slang.runtime.catalog"],
     "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/assets/slang_runtime/libx1_base.asm"]
   },
   {
@@ -668,6 +736,7 @@
       "SGL_SPRCREATE returns zero on failure. Preserve nonzero handles and destroy sprites when they are no longer needed.",
       "SGL_SPRDISP uses 0 for hidden and 1 for visible.",
       "SGL_PRINT draws on the current render page; SGL_PRINT2 draws on both pages. SGL_VSYNC processes characters and flips the screen.",
+      "SGL frame synchronization invokes the program's VSYNC_PROC hook. Define the hook before using SGL frame waits; an empty body is valid when no additional per-frame work is needed.",
       "This profile loads libx1_sgl_lsx.asm, not the separate non-LSX libx1_sgl.asm file also present in the repository."
     ],
     "relatedIds": ["slang.x1.pcg-definition", "slang.x1.display-graphics", "slang.x1.timing", "slang.runtime.catalog"],

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -1180,6 +1180,139 @@ test('SLANG runtime arity is rejected by Validate while valid VSYNC still runs',
   }
 });
 
+test('SLANG INKEY modes and documented inline assembly run with current X1 semantics', { timeout: 120_000 }, async () => {
+  const probeAddress = 0x7000;
+  const readMemory = (offset, length) => page.evaluate(({ address, byteLength }) => (
+    window.X1PenAutomation.debugger.readMemory(address, byteLength).bytes
+  ), { address: probeAddress + offset, byteLength: length });
+  const waitForMemory = async (offset, expected, timeout = 5000) => {
+    await page.waitForFunction(({ address, values }) => {
+      const bytes = window.X1PenAutomation.debugger.readMemory(address, values.length).bytes;
+      return values.every((value, index) => value === null || bytes[index] === value);
+    }, { address: probeAddress + offset, values: expected }, { timeout, polling: 20 });
+    return readMemory(offset, expected.length);
+  };
+  const loadAndRunSlang = (slang) => page.evaluate(async (source) => {
+    const api = window.X1PenAutomation;
+    const current = api.getProgram();
+    await api.setProgram({
+      sourceMode: 'slang', basic: '', asm: '', slang: source,
+    }, current.revision, current.revisionEpoch);
+    const validation = await api.validate();
+    if (!validation.ok) {
+      throw new Error(`INKEY/inline acceptance program did not validate: ${JSON.stringify(validation.diagnostics)}`);
+    }
+    const run = await api.run();
+    if (!run.ok) throw new Error(`INKEY/inline acceptance program did not run: ${JSON.stringify(run)}`);
+    return { validation, run };
+  }, slang);
+  const sendKey = (code, duration = 80) => page.evaluate(([vk, durationMs]) => (
+    window.X1PenAutomation.sendKey(vk, durationMs)
+  ), [code, duration]);
+
+  try {
+    await loadAndRunSlang([
+      'MAIN()',
+      '{',
+      '  VAR KEY, COUNT;',
+      '  MEM[$7000]=$A0; MEM[$7001]=0; MEM[$7002]=0; MEM[$7003]=0; MEMW[$7004]=0;',
+      '  COUNT=0;',
+      '  LOOP',
+      '  {',
+      '    KEY=INKEY(0);',
+      '    MEM[$7003]=KEY;',
+      '    MEMW[$7004]=MEMW[$7004]+1;',
+      '    IF KEY!=0',
+      '    {',
+      '      COUNT=COUNT+1;',
+      '      IF COUNT==1 THEN MEM[$7001]=KEY;',
+      '      IF COUNT==2 THEN MEM[$7002]=KEY;',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n'));
+    await waitForMemory(0, [0xA0]);
+    await page.waitForTimeout(200);
+    const idlePoll = await readMemory(3, 3);
+    assert.equal(idlePoll[0], 0, 'mode 0 must return zero when no key is held');
+    assert.ok((idlePoll[1] | (idlePoll[2] << 8)) > 0, 'mode 0 must keep progressing without input');
+    await sendKey(0x41, 900);
+    assert.deepEqual(await waitForMemory(0, [0xA0, 0x61, 0x61]), [0xA0, 0x61, 0x61]);
+
+    await loadAndRunSlang([
+      'MAIN()',
+      '{',
+      '  VAR I;',
+      '  MEM[$7000]=$A1; MEM[$7001]=0; MEM[$7002]=0;',
+      '  I=0;',
+      '  LOOP',
+      '  {',
+      '    MEM[$7010+I]=INKEY(1);',
+      '    I=I+1;',
+      '    MEM[$7001]=I;',
+      '    IF I==6 THEN EXIT;',
+      '  }',
+      '  MEM[$7002]=$A2;',
+      '  LOOP { }',
+      '}',
+    ].join('\n'));
+    await waitForMemory(0, [0xA1, 0]);
+    await sendKey(0x27, 900);
+    await waitForMemory(1, [1]);
+    await page.waitForTimeout(1200);
+    assert.deepEqual(await readMemory(1, 2), [1, 0],
+      'one held key must satisfy only one mode-1 call');
+    for (const [index, vk] of [[2, 0x25], [3, 0x26], [4, 0x28], [5, 0x70], [6, 0x41]]) {
+      await sendKey(vk);
+      await waitForMemory(1, [index]);
+    }
+    await waitForMemory(2, [0xA2]);
+    assert.deepEqual(await readMemory(0x10, 6), [0x1C, 0x1D, 0x1E, 0x1F, 0x71, 0x61]);
+
+    await loadAndRunSlang([
+      'MAIN()',
+      '{',
+      '  MEM[$7000]=$B2; MEM[$7001]=0; MEM[$7002]=0; MEM[$7003]=0;',
+      '  MEM[$7001]=INKEY(2);',
+      '  MEM[$7002]=INKEY(2);',
+      '  MEM[$7003]=$A3;',
+      '  LOOP { }',
+      '}',
+    ].join('\n'));
+    await waitForMemory(0, [0xB2, 0, 0, 0]);
+    await sendKey(0x41, 900);
+    assert.deepEqual(await waitForMemory(0, [0xB2, 0x61, 0x61, 0xA3]),
+      [0xB2, 0x61, 0x61, 0xA3]);
+
+    await loadAndRunSlang([
+      'MACHINE ASMFUNC(1):ASMROUTINE;',
+      'MAIN() BEGIN',
+      '  VAR VALUE;',
+      '  VALUE=ASMFUNC(100);',
+      '  PRINT(VALUE, /);',
+      '  MEMW[$7000]=VALUE;',
+      '  MEM[$7002]=$A5;',
+      '  LOOP { }',
+      'END;',
+      '#ASM',
+      'ASMROUTINE:',
+      '  LD DE,123',
+      '  ADD HL,DE',
+      '  RET',
+      '#END',
+    ].join('\n'));
+    assert.deepEqual(await waitForMemory(0, [223, 0, 0xA5]), [223, 0, 0xA5]);
+    const textBytes = await page.evaluate(() => (
+      window.X1PenAutomation.debugger.readVram({ region: 'text', offset: 0, length: 2000 }).bytes
+    ));
+    assert.ok(textBytes.some((value, index) => (
+      value === 0x32 && textBytes[index + 1] === 0x32 && textBytes[index + 2] === 0x33
+    )), 'text VRAM must contain the printed 223 sequence');
+  } finally {
+    await page.evaluate(() => window.Module._js_xmil_reset());
+  }
+});
+
 test('automation operations are serialized and stale source modes are cleared', async () => {
   const programs = await page.evaluate(async () => {
     const first = window.X1PenAutomation.setProgram({ sourceMode: 'asm', asm: 'ORG $100\nRET' });

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -136,6 +136,10 @@ test('representative Japanese and English queries reach dedicated SLANG entries'
     ['線を描く', 'slang.include.graph-soroban'],
     ['圧縮データ', 'slang.x1.assets-compression'],
     ['垂直同期', 'slang.x1.timing'],
+    ['INKEY non-blocking', 'slang.x1.inkey'],
+    ['キー入力 ノンブロッキング', 'slang.x1.inkey'],
+    ['inline assembly', 'slang.machine.inline-assembly'],
+    ['埋め込みアセンブラ', 'slang.machine.inline-assembly'],
     ['ゲームライブラリ', 'slang.x1.sgl'],
   ]);
 
@@ -921,6 +925,135 @@ test('SLANG STICK compiles, assembles and stays dependency-pruned', () => {
   assert.ok(assembled.symbols['NAME_SPACE_DEFAULT.STICK'] >= assembled.org);
   assert.ok(assembled.symbols['NAME_SPACE_DEFAULT.SLANG_PROG_END'] < 0x4000);
   assert.ok(assembled.symbols['NAME_SPACE_DEFAULT.__WORKEND__'] < 0x4000);
+});
+
+test('SLANG VSYNC, INKEY and inline-assembly references match shipped contracts', () => {
+  const entries = new Map(validateReferenceData().entries.map((entry) => [entry.id, entry]));
+  const timing = entries.get('slang.x1.timing');
+  const inkey = entries.get('slang.x1.inkey');
+  const machine = entries.get('slang.machine.calling-convention');
+  const inline = entries.get('slang.machine.inline-assembly');
+  const files = entries.get('slang.runtime.lsx-io-files');
+  const preprocessor = entries.get('slang.preprocessor.includes');
+  assert.ok(timing && inkey && machine && inline && files && preprocessor);
+
+  const timingDetails = [timing.summary, ...timing.syntax, ...timing.notes].join(' ');
+  assert.match(timingDetails, /VSYNC\(frames\).*exactly one argument/);
+  assert.match(timingDetails, /must define VSYNC_PROC/);
+  assert.match(timingDetails, /once for every counted frame/);
+  for (const relatedId of ['slang.include.tile-sprite', 'slang.include.chiplib', 'slang.x1.sgl']) {
+    assert.ok(timing.relatedIds.includes(relatedId));
+  }
+
+  const inkeyDetails = [inkey.summary, ...inkey.syntax, ...inkey.notes].join(' ');
+  for (const expected of [
+    'Mode 0 is non-blocking', 'returns 0', 'held key may be returned on consecutive calls',
+    'Mode 1 blocks', 'consumes it', 'mode value 2 or greater',
+    'Right/Left/Up/Down return $1C/$1D/$1E/$1F', 'F1', '$71', '$61',
+  ]) assert.ok(inkeyDetails.includes(expected), expected);
+  assert.ok(inkey.relatedIds.includes('slang.runtime.lsx-io-files'));
+  assert.ok(files.relatedIds.includes('slang.x1.inkey'));
+  assert.equal(files.symbols.includes('INKEY'), false);
+
+  const machineDetails = [machine.summary, ...machine.syntax, ...machine.notes].join(' ');
+  const inlineDetails = [inline.summary, ...inline.syntax, ...inline.notes].join(' ');
+  for (const details of [machineDetails, inlineDetails]) {
+    assert.match(details, /explicit argument count/i);
+    assert.match(details, /unreliable calls/i);
+  }
+  for (const expected of [
+    'pushed left-to-right', 'argument 4 is at SP+2', 'argument 1 at SP+8',
+    'exchanges HL with DE', 'restored to HL after cleanup',
+    '2 bytes per argument', 'IX is not a preserved compiler work pointer',
+    'IY must be preserved', 'interrupt-enable state unchanged',
+  ]) assert.ok(inlineDetails.includes(expected), expected);
+  assert.ok(machine.relatedIds.includes('slang.machine.inline-assembly'));
+  assert.ok(preprocessor.relatedIds.includes('slang.machine.inline-assembly'));
+
+  for (const id of ['slang.include.tile-sprite', 'slang.include.chiplib', 'slang.x1.sgl']) {
+    const consumer = entries.get(id);
+    assert.ok(consumer.relatedIds.includes('slang.x1.timing'), `${id} must link the timing contract`);
+    for (const example of consumer.examples || []) {
+      if (/\b(?:VSYNC|SGL_VSYNC)\s*\(/.test(example.source)) {
+        assert.match(example.source, /\bVSYNC_PROC\s*\(/,
+          `${id} examples driving the vertical-blank hook must define VSYNC_PROC`);
+      }
+    }
+  }
+  assert.match(entries.get('slang.include.tile-sprite').notes.join(' '), /TILE_ANIM_TICK from VSYNC_PROC/);
+  assert.match(entries.get('slang.include.chiplib').notes.join(' '), /CHIP_ANIM_TICK from the program's VSYNC_PROC/);
+  assert.match(entries.get('slang.x1.sgl').notes.join(' '), /invokes the program's VSYNC_PROC hook/);
+
+  const inputRuntime = readFileSync(join(repoRoot, 'assets/slang_runtime/liblsx_input.asm'), 'utf8');
+  assert.match(inputRuntime,
+    /^; @name INKEY[\s\S]*LD A,L[\s\S]*CP 1[\s\S]*CALL sGETKY[\s\S]*CALL sFLGET[\s\S]*CALL sINKEY/m);
+  const baseRuntime = readFileSync(join(repoRoot, 'assets/slang_runtime/liblsx_base.asm'), 'utf8');
+  assert.match(baseRuntime, /^; @name sGETKY[\s\S]*LD\s+E,\$FF[\s\S]*LD\s+C,INPOUT/m);
+  assert.match(baseRuntime, /^; @name sFLGET[\s\S]*LD\s+C,DIRIN/m);
+  assert.match(baseRuntime, /^; @name sINKEY[\s\S]*CALL\s+sGETKY[\s\S]*JR\s+Z,sINKEY/m);
+
+  const inputSource = readFileSync(join(repoRoot, 'src/Input.cpp'), 'utf8');
+  for (const [physical, result] of [['0xcd', '0x1c'], ['0xcb', '0x1d'], ['0xc8', '0x1e'], ['0xd0', '0x1f']]) {
+    assert.match(inputSource, new RegExp(`KEY_CHR == ${physical}[\\s\\S]*?data\\[1\\] = ${result}`));
+  }
+  const baseTable = inputSource.match(/BYTE CHR_TBL0\[\]=\{([\s\S]*?)\n\};/);
+  assert.ok(baseTable);
+  assert.match(baseTable[1], /\/\* Alt, SPC, Cap, f\.1,[\s\S]*?0x00, ' ',0x00, 'q'/);
+  assert.match(baseTable[1], /\/\*  Ｏ,  Ｐ,[\s\S]*?0x0d,0x00, 'a', 's'/);
+});
+
+test('documented VSYNC, INKEY and inline-assembly examples compile and assemble', () => {
+  const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const vfs = loadSlangVfs();
+  const entries = new Map(validateReferenceData().entries.map((entry) => [entry.id, entry]));
+  const options = { defaultOrg: 0x100, codeReadonly: false, defines: { ENV_TYPE: 1 } };
+
+  for (const id of ['slang.x1.timing', 'slang.x1.inkey', 'slang.machine.inline-assembly']) {
+    const example = entries.get(id).examples[0];
+    const compiled = compiler.compile(example.source, vfs, options);
+    assert.equal(compiled.errors.length, 0, `${id}: ${JSON.stringify(compiled.errors)}`);
+    const assembled = assembler.assemble(compiled.asm, { ENV_TYPE: 1 });
+    assert.equal(assembled.errors.length, 0, `${id}: ${JSON.stringify(assembled.errors)}`);
+    assert.ok(assembled.bytes.length > 0, id);
+    if (id === 'slang.machine.inline-assembly') {
+      assert.match(compiled.asm, /LD\s+HL,\$0064\s+CALL\s+ASMROUTINE/);
+      assert.match(compiled.asm, /^ASMROUTINE:/m);
+    }
+  }
+
+  const abiProbe = compiler.compile([
+    'MACHINE ZERO(0):ZERO_ROUTINE;',
+    'MACHINE ONE(1):ONE_ROUTINE;',
+    'MACHINE TWO(2):TWO_ROUTINE;',
+    'MACHINE THREE(3):THREE_ROUTINE;',
+    'MACHINE FOUR(4):FOUR_ROUTINE;',
+    'MACHINE NUMERIC(0):$1234;',
+    'MAIN() BEGIN',
+    '  ZERO(); ONE(1); TWO(1,2); THREE(1,2,3); FOUR(1,2,3,4); NUMERIC();',
+    'END;',
+    '#ASM',
+    'ZERO_ROUTINE: RET',
+    'ONE_ROUTINE: RET',
+    'TWO_ROUTINE: RET',
+    'THREE_ROUTINE: RET',
+    'FOUR_ROUTINE: RET',
+    '#END',
+  ].join('\n'), vfs, options);
+  assert.equal(abiProbe.errors.length, 0, JSON.stringify(abiProbe.errors));
+  assert.match(abiProbe.asm, /CALL\s+ZERO_ROUTINE/);
+  assert.match(abiProbe.asm, /LD\s+HL,\$0001\s+CALL\s+ONE_ROUTINE/);
+  assert.match(abiProbe.asm, /LD\s+HL,\$0001\s+LD\s+DE,\$0002\s+CALL\s+TWO_ROUTINE/);
+  assert.match(abiProbe.asm,
+    /LD\s+HL,\$0001\s+LD\s+DE,\$0002\s+LD\s+BC,\$0003\s+CALL\s+THREE_ROUTINE/);
+  assert.match(abiProbe.asm,
+    /LD\s+HL,\$0001\s+PUSH\s+HL\s+LD\s+HL,\$0002\s+PUSH\s+HL\s+LD\s+HL,\$0003\s+PUSH\s+HL\s+LD\s+HL,\$0004\s+PUSH\s+HL\s+CALL\s+FOUR_ROUTINE\s+EX\s+DE,HL\s+LD\s+HL,8\s+ADD\s+HL,SP\s+LD\s+SP,HL\s+EX\s+DE,HL/);
+  assert.match(abiProbe.asm, /CALL\s+\$1234/);
+  assert.match(abiProbe.asm, /LD IY,__IYWORK/);
+  assert.doesNotMatch(abiProbe.asm, /\bIX\b/,
+    'the compiler must not retain an IX work value across MACHINE calls');
+  const assembledProbe = assembler.assemble(abiProbe.asm, { ENV_TYPE: 1 });
+  assert.equal(assembledProbe.errors.length, 0, JSON.stringify(assembledProbe.errors));
 });
 
 test('LSX-Dodgers-specific file limitations are documented', () => {


### PR DESCRIPTION
## Summary
- document the current VSYNC/VSYNC_PROC frame-hook contract
- add dedicated INKEY mode and X1Pen key-code reference
- add verified inline Z80 assembly syntax and MACHINE calling convention
- add compile/assemble, source-contract, and browser runtime coverage

## Prerequisite re-evaluation
- #93 remains needed but is narrower because runtime arity validation is already merged
- #94 remains needed and keyboard injection is now merged, enabling full runtime coverage
- #95 remains needed independently; the merged M8ALOAD fix removes its workaround framing

No claims are added for open PR #111, unimplemented #106/#90, deferred MCP raw-binary support, or upstream SLANG TATTR. No package/reference version is changed.

## Packaged MCP note
Reference JSON is loaded when the packaged MCP module is imported. Existing installations pick up these entries after rebuilding/reinstalling the package and restarting the MCP process; no long-lived content cache is keyed by `referenceVersion`.

## Verification
- `./build.sh`
- `node --test tests/x1pen_reference_test.mjs` (40/40)
- `npm run test:mcp` (76/76)
- `npm run test:mcp-package` (1/1)
- `npm run test:automation` (24/24)
- `node --check` for changed JavaScript and `git diff --check`
- opposite-provider plan/implementation review: APPROVED through round 5, no high-severity findings

Closes #93
Closes #94
Closes #95