### PR TITLE
docs: prevent release artifact loss after build

### DIFF
--- a/docs/RELEASE_CHECKLIST_0.9.0.md
+++ b/docs/RELEASE_CHECKLIST_0.9.0.md
@@ -62,6 +62,7 @@ done | shasum -a 256
 
 - [ ] deploy前に直前正常なCloudflare Pages deployment IDと`v0.8.1`を記録した。
 - [ ] release merge commitにannotated tag `v0.9.0`を付けた。
+- [ ] tag作成後、`v0.9.0`を対象とするGitHub Releaseを**draft**で作成し、3コンポーネントのrelease notesと公開状況を記載した。公開物がすべて揃うまではdraftのままにした。
 - [ ] X1Pen Webをdeployし、hard reload／cache無効化を行った。
 - [ ] `x1pen-version.js`、page status、feature descriptorがすべて`0.9.0`相当を示した。
 - [ ] editor、RUN、project disk、MCP coreを本番でsmoke testした。
@@ -87,3 +88,13 @@ npm_config_min_release_age=0 npx -y x1pen-mcp@2.7.0 --version
 - [ ] `dist/x1pen-connector-1.3.0.zip`を提出した。
 - [ ] 審査手順で本番X1Pen 0.9.0と`x1pen-mcp@latest`を使って新機能を再現できることを確認した。
 - [ ] 提出日時、artifact checksum、Dashboard statusを記録した。
+- [ ] Connector 1.3.0がChrome Web Storeで公開され、MCP接続からもConnector 1.3.0／MCP 2.7.0の組み合わせを確認した。
+
+## 8. GitHub Release公開（Owner）
+
+- [ ] X1Pen Web 0.9.0、x1pen-mcp 2.7.0、Connector 1.3.0がすべて公開済みで、production smoke testが完了した。
+- [ ] draft本文を最終状態に更新した。`審査中`／`pending`や「Web／MCPを先に公開する」といった古い前提を除き、自動更新がまだ届いていない旧Connector利用者向けの`revision-only`注意だけを残した。
+- [ ] draftがtag `v0.9.0`と最終release commitを指し、version、artifact checksum、既知の制約が実際の公開物と一致することを確認した。
+- [ ] GitHub Releaseをdraftからpublishし、公開URLと公開日時をrelease logへ記録した。
+
+GitHub Releaseを作る運用は`v0.9.0`から開始します。過去のtagへ遡ってReleaseを作る必要はありません。

--- a/docs/RELEASE_CHECKLIST_0.9.0.md
+++ b/docs/RELEASE_CHECKLIST_0.9.0.md
@@ -8,7 +8,22 @@ OwnerがWeb deploy → npm publish → Chrome Web Store提出の直前に実行�
 - [ ] `html/x1pen-version.js`は`0.9.0`、`mcp/package.json`は`2.7.0`、`extension/manifest.json`は`1.3.0`である。
 - [ ] `npm run test:project-disk`、`npm run test:bridge`、`npm run test:mcp`、`npm run test:mcp-package`、`npm run test:extension-package`が成功した。
 - [ ] `./build.sh`と`npm run test:automation`が成功した。
-- [ ] MCP tarballとConnector ZIPのversion／内容を確認し、公開するartifactを固定した。
+- [ ] **最終の`./build.sh`とテストより後に**`npm run pack:extension`を実行した。`./build.sh`は`dist/`を作り直し、先にpackしたConnector ZIPを削除するため、以後は提出までbuildしない。
+- [ ] MCP tarballとConnector ZIPのversion／内容を確認し、公開するartifactを固定した。Connector ZIPは、存在、ZIP直下のmanifest version、ZIP全体のSHA256、下記のcontent digestを記録した。
+
+Connector ZIPはpackのたびにstagingへファイルをcopyするため、同じ内容でもZIP entryのtimestampとZIP全体のSHA256が変わり得ます。再pack後は古いZIP SHA256との不一致だけで内容変更と判断せず、timestampに依存しない「entry名＋各entry SHA256」のcontent digestも比較し、新しいZIP SHA256を提出記録に採用します。
+
+```sh
+ZIP=dist/x1pen-connector-1.3.0.zip
+test -f "$ZIP"
+unzip -p "$ZIP" manifest.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version"
+shasum -a 256 "$ZIP"
+unzip -Z1 "$ZIP" | LC_ALL=C sort | while IFS= read -r entry; do
+  case "$entry" in */) continue ;; esac
+  entry_sha=$(unzip -p "$ZIP" "$entry" | shasum -a 256 | awk '{print $1}')
+  printf '%s  %s\n' "$entry_sha" "$entry"
+done | shasum -a 256
+```
 
 ## 2. Project diskのexact click path
 
@@ -55,11 +70,20 @@ OwnerがWeb deploy → npm publish → Chrome Web Store提出の直前に実行�
 
 - [ ] `npm whoami`と`npm run test:mcp-package`を再確認した。
 - [ ] `npm publish ./mcp`を実行した。
-- [ ] `npm view x1pen-mcp version`と`npx -y x1pen-mcp@2.7.0 --version`が`2.7.0`を示した。
+- [ ] installを伴わない`npm view x1pen-mcp@2.7.0 version`が`2.7.0`を示し、`npm view x1pen-mcp dist-tags --json`で`latest`が`2.7.0`を示した。
+
+このprojectの`.npmrc`は公開から7日未満のpackageを除外するため、公開直後の`npx -y x1pen-mcp@2.7.0 --version`や`npx -y x1pen-mcp@latest --version`は`ETARGET`になり得ます。実行確認は原則として7日後へ延期します。どうしても公開直後に一回だけ必要なら、package内容とdependency graphを確認したうえで次を手動実行できます。
+
+```sh
+npm_config_min_release_age=0 npx -y x1pen-mcp@2.7.0 --version
+```
+
+このoverrideは`x1pen-mcp`だけでなく、この呼び出しで解決するtransitive dependencies全体のrelease-age制限を解除します。shell profileやCIへexportせず、`.npmrc`の`min-release-age=7`／`strict-allow-scripts=true`も変更しません。package単位の`min-release-age-exclude`は、現行npm 12.0.2の`npx`が除外を反映しない既知バグの修正待ちです。
 
 ## 7. Chrome Web Store（Owner）
 
 - [ ] 公開中が`1.2.0`で、別の審査中draftがないことをDashboardで再確認した。
+- [ ] 提出直前に`dist/x1pen-connector-1.3.0.zip`の存在、manifest version `1.3.0`、ZIP SHA256、content digestがRelease candidate節で固定した記録と一致することを再確認した。不一致なら提出せず、`./build.sh`、再pack、source変更の有無を調べ、再生成・全entry内容確認・両hashの再固定からやり直す。
 - [ ] `dist/x1pen-connector-1.3.0.zip`を提出した。
 - [ ] 審査手順で本番X1Pen 0.9.0と`x1pen-mcp@latest`を使って新機能を再現できることを確認した。
 - [ ] 提出日時、artifact checksum、Dashboard statusを記録した。


### PR DESCRIPTION
## Summary

- run Connector packaging only after the final build and tests
- freeze and re-check manifest version, archive SHA256, and a timestamp-independent per-entry content digest
- document the 7-day npm release-age window, safe `npm view` checks, and the full dependency scope of the one-off `npx` override
- establish the GitHub Release flow from v0.9.0 onward: create a draft after tagging, keep it draft while artifacts roll out, then update and publish only after Web, npm, and Connector are all live

## Verification

- `git diff --check`
- generated two ZIPs from the same `main` content: archive SHA256 differed, while the documented content digest matched (`1c9d11c33ea1f868db9c088a6ad506609b5db672717f2b0a91f4dd5d1763df5d`)

## Cross-review

Secretary opposite-provider review Round 5/5: APPROVED (`claude-opus-5`, policy `normal`, host override `no`, blocking findings `0`). The medium finding about `min_release_age=0` affecting the full transitive dependency resolution was adopted. The GitHub Release timing follows the already-approved release plan: publish the Release only after all components are available.