### PR TITLE
feat: 内蔵 Z80 アセンブラの条件式に論理演算子を追加

### DIFF
--- a/html/x1pen_z80asm.js
+++ b/html/x1pen_z80asm.js
@@ -52,7 +52,7 @@
             // 2文字比較演算子を先にチェック
             if (i + 1 < s.length) {
                 var c2 = s[i] + s[i + 1];
-                if (c2 === '>>' || c2 === '<<') {
+                if (c2 === '>>' || c2 === '<<' || c2 === '&&' || c2 === '||') {
                     tokens.push({ type: 'OP', val: c2 }); i += 2; continue;
                 }
                 if (c2 === '==' || c2 === '!=' || c2 === '>=' || c2 === '<=') {
@@ -66,7 +66,9 @@
             if (c === '/') { tokens.push({ type: 'OP', val: '/' }); i++; continue; }
             if (c === '&') { tokens.push({ type: 'OP', val: '&' }); i++; continue; }
             if (c === '|') { tokens.push({ type: 'OP', val: '|' }); i++; continue; }
+            if (c === '^') { tokens.push({ type: 'OP', val: '^' }); i++; continue; }
             if (c === '~') { tokens.push({ type: 'OP', val: '~' }); i++; continue; }
+            if (c === '!') { tokens.push({ type: 'OP', val: '!' }); i++; continue; }
             if (c === '(') { tokens.push({ type: 'LPAREN' }); i++; continue; }
             if (c === ')') { tokens.push({ type: 'RPAREN' }); i++; continue; }
             if (c === '$' && (i + 1 >= s.length || !/[0-9a-f]/i.test(s[i + 1]))) {
@@ -115,9 +117,10 @@
         return tokens;
     }
 
-    function evalExpr(exprStr, symbols, pc, globalLabel, currentNamespace) {
+    function evalExpr(exprStr, symbols, pc, globalLabel, currentNamespace, options) {
         var tokens = tokenizeExpr(exprStr);
         if (!tokens) return null;
+        var undefinedIsZero = options && options.undefinedIsZero;
 
         var pos = 0;
         function peek() { return pos < tokens.length ? tokens[pos] : null; }
@@ -135,8 +138,18 @@
                 var keyUpper = key;
                 if (keyUpper === 'LOW' && peek()) { var lv = parseAtom(); return (lv !== null && lv !== undefined) ? lv & 0xFF : lv; }
                 if (keyUpper === 'HIGH' && peek()) { var hv = parseAtom(); return (hv !== null && hv !== undefined) ? (hv >> 8) & 0xFF : hv; }
-                if (keyUpper === 'EXISTS' && peek() && peek().type === 'SYMBOL') {
-                    var existsName = next().val.toUpperCase();
+                if (keyUpper === 'EXISTS' && peek()) {
+                    var existsName = null;
+                    if (peek().type === 'SYMBOL') {
+                        existsName = next().val.toUpperCase();
+                    } else if (peek().type === 'LPAREN') {
+                        next();
+                        if (!peek() || peek().type !== 'SYMBOL') return null;
+                        existsName = next().val.toUpperCase();
+                        if (!peek() || peek().type !== 'RPAREN') return null;
+                        next();
+                    }
+                    if (existsName === null) return undefinedIsZero ? 0 : undefined;
                     // シンボルテーブル + 名前空間解決で存在チェック
                     if (existsName in symbols) return 1;
                     if (currentNamespace) {
@@ -176,12 +189,13 @@
                         }
                     }
                 }
-                return undefined; // unresolved
+                return undefinedIsZero ? 0 : undefined; // unresolved
             }
             if (t.type === 'LPAREN') {
                 next();
-                var v = parseBitwise();
-                if (peek() && peek().type === 'RPAREN') next();
+                var v = parseLogicalOr();
+                if (!peek() || peek().type !== 'RPAREN') return null;
+                next();
                 return v;
             }
             if (t.type === 'OP' && t.val === '+') {
@@ -199,6 +213,12 @@
                 var v3 = parseAtom();
                 if (v3 === null || v3 === undefined) return v3;
                 return (~v3) & 0xFFFF;
+            }
+            if (t.type === 'OP' && t.val === '!') {
+                next();
+                var v4 = parseAtom();
+                if (v4 === null || v4 === undefined) return v4;
+                return ((v4 & 0xFFFF) === 0) ? 1 : 0;
             }
             return null;
         }
@@ -259,7 +279,7 @@
                 var op = t.val;
                 if (op !== '==' && op !== '!=' && op !== '>=' && op !== '<=' && op !== '>' && op !== '<') break;
                 next();
-                var right = parseAddSub();
+                var right = parseBitwise();
                 if (right === null || left === null) return null;
                 if (left === undefined || right === undefined) return undefined;
                 if (op === '==') left = (left === right) ? 1 : 0;
@@ -272,7 +292,35 @@
             return left;
         }
 
-        var result = parseCompare();
+        function parseLogicalAnd() {
+            var left = parseCompare();
+            while (true) {
+                var t = peek();
+                if (!t || t.type !== 'OP' || t.val !== '&&') break;
+                next();
+                var right = parseCompare();
+                if (right === null || left === null) return null;
+                if (left === undefined || right === undefined) return undefined;
+                left = ((left & 0xFFFF) !== 0 && (right & 0xFFFF) !== 0) ? 1 : 0;
+            }
+            return left;
+        }
+
+        function parseLogicalOr() {
+            var left = parseLogicalAnd();
+            while (true) {
+                var t = peek();
+                if (!t || t.type !== 'OP' || t.val !== '||') break;
+                next();
+                var right = parseLogicalAnd();
+                if (right === null || left === null) return null;
+                if (left === undefined || right === undefined) return undefined;
+                left = ((left & 0xFFFF) !== 0 || (right & 0xFFFF) !== 0) ? 1 : 0;
+            }
+            return left;
+        }
+
+        var result = parseLogicalOr();
         if (pos < tokens.length) return null; // leftover tokens
         return result;
     }
@@ -860,12 +908,11 @@
                     var condActive = false;
                     if (parentActive) {
                         var exprStr = (directive[2] || '').replace(/;.*$/, '').trim();
-                        var condVal = evalExpr(exprStr, ppSymbols, 0, '');
+                        var condVal = evalExpr(exprStr, ppSymbols, 0, '', '', { undefinedIsZero: true });
                         if (condVal === null) {
                             errors.push({ line: pi + 1, msg: 'Invalid #IF expression' });
-                        } else if (condVal === undefined) {
                             condVal = 0;
-                        }
+                        } else if (condVal === undefined) condVal = 0;
                         condActive = (condVal !== 0);
                     }
                     ifStack.push({ parentActive: parentActive, condTrue: condActive, inElse: false, anyTrue: condActive });
@@ -881,7 +928,7 @@
                             top.condTrue = false;
                         } else {
                             var exprStr = (directive[2] || '').replace(/;.*$/, '').trim();
-                            var condVal = evalExpr(exprStr, ppSymbols, 0, '');
+                            var condVal = evalExpr(exprStr, ppSymbols, 0, '', '', { undefinedIsZero: true });
                             if (condVal === null) {
                                 errors.push({ line: pi + 1, msg: 'Invalid #ELIF expression' });
                                 condVal = 0;

--- a/mcp/reference/z80asm.json
+++ b/mcp/reference/z80asm.json
@@ -35,23 +35,27 @@
     "kind": "syntax",
     "title": "Numbers, character literals and expressions",
     "profiles": ["x1pen-z80asm-current"],
-    "symbols": ["0x", "$", "H", "%", "B", "LOW", "HIGH", "EXISTS", "+", "-", "*", "/", "<<", ">>", "&", "|", "~", "==", "!=", "<", "<=", ">", ">="],
+    "symbols": ["0x", "$", "H", "%", "B", "LOW", "HIGH", "EXISTS", "+", "-", "*", "/", "<<", ">>", "&", "^", "|", "~", "!", "==", "!=", "<", "<=", ">", ">=", "&&", "||"],
     "aliases": ["numeric literal", "hexadecimal", "binary", "expression", "operator precedence", "character literal", "数値", "16進数", "2進数", "式", "演算子", "文字リテラル"],
-    "summary": "Expressions are 16-bit and accept decimal, hexadecimal, binary, ASCII character, symbol and current-address values with arithmetic, shift, bitwise and comparison operators.",
+    "summary": "Expressions are 16-bit and accept decimal, hexadecimal, binary, ASCII character, symbol and current-address values with arithmetic, shift, bitwise, comparison and logical operators.",
     "syntax": [
       "123 / 0x7B / $7B / 7BH      decimal and hexadecimal",
       "%1010 / 1010B              binary",
       "'A' or \"A\"                one-byte ASCII character literal",
       "$                            current assembly address",
       "LOW expr / HIGH expr         low or high byte",
-      "EXISTS symbol                1 when a symbol is already defined, otherwise 0",
-      "precedence: unary; *, /, <<, >>; +, -; &, |; comparisons"
+      "EXISTS symbol or EXISTS(symbol)  1 when a symbol is already defined, otherwise 0",
+      "!value / left && right / left || right  logical operations normalized to 0 or 1",
+      "precedence: unary +, -, ~, !; *, /, <<, >>; +, -; &, ^, |; comparisons; &&; ||"
     ],
     "notes": [
       "Expression results wrap to 16 bits. Division by zero currently evaluates to zero.",
       "Only single-byte ASCII character literals are accepted; use DB with an ASCII double-quoted string for multiple bytes.",
-      "Comparisons return 1 or 0 and are primarily useful in #IF/#ELIF.",
-      "An unresolved symbol is tolerated as a pass-one placeholder but must resolve during pass two."
+      "Comparisons and logical operators return 1 or 0. Truthiness is tested after masking to 16 bits, so 0x10000 is false and -1 is true.",
+      "Binary operators are left-associative within each tier, including comparison chaining. Parentheses contain a full expression and must be balanced.",
+      "Logical evaluation is eager: both operands must be valid even when the left operand determines the result.",
+      "The same evaluator is used by operands, indexed displacements, EQU, ORG, ALIGN, DB, DW, DS and #IF/#ELIF.",
+      "An unresolved symbol is tolerated as a pass-one placeholder but must resolve during pass two; only conditional preprocessing substitutes zero for an undefined symbol."
     ],
     "examples": [{
       "title": "Build a word from high and low byte expressions",
@@ -99,16 +103,18 @@
     "symbols": ["#IF", "#ELIF", "#ELSEIF", "#ELSE", "#ENDIF", "EXISTS"],
     "aliases": ["conditional assembly", "preprocessor", "feature flag", "defined symbol", "条件アセンブル", "プリプロセッサ", "条件分岐", "シンボル判定"],
     "summary": "A preprocessing pass supports nested #IF blocks, multiple #ELIF/#ELSEIF branches, #ELSE and #ENDIF using assembler expressions and predefined symbols.",
-    "syntax": ["#IF expression", "#ELIF expression or #ELSEIF expression", "#ELSE", "#ENDIF", "#IF EXISTS SYMBOL"],
+    "syntax": ["#IF expression", "#ELIF expression or #ELSEIF expression", "#ELSE", "#ENDIF", "#IF EXISTS SYMBOL", "#IF EXISTS(SYMBOL) && expression"],
     "notes": [
-      "Undefined symbols evaluate as zero during conditional preprocessing, so #IF UNKNOWN is false and #IF UNKNOWN==0 is true.",
+      "Undefined symbols evaluate as zero throughout a conditional expression, so #IF UNKNOWN is false and #IF UNKNOWN==0 is true. Ordinary assembler expressions keep unresolved symbols unresolved.",
+      "EXISTS checks the real symbol table and is not changed by undefined-as-zero substitution. Evaluation is eager, so an EXISTS guard does not skip its right operand.",
       "Only active EQU definitions become available to later conditions in the preprocessing pass.",
+      "An invalid #IF or #ELIF reports an error, keeps that branch inactive and leaves the chain unsatisfied, so a later valid #ELIF or #ELSE remains eligible.",
       "#ELIF after #ELSE, duplicate #ELSE, unmatched directives and unterminated blocks are errors.",
       "X1Pen address-map predefined symbols are available to the preprocessor as bare names and through NAME_SPACE_DEFAULT."
     ],
     "examples": [{
-      "title": "Select code using a predefined or user EQU flag",
-      "source": "ORG 0100H\nTURBO EQU 1\n#IF TURBO\n  LD A,2\n#ELSE\n  LD A,1\n#ENDIF\nRET"
+      "title": "Select the M8A width path with a compound condition",
+      "source": "ORG 0100H\nCALCSPEED EQU 1\nM8A_WIDTH EQU 40\n#IF CALCSPEED != 0 && M8A_WIDTH == 40\n  LD A,2\n#ELIF !EXISTS(M8A_WIDTH)\n  LD A,0\n#ELSE\n  LD A,1\n#ENDIF\nRET"
     }],
     "relatedIds": ["z80asm.syntax.expressions", "z80asm.directives.data", "z80asm.syntax.source", "z80asm.macros"],
     "sourceUrls": ["https://github.com/ho-ogino/xmil-web/blob/main/html/x1pen_z80asm.js"]

--- a/tests/x1pen_reference_test.mjs
+++ b/tests/x1pen_reference_test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
@@ -89,6 +89,9 @@ test('reference search matches punctuation-only symbols without changing token n
     ['slang', '!=', 'slang.expressions.operators'],
     ['slang', '<<', 'slang.expressions.operators'],
     ['slang', '<>', 'slang.expressions.operators'],
+    ['z80asm', '&&', 'z80asm.syntax.expressions'],
+    ['z80asm', '||', 'z80asm.syntax.expressions'],
+    ['z80asm', '!', 'z80asm.syntax.expressions'],
     ['fuzzybasic', '<=', 'fuzzybasic.values.operators'],
     ['fuzzybasic', '>=', 'fuzzybasic.values.operators'],
   ]) {
@@ -433,6 +436,35 @@ test('every X1Pen assembler example assembles with the bundled assembler', () =>
       assert.ok(result.bytes.length > 0, `${entry.id}: ${example.title} must produce bytes`);
     }
   }
+});
+
+test('X1Pen assembler reference pins the portable logical-expression contract', () => {
+  const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
+  const entries = new Map(validateReferenceData().entries.map((entry) => [entry.id, entry]));
+  const expressions = entries.get('z80asm.syntax.expressions');
+  const conditionals = entries.get('z80asm.preprocessor.conditionals');
+  const expressionText = JSON.stringify(expressions);
+  const conditionalText = JSON.stringify(conditionals);
+
+  for (const symbol of ['!', '&&', '||', '^']) assert.ok(expressions.symbols.includes(symbol));
+  for (const fact of [
+    'comparisons; &&; ||',
+    'masking to 16 bits',
+    'left-associative',
+    'eager',
+    'DB, DW, DS',
+    'only conditional preprocessing substitutes zero',
+  ]) assert.ok(expressionText.includes(fact), `${fact} must remain documented`);
+  for (const fact of [
+    '#IF UNKNOWN==0 is true',
+    'real symbol table',
+    'leaves the chain unsatisfied',
+    'CALCSPEED != 0 && M8A_WIDTH == 40',
+  ]) assert.ok(conditionalText.includes(fact), `${fact} must remain documented`);
+
+  const assembled = assembler.assemble(conditionals.examples[0].source);
+  assert.equal(assembled.errors.length, 0);
+  assert.deepEqual(Array.from(assembled.bytes), [0x3E, 0x02, 0xC9]);
 });
 
 test('every assembler mnemonic is covered by the X1Pen assembler reference', () => {
@@ -1126,22 +1158,10 @@ test('documented embedded M8A example compiles and assembles with its standalone
     'M8ALOAD must pull X1WORK without requiring the caller to use WIDTH first');
 });
 
-test('M8A runtime conditionals use supported syntax and preserve both dormant width tables', () => {
+test('M8A runtime conditionals preserve both dormant width tables', () => {
   const compiler = loadBrowserGlobal('html/x1pen_slang_compiler.js', 'X1PenSlangCompiler');
   const assembler = loadBrowserGlobal('html/x1pen_z80asm.js', 'X1PenZ80Asm');
   const vfs = loadSlangVfs();
-  const runtimeDir = join(repoRoot, 'assets/slang_runtime');
-  const unsupported = [];
-  for (const filename of readdirSync(runtimeDir).filter((name) => name.endsWith('.asm'))) {
-    const source = readFileSync(join(runtimeDir, filename), 'utf8');
-    source.split(/\r?\n/).forEach((line, index) => {
-      if (/^\s*#(?:IF|ELIF|ELSEIF)\b.*(?:&&|\|\|)/i.test(line)) {
-        unsupported.push(`${filename}:${index + 1}`);
-      }
-    });
-  }
-  assert.deepEqual(unsupported, [], 'assembler runtime directives must avoid unsupported logical tokens');
-
   const m8aSource = vfs['libm8a.asm'];
   const magSource = vfs['libmag.asm'];
   assert.match(m8aSource, /^; @calls X1WORK$/m);

--- a/tests/z80asm_test.js
+++ b/tests/z80asm_test.js
@@ -32,6 +32,20 @@ function testFail(name, source) {
     } else { passes++; }
 }
 
+function testErrorBytes(name, source, expectedBytes, expectedMessage) {
+    var result = asm.assemble(source);
+    var actual = Array.from(result.bytes);
+    var hasMessage = result.errors.some(function(error) { return error.msg === expectedMessage; });
+    if (!hasMessage || JSON.stringify(actual) !== JSON.stringify(expectedBytes)) {
+        console.error('FAIL:', name);
+        console.error('  expected error:', expectedMessage);
+        console.error('  actual errors: ', result.errors);
+        console.error('  expected bytes:', expectedBytes.map(hex).join(' '));
+        console.error('  actual bytes:  ', actual.map(hex).join(' '));
+        failures++;
+    } else { passes++; }
+}
+
 // ================================================================
 // 1. No-argument instructions
 // ================================================================
@@ -443,7 +457,7 @@ testOK('#IF false EQU hidden',
 testOK('#IF false ORG hidden',
     'ORG 0\n#IF 0\nORG 0x8000\n#ENDIF\nNOP', [0x00]);
 testOK('#IF UNDEF is false', '#IF UNDEF\nNOP\n#ENDIF', []);
-testOK('#IF UNDEF == 0 is true', '#IF UNDEF == 0\nNOP\n#ENDIF', []);
+testOK('#IF UNDEF == 0 is true', '#IF UNDEF == 0\nNOP\n#ENDIF', [0x00]);
 testOK('#IF nested false-true',
     '#IF 0\n#IF 1\nNOP\n#ENDIF\n#ENDIF', []);
 testOK('#IF nested true-false-else',
@@ -476,6 +490,60 @@ testOK('#ELIF: multiple (V=2)', 'V EQU 2\n#IF V==0\n DB 0\n#ELIF V==1\n DB 1\n#E
 testOK('#ELIF: none match, ELSE', 'V EQU 5\n#IF V==0\n DB 0\n#ELIF V==1\n DB 1\n#ELIF V==2\n DB 2\n#ELSE\n DB 99\n#ENDIF', [0x63]);
 testFail('#ELIF after #ELSE', '#IF 0\n NOP\n#ELSE\n NOP\n#ELIF 1\n NOP\n#ENDIF');
 testFail('#ELIF without #IF', '#ELIF 1\nNOP\n#ENDIF');
+
+// Logical expressions and conditional error recovery
+testOK('#IF compound M8A condition',
+    'CALCSPEED EQU 1\nM8A_WIDTH EQU 40\n#IF CALCSPEED != 0 && M8A_WIDTH == 40\n DB $28\n#ELSE\n DB $50\n#ENDIF',
+    [0x28]);
+testOK('logical truth and normalization',
+    'DB 0 && 1,2 && 4,0 || 0,0 || 7,!0,!5,!!4,!!!4',
+    [0, 1, 0, 1, 1, 0, 1, 0]);
+testOK('logical token boundaries and bitwise XOR',
+    'DB 6 & 3,6 && 3,4 | 2,4 || 2,1 != 0,!0,3 ^ 1',
+    [2, 1, 6, 1, 1, 1, 2]);
+testOK('logical precedence and left associativity',
+    'DB 0 || 1 && 0,1 || 0 || 0,1 == 1 == 1',
+    [0, 1, 1]);
+testOK('bitwise comparison operands are symmetric',
+    'DB 1 | 0 == 1,1 == 1 | 0',
+    [1, 1]);
+testOK('full expression parentheses',
+    'DB (1 == 1) && (0 || (2 ^ 3))',
+    [1]);
+testFail('missing expression close parenthesis', 'DB (1 == 1');
+testFail('unexpected expression close parenthesis', 'DB 1 == 1)');
+testFail('logical eager RHS syntax validation', '#IF 0 && (1 +)\nNOP\n#ENDIF');
+testOK('16-bit masked logical truthiness',
+    'DB !0x10000,-1 && 1,0x10000 || 0',
+    [1, 1, 0]);
+
+testOK('logical result in EQU and immediate operand',
+    'FLAG EQU 2 && 4\nLD A,FLAG || 0',
+    [0x3E, 0x01]);
+testOK('logical result in ORG', 'ORG 0\nORG (0 || 2)\nNOP', [0x00, 0x00]);
+testOK('logical result in DW', 'DW 0 || 7,2 && 3', [1, 0, 1, 0]);
+testOK('logical result in DS', 'DS 2 && 4,0', [0]);
+testFail('ordinary unresolved comparison remains unresolved', 'LD A,UNDEFINED == 0');
+
+testOK('EXISTS defined compound condition',
+    'DEFINED EQU 3\n#IF EXISTS(DEFINED) && DEFINED == 3\n DB 1\n#ELSE\n DB 0\n#ENDIF',
+    [1]);
+testOK('EXISTS undefined compound condition',
+    '#IF EXISTS(UNDEFINED) && UNDEFINED == 0\n DB 1\n#ELSE\n DB 0\n#ENDIF',
+    [0]);
+testOK('logical NOT EXISTS undefined',
+    '#IF !EXISTS(UNDEFINED)\n DB 1\n#ELSE\n DB 0\n#ENDIF',
+    [1]);
+testOK('logical NOT EXISTS defined',
+    'DEFINED EQU 1\n#IF !EXISTS(DEFINED)\n DB 1\n#ELSE\n DB 0\n#ENDIF',
+    [0]);
+
+testErrorBytes('invalid #IF leaves valid #ELIF eligible',
+    '#IF 1 +\n DB 1\n#ELIF 1\n DB 2\n#ELSE\n DB 3\n#ENDIF',
+    [2], 'Invalid #IF expression');
+testErrorBytes('invalid #ELIF leaves #ELSE eligible',
+    '#IF 0\n DB 1\n#ELIF 1 +\n DB 2\n#ELSE\n DB 3\n#ENDIF',
+    [3], 'Invalid #ELIF expression');
 
 // --- IX/IY half registers ---
 console.log('\n--- IX/IY half registers ---');


### PR DESCRIPTION
## Summary

- add logical &&, ||, and ! with 16-bit truthiness and normalized 0/1 results
- enable existing bitwise ^ support, full-expression parentheses, and symmetric comparison operands
- keep undefined-as-zero limited to conditional preprocessing and make invalid #IF/#ELIF branches inactive
- document and test precedence, eager evaluation, EXISTS behavior, and the original M8A compound condition

## Verification

- node tests/z80asm_test.js (343 passed)
- node --test tests/x1pen_reference_test.mjs (41 passed)
- ./build.sh
- npm run test:mcp (77 passed)
- npm run test:mcp-package (1 passed)
- node --check and JSON parse checks
- git diff --check

Closes #102