### PR TITLE
chore: prepare X1Pen 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## X1Pen 0.9.0 / x1pen-mcp 2.7.0 / Connector 1.3.0
+
+### X1Pen Web 0.9.0
+
+- 書き込み可能なLSX-Dodgers diskを元に、非破壊のworking copyを作るproject disk機能を追加しました。project diskからのRUNはcold startとなり、X1／X1turbo／X1turboZのMODELを選べます。
+- ディスクなしで作ったBASIC／SLANGプログラムの一時PROGRAM diskを保存し、project diskの安全なベースとして再利用できるようになりました。
+- SLANGに`STICK`と`TATTR`を追加し、runtime呼出しの引数個数検証を強化しました。
+- SLANGタブにbinary Importを追加しました。
+- Z80 assemblerの`#IF`で`&&`、`||`、`!`を利用できるようになりました。
+- NMI操作がIPL resetの代用ではなく、実際のZ80 NMIを発生するようになりました。
+- 物理キー入力の取りこぼし、M8ALOADのbrowser assembly経路を修正しました。
+- source revision／hash／epochを追加し、page reloadや競合をまたぐ古い編集を検出できるようにしました。
+- timing、`INKEY`、inline assembly、大量書き込み、SLANGの`{}`推奨記法などのreferenceを更新しました。
+
+挙動が変わる点:
+
+- project disk RUNはcold startのため、RAM、VRAM、PCGと未保存のmachine stateが消えます。MODEL切り替えはこの経路だけで利用できます。
+- NMIはresetではなくなりました。再起動が必要な場合はIPL Resetを使用してください。
+- staleなsource更新と、引数個数が不正なSLANG runtime呼出しは、誤動作させず明示的に拒否します。
+
+### x1pen-mcp 2.7.0
+
+- `x1pen_send_key`、`x1pen_set_pad`を追加しました。
+- bounded source read/search、`x1pen_diff_source`、`x1pen_apply_edits`を追加しました。
+- revision／hash／epochに基づくsource conflict guardを追加しました。
+- 旧Connectorでもsourceの読み書きを継続できるgraceful degradationを追加しました。
+- project disk、MODEL、実行、入力、SLANG／FuzzyBASIC／Z80 assemblyのreferenceを更新しました。
+
+Connector 1.2.0ではsource read/writeを`revision-only` modeで継続できますが、reloadをまたぐ完全な競合防止、`x1pen_diff_source`、remote key入力、remote pad入力は利用できません。完全な機能にはConnector 1.3.0以降が必要です。
+
+### X1Pen Connector 1.3.0
+
+- X1Penの表示中emulatorへ送る、許可済みのbounded key入力とactive-low joystick pad入力を追加しました。
+- disconnect、reload、session変更、bridge終了、emulator resetで保持中のpad入力を解放します。
+- source revision epoch／capability descriptor／source-sync transportと構造化errorを追加しました。
+- manifest permissionは1.2.0から増えていません。
+
+### Project diskとMODELについて
+
+- project diskには、書き込み可能なsingle-member LSX-Dodgers形式のD88／2Dが必要です。起動には`LD.BIN`と`AUTOEXEC.BAT`、BASICには`FZBASIC.COM`が必要です。X1PenはBASICの`PROGRAM.BIN`／`AUTORUN.BAS`、SLANGの`PROG.COM`をworking copyへ書き込みます。
+- 一時PROGRAM diskをSaveして再登録する方法なら、`MAGIC.BIN`、`PSGAKM.BIN`、`PSGAKG.BIN`などの同梱fileも保持されます。
+- MODEL切り替えはproject diskのcold-start RUN限定です。通常のRUNでは切り替えられません。
+- cold startではRAM、VRAM、PCGが消去されます。
+- ROM未登録時はstub BIOSを使います。実IPL ROMとは動作が異なる場合があるため、必要に応じてX1用`IPLROM.X1`、turbo／turboZ用`IPLROM.X1T`を登録してください。

--- a/docs/RELEASE_CHECKLIST_0.9.0.md
+++ b/docs/RELEASE_CHECKLIST_0.9.0.md
@@ -1,0 +1,65 @@
+# X1Pen 0.9.0 公開前チェックリスト
+
+OwnerがWeb deploy → npm publish → Chrome Web Store提出の直前に実行するチェックリストです。失敗項目が1つでもあれば次の公開工程へ進みません。
+
+## 1. Release candidate
+
+- [ ] PR #111が含まれておらず、PR #118を含むrelease準備PRのmerge commitを記録した。
+- [ ] `html/x1pen-version.js`は`0.9.0`、`mcp/package.json`は`2.7.0`、`extension/manifest.json`は`1.3.0`である。
+- [ ] `npm run test:project-disk`、`npm run test:bridge`、`npm run test:mcp`、`npm run test:mcp-package`、`npm run test:extension-package`が成功した。
+- [ ] `./build.sh`と`npm run test:automation`が成功した。
+- [ ] MCP tarballとConnector ZIPのversion／内容を確認し、公開するartifactを固定した。
+
+## 2. Project diskのexact click path
+
+### BASIC
+
+- [ ] FDD0／FDD1を空にし、`10 PRINT "HELLO, WORLD"`をRUNした。
+- [ ] **FDD → FDD0 → Save** で`PROGRAM.d88`を保存した。
+- [ ] 保存したdiskをライブラリへ追加し、FDD0へマウントした。
+- [ ] MODELを選んでRUNし、`<元名>-X1Pen` working copy作成を承認した。
+- [ ] cold start後にHELLOプログラムが実行された。
+- [ ] working copyに`LD.BIN`、`AUTOEXEC.BAT`、`FZBASIC.COM`、`MAGIC.BIN`、`PSGAKM.BIN`、`PSGAKG.BIN`が残っている。
+
+### SLANG
+
+- [ ] FDD0／FDD1を空にし、短いHELLOプログラムをSLANGでRUNした。
+- [ ] FDD0をSaveしてライブラリへ再登録し、project working copyを作成した。
+- [ ] cold start後に`PROG.COM`が実行された。
+- [ ] `LD.BIN`、`AUTOEXEC.BAT`、`MAGIC.BIN`、`PSGAKM.BIN`、`PSGAKG.BIN`が残っている。
+
+## 3. MODEL／ROM
+
+- [ ] X1、X1turbo、X1turboZをproject diskのcold-start RUNで順に起動した。
+- [ ] MODEL変更ごとにRAM／VRAM／PCGが初期化されることを確認した。
+- [ ] 通常の一時PROGRAM disk RUNではMODEL切り替えを案内しないことを確認した。
+- [ ] ROM未登録のstub BIOS環境で起動結果を記録した。
+- [ ] 利用可能なら、X1は`IPLROM.X1`、turbo／turboZは`IPLROM.X1T`でも起動結果を記録した。stubと実ROMの結果は別々に扱った。
+
+## 4. MCP／Connector互換性
+
+- [ ] X1Pen 0.9.0 + MCP 2.7.0 + Connector 1.2.0でsource read/writeが成功し、statusが`revision-only`／degradedを示した。
+- [ ] 上記の旧Connector構成で`x1pen_diff_source`、remote key、remote padが利用不可となり、1.3.0への更新案内が表示された。
+- [ ] Connector 1.3.0でfull source-sync、`x1pen_diff_source`、remote key、remote padが成功した。
+- [ ] padを保持した状態からdisconnect／reload／session変更／resetを行い、入力が解放された。
+
+## 5. Web deploy（Owner）
+
+- [ ] deploy前に直前正常なCloudflare Pages deployment IDと`v0.8.1`を記録した。
+- [ ] release merge commitにannotated tag `v0.9.0`を付けた。
+- [ ] X1Pen Webをdeployし、hard reload／cache無効化を行った。
+- [ ] `x1pen-version.js`、page status、feature descriptorがすべて`0.9.0`相当を示した。
+- [ ] editor、RUN、project disk、MCP coreを本番でsmoke testした。
+
+## 6. npm publish（Owner）
+
+- [ ] `npm whoami`と`npm run test:mcp-package`を再確認した。
+- [ ] `npm publish ./mcp`を実行した。
+- [ ] `npm view x1pen-mcp version`と`npx -y x1pen-mcp@2.7.0 --version`が`2.7.0`を示した。
+
+## 7. Chrome Web Store（Owner）
+
+- [ ] 公開中が`1.2.0`で、別の審査中draftがないことをDashboardで再確認した。
+- [ ] `dist/x1pen-connector-1.3.0.zip`を提出した。
+- [ ] 審査手順で本番X1Pen 0.9.0と`x1pen-mcp@latest`を使って新機能を再現できることを確認した。
+- [ ] 提出日時、artifact checksum、Dashboard statusを記録した。

--- a/docs/RELEASE_NOTES_0.9.0.md
+++ b/docs/RELEASE_NOTES_0.9.0.md
@@ -1,0 +1,33 @@
+# X1Pen 0.9.0 リリースノート原稿
+
+公開時にそのまま転記できる、コンポーネント別の原稿です。
+
+## X1Pen Web 0.9.0
+
+X1Pen 0.9.0では、ライブラリのLSX-Dodgers diskを安全なworking copyにして使うproject disk機能を追加しました。project diskからのRUNはcold startとなり、X1／X1turbo／X1turboZのMODELを選択できます。SLANGの`STICK`／`TATTR`、binary Import、Z80 assembler `#IF`の論理演算子、実NMIにも対応しました。物理キーの取りこぼしとM8ALOADのbrowser assemblyも修正し、source revision／hash／epochによる競合検出を強化しています。
+
+注意: MODEL切り替えはproject diskのcold-start RUN限定です。通常のRUNでは切り替えられません。cold startではRAM、VRAM、PCGと未保存のmachine stateが消えます。NMIもresetではなくなったため、再起動にはIPL Resetを使用してください。不正なSLANG runtime引数とstaleなsource更新は明示エラーになります。
+
+### MODELを切り替える安全な手順
+
+1. FDD0／FDD1を空にして、BASICまたはSLANGで短いプログラムをRUNします。
+2. **FDD → FDD0 → Save** で`PROGRAM.d88`を保存します。
+3. `PROGRAM.d88`をファイルライブラリへ追加し、FDD0へマウントします。
+4. MODELを選んで再度RUNし、`<元の名前>-X1Pen` working copyの作成を承認します。
+5. cold start後の実行を確認し、元の`PROGRAM.d88`はベースとして保管します。
+
+このdiskには起動に必要な`LD.BIN`／`AUTOEXEC.BAT`、BASIC用の`FZBASIC.COM`、グラフィック／サウンド用の`MAGIC.BIN`／`PSGAKM.BIN`／`PSGAKG.BIN`が含まれ、Saveと再登録後も保持されます。X1PenはBASICなら`PROGRAM.BIN`／`AUTORUN.BAS`、SLANGなら`PROG.COM`を書き込みます。
+
+ROMを登録していない環境では内蔵stub BIOSで起動します。実IPL ROMとは動作が異なるsoftwareがあるため、必要に応じてX1用`IPLROM.X1`、X1turbo／turboZ用`IPLROM.X1T`を登録してください。stubでの確認は実ROMでの動作保証ではありません。
+
+## npm: x1pen-mcp 2.7.0
+
+x1pen-mcp 2.7.0では、`x1pen_send_key`／`x1pen_set_pad`、bounded source read/search、`x1pen_diff_source`、`x1pen_apply_edits`を追加しました。revision／hash／epochによるsource conflict guardで、page reloadや同時編集をまたぐstale updateを安全に拒否します。project disk、MODEL、SLANG／FuzzyBASIC／Z80 assemblyのreferenceも更新しました。
+
+Connector 1.2.0の審査待ち環境でもsource read/writeは`revision-only` modeで継続できます。ただしreloadをまたぐ完全な競合防止、`x1pen_diff_source`、remote key入力、remote pad入力は利用できません。MCPのstatusにdegraded表示が出た場合は、Connector 1.3.0以降へ更新すると全機能を利用できます。
+
+## Chrome Web Store: X1Pen Connector 1.3.0
+
+X1Pen Connector 1.3.0では、表示中のX1Pen emulatorに対する許可済みのbounded key入力とjoystick pad入力、source revision epoch／capability negotiation／source-sync transportを追加しました。保持中のpad入力はdisconnect、reload、session変更、bridge終了、emulator resetで自動解放されます。manifest permissionは1.2.0から増えていません。
+
+完全なsource conflict guard、`x1pen_diff_source`、remote key／pad入力を使うには、X1Pen 0.9.0、x1pen-mcp 2.7.0、Connector 1.3.0以降を組み合わせてください。

--- a/docs/X1PEN.md
+++ b/docs/X1PEN.md
@@ -116,6 +116,25 @@ project diskはRUNとguest writeのたびライブラリへ自動保存されま
 このディスクには LSX-Dodgers と FuzzyBASIC が含まれており、そのままブートできる起動ディスクです。
 X millennium Web 本体のエミュレータで FDD にマウントして起動すれば、AUTORUN.BAS が自動実行されます。
 
+### 安全なproject diskベースを作る
+
+手元にboot可能なLSX-Dodgers diskがない場合は、X1Pen自身が作る一時PROGRAM diskをベースにできます。
+
+1. FDD0とFDD1を空にし、BASICまたはSLANGで短いプログラムを書いてRUNします。
+2. **FDD** → FDD0の **Save** で`PROGRAM.d88`を保存します。
+3. `PROGRAM.d88`をファイルライブラリへ追加し、FDD0へマウントします。
+4. MODELを選び、もう一度RUNして`<元の名前>-X1Pen` working copyの作成を承認します。
+5. cold start後にプログラムが実行されることを確認します。元の`PROGRAM.d88`は再利用できる安全なベースとして保管してください。
+
+この方法では元ディスクに含まれる`LD.BIN`、`AUTOEXEC.BAT`、`MAGIC.BIN`、`PSGAKM.BIN`、`PSGAKG.BIN`が保持されます。BASIC用ディスクには`FZBASIC.COM`も含まれます。X1PenはBASICで`PROGRAM.BIN`／`AUTORUN.BAS`、SLANGで`PROG.COM`をworking copyへ書き込みます。
+
+### MODEL切り替えの制約
+
+- MODEL切り替えを適用できるのは、libraryのproject diskから行うcold-start RUNです。通常の一時PROGRAM disk／cold stateを使うRUNの途中ではMODELを切り替えられません。
+- cold startではCPU stateに加えてRAM、VRAM、PCGが初期化され、未保存の内容は消えます。必要なdisk writeを保存してから切り替えてください。
+- X1では`IPLROM.X1`、X1turbo／X1turboZでは`IPLROM.X1T`を使用します。ROM未登録時は内蔵stub BIOSで最低限の起動ができますが、実IPL ROMと動作が異なるsoftwareがあります。stubでの起動確認は実ROMでの互換性保証ではなく、その逆も同様です。利用者が合法的に用意した実IPL ROMでの確認を推奨します。
+- project diskの検証はfilesystem構造、保存、mountまでです。任意のdiskが選択MODEL／ROMでbootし、guest programを開始することまでは保証しません。
+
 ## Share（共有）
 
 **Share ボタン**をクリックすると、BASIC と ASM の内容が共有用 URL としてクリップボードにコピーされます。

--- a/docs/X1PEN_MCP.md
+++ b/docs/X1PEN_MCP.md
@@ -370,8 +370,10 @@ npm publish ./mcp
 互換性機能を追加するリリースは、次の順序で公開します。
 
 1. `html/x1pen-version.js`を更新し、X1Penをデプロイ
-2. `extension/manifest.json`を更新し、ConnectorをChrome Web Storeへ提出・公開
-3. `mcp/package.json`を更新し、MCPサーバーをnpmへ公開
+2. `mcp/package.json`を確認し、MCPサーバーをnpmへ公開
+3. `extension/manifest.json`を確認し、ConnectorをChrome Web Storeへ提出・公開
+
+Connectorの審査中でも、旧Connector 1.2.0と新しいMCPを組み合わせて、sourceの読み書きを`revision-only` modeで継続できます。この組み合わせではreloadをまたぐ完全な競合防止は利用できず、`x1pen_diff_source`、remote key入力、remote pad入力も利用できません。MCPのstatusとerrorに更新案内が表示されたら、Connector 1.3.0以降へ更新してください。
 
 X1Pen製品バージョンの真実の源は`html/x1pen-version.js`です。X1Pen 0.8.0、Connector 1.2.0、MCP 2.6.0から明示的な3層互換性情報に対応します。X1Penのリリースタグは製品バージョンと同じ`v<version>`形式にします。
 

--- a/html/x1pen-version.js
+++ b/html/x1pen-version.js
@@ -3,6 +3,6 @@
 
     window.X1PenBuild = Object.freeze({
         name: 'x1pen',
-        version: '0.8.1'
+        version: '0.9.0'
     });
 })();

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -120,7 +120,7 @@ test('automation API loads and runs a BASIC program', { timeout: 60_000 }, async
   assert.equal(await page.evaluate(() => window.X1PenAutomation.version), 2);
   assert.deepEqual(ready.x1pen, {
     name: 'x1pen',
-    version: '0.8.1',
+    version: '0.9.0',
     automationApiVersion: 2,
     features: ['automation.core', 'automation.run-recovery', 'automation.source-sync', 'screen.capture', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'],
   });

--- a/tests/x1pen_bridge_test.mjs
+++ b/tests/x1pen_bridge_test.mjs
@@ -157,7 +157,7 @@ test('legacy Connector inference is frozen and blocks unsupported debugger RPCs 
   const mcp = createMcpDescriptor('2.7.0');
   const connector = normalizeConnectorPair({ extensionVersion: '1.1.1' });
   const x1pen = {
-    name: 'x1pen', version: '0.8.1', automationApiVersion: 2,
+    name: 'x1pen', version: '0.9.0', automationApiVersion: 2,
     features: [...mcp.features], featureSource: 'advertised',
   };
   const capabilities = evaluateCompatibility({ mcp, connector, x1pen });
@@ -221,7 +221,7 @@ test('every MCP server bridge command has an explicit capability mapping', () =>
     },
   });
   const x1pen = {
-    name: 'x1pen', version: '0.8.1', automationApiVersion: 2,
+    name: 'x1pen', version: '0.9.0', automationApiVersion: 2,
     features: [...mcp.features], featureSource: 'advertised',
   };
   const capabilities = evaluateCompatibility({ mcp, connector, x1pen });
@@ -286,7 +286,7 @@ test('session selection releases pad input on the previous live tab', async () =
     },
   });
   const x1pen = {
-    version: '0.8.1', automationApiVersion: 2,
+    version: '0.9.0', automationApiVersion: 2,
     features: ['automation.core', 'input.pad'],
   };
   socket.send(JSON.stringify({
@@ -327,7 +327,7 @@ test('session selection bounds pad cleanup and requires explicit force to fail o
     },
   });
   const x1pen = {
-    version: '0.8.1', automationApiVersion: 2,
+    version: '0.9.0', automationApiVersion: 2,
     features: ['automation.core', 'input.pad'],
   };
   socket.send(JSON.stringify({

--- a/tests/x1pen_extension_bridge_test.mjs
+++ b/tests/x1pen_extension_bridge_test.mjs
@@ -37,7 +37,7 @@ function createAutomationApi() {
     version: 2,
     ready: async () => ({ ready: true }),
     getStatus: () => ({
-      x1pen: { version: '0.8.1', features: ['automation.core', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'] },
+      x1pen: { version: '0.9.0', features: ['automation.core', 'input.keyboard', 'input.pad', 'debugger.cpu', 'debugger.vram'] },
       capabilities: {
         debugger: { available: true, runPending: pendingReads-- > 0, vram: { available: true } },
       },
@@ -209,7 +209,7 @@ test('page bridge allowlists keyboard input and requires its advertised capabili
     { locked: false, label: undefined },
   ]);
 
-  api.getStatus = () => ({ x1pen: { version: '0.8.1', features: ['automation.core'] } });
+  api.getStatus = () => ({ x1pen: { version: '0.9.0', features: ['automation.core'] } });
   await assert.rejects(
     invokeX1PenInPage('sendKey', { code: 0x41, durationMs: 80 }),
     (error) => error.code === 'FEATURE_UNAVAILABLE' && error.feature === 'input.keyboard',
@@ -232,7 +232,7 @@ test('page bridge allowlists pad input and exposes cleanup without arbitrary rou
   });
   assert.equal(calls.at(-1), 'releasePads');
 
-  api.getStatus = () => ({ x1pen: { version: '0.8.1', features: ['automation.core'] } });
+  api.getStatus = () => ({ x1pen: { version: '0.9.0', features: ['automation.core'] } });
   await assert.rejects(
     invokeX1PenInPage('setPad', { port: 1, bits: 0xFE }),
     (error) => error.code === 'FEATURE_UNAVAILABLE' && error.feature === 'input.pad',

--- a/tests/x1pen_extension_package_test.mjs
+++ b/tests/x1pen_extension_package_test.mjs
@@ -110,7 +110,7 @@ test('X1Pen Connector store package is complete and minimally scoped', async () 
 
 test('X1Pen product version is declared once and copied into browser builds', async () => {
   const versionSource = await readFile(join(repoRoot, 'html/x1pen-version.js'), 'utf8');
-  assert.match(versionSource, /version:\s*'0\.8\.1'/);
+  assert.match(versionSource, /version:\s*'0\.9\.0'/);
   assert.match(versionSource, /name:\s*'x1pen'/);
 
   const x1penHtml = await readFile(join(repoRoot, 'html/x1pen.html'), 'utf8');

--- a/tests/x1pen_mcp_test.mjs
+++ b/tests/x1pen_mcp_test.mjs
@@ -49,7 +49,7 @@ function configureCompatibility({ connectorSourceSync = true, x1penSourceSync = 
       },
     }),
     x1pen: normalizeX1PenDescriptor({
-      version: x1penSourceSync ? '0.8.1' : '0.8.0', automationApiVersion: 2,
+      version: x1penSourceSync ? '0.9.0' : '0.8.0', automationApiVersion: 2,
       features: FULL_FEATURES.filter((feature) => x1penSourceSync || feature !== 'automation.source-sync'),
     }),
   };
@@ -402,7 +402,7 @@ test('connection and status tools report all component versions and effective ca
   assert.equal(sessions.sessions[0].x1pen.version, '0.8.0');
 
   const status = jsonContent(await client.callTool({ name: 'x1pen_get_status', arguments: {} }));
-  assert.equal(status.compatibility.components.x1pen.version, '0.8.1');
+  assert.equal(status.compatibility.components.x1pen.version, '0.9.0');
   assert.equal(status.compatibility.capabilities['debugger.vram'].available, true);
 });
 


### PR DESCRIPTION
## Summary

- bump X1Pen Web from 0.8.1 to 0.9.0
- keep x1pen-mcp at 2.7.0 and Connector at 1.3.0 because both main versions are already newer than their published versions
- add CHANGELOG, component release-note copy, and the Owner manual release checklist
- document project-disk cold-start MODEL switching, the safe PROGRAM.d88 base-image flow, ROM/stub differences, and legacy Connector degradation
- keep PR #111 out of the release

## Verification

- ./build.sh
- npm run test:project-disk (5 passed)
- npm run test:bridge (12 passed)
- npm run test:mcp (78 passed)
- npm run test:mcp-package (1 passed)
- npm run test:extension-package (16 passed)
- npm run test:automation (25 passed)
- packed x1pen-mcp-2.7.0.tgz and dist/x1pen-connector-1.3.0.zip; versions and manifests verified

## Review and release gate

Secretary opposite-provider plan review reached APPROVED in round 2 with claude-opus-5 under the normal policy. All findings were dispositioned. The exact UI Save/re-import/cold-start smoke remains an Owner pre-publication gate in docs/RELEASE_CHECKLIST_0.9.0.md. No deploy, npm publish, Store submission, or tag creation was performed.