### PR TITLE
Fix clipped text glyphs in 24kHz underline modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     }
   },
   "scripts": {
+    "test": "npm run test:draw && npm run test:project-disk && npm run test:bridge && npm run test:mcp && npm run test:mcp-package && npm run test:extension-package && npm run test:automation",
+    "test:draw": "node --test tests/draw_width_kanji_test.mjs",
     "build:editor": "esbuild src/x1pen_editor.js --bundle --outfile=html/x1pen_editor.bundle.js --format=iife --minify",
     "build:extension-assets": "node scripts/render-extension-assets.mjs",
     "capture:extension-store": "node scripts/capture-x1pen-store-screenshot.mjs",

--- a/platform/draw_width.cpp
+++ b/platform/draw_width.cpp
@@ -244,6 +244,20 @@ static inline BYTE effect16_fetch_knj(const BYTE* src32, BYTE eff4, BYTE row_fyc
     return apply_upt_hfx(v, eff4);
 }
 
+// Underline-capable 24kHz modes reserve two logical rows from fontlpcnt.
+// A ROM Kanji still has up to 16 source rows, so let it use the remaining
+// cell rows without ever exceeding either the CRTC cell or the 32-byte glyph.
+static inline int kanji24_render_rows(BYTE knj_code, int default_rows) {
+    if (!(knj_code & 0x80) || !(fonttype & KNJ_24KHz) ||
+        vramylpcnt <= default_rows) {
+        return default_rows;
+    }
+
+    int rows = (int)vramylpcnt;
+    if (rows > 8) rows = 8;
+    return (rows > default_rows) ? rows : default_rows;
+}
+
 // DRAW8.CPP の各モードが持つ差分（更新マスク/縦倍率/TRAM上限）を
 // 共通 C++ 描画器に反映する。
 static void draw_text_graph_common(BYTE update_mask, WORD tram_limit, int max_rows, int y_scale,
@@ -1675,6 +1689,9 @@ void width80x20_24khz(void) {
             BYTE color_idx = (attr & X1ATR_REVERSE)
                            ? (BYTE)((attr & X1ATR_COLOR) + 8)
                            : (BYTE)(attr & X1ATR_COLOR);
+            const int kanji_rows = kanji24_render_rows(knj_code, chr_h);
+            const bool full_cell_kanji = !(src_attr & X1ATR_PCG) &&
+                                         (kanji_rows > chr_h);
             int sx = col * 8;
             BYTE* base = &screenmap[sy * SCREEN_WIDTH + sx];
 
@@ -1723,7 +1740,8 @@ void width80x20_24khz(void) {
                     }
                 }
             } else {
-                for (int y = 0; y < chr_h; y++) {
+                const int render_rows = full_cell_kanji ? kanji_rows : chr_h;
+                for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 2; ys++) {
                         BYTE pf = 0;
                         if (knj_code & 0x80) {
@@ -1755,14 +1773,19 @@ void width80x20_24khz(void) {
             BYTE ul = (TXT_RAM[addr + TEXT_KNJ] & X1KNJ_ULINE) ? 0x01 : 0x00;
             DWORD ulv = (DWORD)ul * 0x01010101u;
             int tail = (int)fontlpcnt * 2;
-            *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) = ulv;
-            *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) = ulv;
-            *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 4) = 0;
+            if (full_cell_kanji) {
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) |= ulv;
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) |= ulv;
+            } else {
+                *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) = ulv;
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) = ulv;
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 4) = 0;
+            }
 
             tram_pos++;
         }
@@ -1830,6 +1853,9 @@ void width80x10_24khz(void) {
             BYTE color_idx = (attr & X1ATR_REVERSE)
                            ? (BYTE)((attr & X1ATR_COLOR) + 8)
                            : (BYTE)(attr & X1ATR_COLOR);
+            const int kanji_rows = kanji24_render_rows(knj_code, chr_h);
+            const bool full_cell_kanji = !(src_attr & X1ATR_PCG) &&
+                                         (kanji_rows > chr_h);
             int sx = col * 8;
             BYTE* base = &screenmap[sy * SCREEN_WIDTH + sx];
 
@@ -1878,7 +1904,8 @@ void width80x10_24khz(void) {
                     }
                 }
             } else {
-                for (int y = 0; y < chr_h; y++) {
+                const int render_rows = full_cell_kanji ? kanji_rows : chr_h;
+                for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 4; ys++) {
                         BYTE pf = 0;
                         if (knj_code & 0x80) {
@@ -1910,22 +1937,29 @@ void width80x10_24khz(void) {
             BYTE ul = (TXT_RAM[addr + TEXT_KNJ] & X1KNJ_ULINE) ? 0x01 : 0x00;
             DWORD ulv = (DWORD)ul * 0x01010101u;
             int tail = (int)fontlpcnt * 4;
-            *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) = ulv;
-            *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) = ulv;
-            *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) = ulv;
-            *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 4) = ulv;
-            *(DWORD*)(base + (tail + 4) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 4) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 5) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 5) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 6) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 6) * SCREEN_WIDTH + 4) = 0;
-            *(DWORD*)(base + (tail + 7) * SCREEN_WIDTH + 0) = 0;
-            *(DWORD*)(base + (tail + 7) * SCREEN_WIDTH + 4) = 0;
+            if (full_cell_kanji) {
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) |= ulv;
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) |= ulv;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) |= ulv;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 4) |= ulv;
+            } else {
+                *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 0) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) = ulv;
+                *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) = ulv;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) = ulv;
+                *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 4) = ulv;
+                *(DWORD*)(base + (tail + 4) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 4) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 5) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 5) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 6) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 6) * SCREEN_WIDTH + 4) = 0;
+                *(DWORD*)(base + (tail + 7) * SCREEN_WIDTH + 0) = 0;
+                *(DWORD*)(base + (tail + 7) * SCREEN_WIDTH + 4) = 0;
+            }
 
             tram_pos++;
         }

--- a/platform/draw_width.cpp
+++ b/platform/draw_width.cpp
@@ -245,11 +245,10 @@ static inline BYTE effect16_fetch_knj(const BYTE* src32, BYTE eff4, BYTE row_fyc
 }
 
 // Underline-capable 24kHz modes reserve two logical rows from fontlpcnt.
-// A ROM Kanji still has up to 16 source rows, so let it use the remaining
-// cell rows without ever exceeding either the CRTC cell or the 32-byte glyph.
-static inline int kanji24_render_rows(BYTE knj_code, int default_rows) {
-    if (!(knj_code & 0x80) || !(fonttype & KNJ_24KHz) ||
-        vramylpcnt <= default_rows) {
+// Text glyphs still use the complete cell, bounded to their 8 logical rows.
+// Never shorten a taller configuration that the existing renderer accepted.
+static inline int underline24_render_rows(int default_rows) {
+    if (vramylpcnt <= default_rows) {
         return default_rows;
     }
 
@@ -1689,9 +1688,8 @@ void width80x20_24khz(void) {
             BYTE color_idx = (attr & X1ATR_REVERSE)
                            ? (BYTE)((attr & X1ATR_COLOR) + 8)
                            : (BYTE)(attr & X1ATR_COLOR);
-            const int kanji_rows = kanji24_render_rows(knj_code, chr_h);
-            const bool full_cell_kanji = !(src_attr & X1ATR_PCG) &&
-                                         (kanji_rows > chr_h);
+            const int render_rows = underline24_render_rows(chr_h);
+            const bool full_cell_glyph = render_rows > chr_h;
             int sx = col * 8;
             BYTE* base = &screenmap[sy * SCREEN_WIDTH + sx];
 
@@ -1708,7 +1706,7 @@ void width80x20_24khz(void) {
                 const bool pcg16 = (knj_code & 0x90) != 0;
                 BYTE pcg_chr = pcg16 ? (BYTE)(char_code & 0xFE) : char_code;
 
-                for (int y = 0; y < chr_h; y++) {
+                for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 2; ys++) {
                         int subline = y * 2 + ys;
                         DWORD pl = 0, pr = 0;
@@ -1740,7 +1738,6 @@ void width80x20_24khz(void) {
                     }
                 }
             } else {
-                const int render_rows = full_cell_kanji ? kanji_rows : chr_h;
                 for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 2; ys++) {
                         BYTE pf = 0;
@@ -1773,7 +1770,7 @@ void width80x20_24khz(void) {
             BYTE ul = (TXT_RAM[addr + TEXT_KNJ] & X1KNJ_ULINE) ? 0x01 : 0x00;
             DWORD ulv = (DWORD)ul * 0x01010101u;
             int tail = (int)fontlpcnt * 2;
-            if (full_cell_kanji) {
+            if (full_cell_glyph) {
                 *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 0) |= ulv;
                 *(DWORD*)(base + (tail + 1) * SCREEN_WIDTH + 4) |= ulv;
             } else {
@@ -1853,9 +1850,8 @@ void width80x10_24khz(void) {
             BYTE color_idx = (attr & X1ATR_REVERSE)
                            ? (BYTE)((attr & X1ATR_COLOR) + 8)
                            : (BYTE)(attr & X1ATR_COLOR);
-            const int kanji_rows = kanji24_render_rows(knj_code, chr_h);
-            const bool full_cell_kanji = !(src_attr & X1ATR_PCG) &&
-                                         (kanji_rows > chr_h);
+            const int render_rows = underline24_render_rows(chr_h);
+            const bool full_cell_glyph = render_rows > chr_h;
             int sx = col * 8;
             BYTE* base = &screenmap[sy * SCREEN_WIDTH + sx];
 
@@ -1872,7 +1868,7 @@ void width80x10_24khz(void) {
                 const bool pcg16 = (knj_code & 0x90) != 0;
                 BYTE pcg_chr = pcg16 ? (BYTE)(char_code & 0xFE) : char_code;
 
-                for (int y = 0; y < chr_h; y++) {
+                for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 4; ys++) {
                         int subline = (y * 4 + ys) / 2;  // TEXT_DOUBLERASTER equivalent
                         DWORD pl = 0, pr = 0;
@@ -1904,7 +1900,6 @@ void width80x10_24khz(void) {
                     }
                 }
             } else {
-                const int render_rows = full_cell_kanji ? kanji_rows : chr_h;
                 for (int y = 0; y < render_rows; y++) {
                     for (int ys = 0; ys < 4; ys++) {
                         BYTE pf = 0;
@@ -1937,7 +1932,7 @@ void width80x10_24khz(void) {
             BYTE ul = (TXT_RAM[addr + TEXT_KNJ] & X1KNJ_ULINE) ? 0x01 : 0x00;
             DWORD ulv = (DWORD)ul * 0x01010101u;
             int tail = (int)fontlpcnt * 4;
-            if (full_cell_kanji) {
+            if (full_cell_glyph) {
                 *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 0) |= ulv;
                 *(DWORD*)(base + (tail + 2) * SCREEN_WIDTH + 4) |= ulv;
                 *(DWORD*)(base + (tail + 3) * SCREEN_WIDTH + 0) |= ulv;

--- a/tests/draw_width_kanji_test.cpp
+++ b/tests/draw_width_kanji_test.cpp
@@ -1,0 +1,277 @@
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "common.h"
+#include "xmil.h"
+#include "x1.h"
+#include "x1_crtc.h"
+#include "x1_pcg.h"
+#include "x1_vram.h"
+#include "draw.h"
+#include "draw_sub.h"
+
+BYTE TXT_RAM[0x01800];
+BYTE ANK_FNT[256][8];
+BYTE KNJ_FNT[0x4bc00];
+BYTE GRP_RAM[0x20000];
+BYTE screenmap[SCREEN_WIDTH * SCREEN_HEIGHT];
+BYTE blinktest;
+BYTE fontlpcnt;
+BYTE fonttype;
+BYTE vramylpcnt;
+BYTE dispflg;
+WORD vramsize;
+BYTE updatetmp[0x800 + 0x101];
+BYTE* dispp = &GRP_RAM[GRAM_BANK0];
+BYTE* dispp2 = &GRP_RAM[GRAM_BANK1];
+WORD vramylpad;
+BYTE g_cli_disable_text;
+BYTE g_cli_disable_graph;
+BYTE renewalline[SCREEN_HEIGHT + 4];
+PCG_TABLE pcg;
+CRTC_TABLE crtc;
+PALETTE_TABLE xm_palette[256];
+int xm_palettes;
+
+void ddraws_change_palette(void) {}
+
+static BYTE synthetic_kanji[32];
+
+BYTE* __fastcall getfontjis(WORD) {
+    return synthetic_kanji;
+}
+
+WORD __fastcall adr2jis_x1t(WORD adr) {
+    return adr;
+}
+
+static void fail(const std::string& message) {
+    throw std::runtime_error(message);
+}
+
+static void expect_equal(int actual, int expected, const std::string& label) {
+    if (actual != expected) {
+        std::ostringstream out;
+        out << label << ": expected " << expected << ", got " << actual;
+        fail(out.str());
+    }
+}
+
+static void expect_equal(BYTE actual, BYTE expected, const std::string& label) {
+    expect_equal(static_cast<int>(actual), static_cast<int>(expected), label);
+}
+
+static void reset_renderer(int logical_font_rows, int logical_cell_rows, int rows = 1) {
+    std::memset(TXT_RAM, 0, sizeof(TXT_RAM));
+    std::memset(ANK_FNT, 0, sizeof(ANK_FNT));
+    std::memset(KNJ_FNT, 0, sizeof(KNJ_FNT));
+    std::memset(GRP_RAM, 0, sizeof(GRP_RAM));
+    std::memset(screenmap, 0, sizeof(screenmap));
+    std::memset(updatetmp, 0, sizeof(updatetmp));
+    std::memset(renewalline, 0, sizeof(renewalline));
+    std::memset(&pcg, 0, sizeof(pcg));
+    std::memset(&crtc, 0, sizeof(crtc));
+    std::memset(synthetic_kanji, 0, sizeof(synthetic_kanji));
+
+    init_drawtable();
+    blinktest = 0;
+    fontlpcnt = static_cast<BYTE>(logical_font_rows);
+    vramylpcnt = static_cast<BYTE>(logical_cell_rows);
+    fonttype = ANK_24KHz | KNJ_24KHz;
+    dispflg = UPDATE_VRAM0;
+    vramsize = static_cast<WORD>(rows);
+    g_cli_disable_text = 0;
+    g_cli_disable_graph = 1;
+    crtc.TXT_TOP = 0;
+    crtc.TXT_XL = 1;
+    crtc.TXT_YL = static_cast<BYTE>(rows);
+}
+
+static void set_row_coded_glyph() {
+    for (int row = 0; row < 16; row++) {
+        synthetic_kanji[row * 2] = static_cast<BYTE>(row + 1);
+        synthetic_kanji[row * 2 + 1] = static_cast<BYTE>(0x80 | row);
+    }
+}
+
+static void set_cell(int addr, bool kanji, bool underline) {
+    TXT_RAM[TEXT_ANK + addr] = 0;
+    TXT_RAM[TEXT_ATR + addr] = 7;
+    TXT_RAM[TEXT_KNJ + addr] = static_cast<BYTE>((kanji ? 0x80 : 0) |
+                                                 (underline ? X1KNJ_ULINE : 0));
+    updatetmp[addr] = UPDATE_TVRAM;
+}
+
+static BYTE decode_text_pattern(int scanline, int x = 0) {
+    BYTE pattern = 0;
+    const BYTE* pixels = &screenmap[scanline * SCREEN_WIDTH + x];
+    for (int bit = 0; bit < 8; bit++) {
+        if (pixels[bit] & 0x38) {
+            pattern |= static_cast<BYTE>(0x80 >> bit);
+        }
+    }
+    return pattern;
+}
+
+static bool has_underline_mask(int scanline, int x = 0) {
+    const BYTE* pixels = &screenmap[scanline * SCREEN_WIDTH + x];
+    for (int bit = 0; bit < 8; bit++) {
+        if ((pixels[bit] & 0x01) == 0) return false;
+    }
+    return true;
+}
+
+static int count_nonzero_text_rows(int first, int count) {
+    int nonzero = 0;
+    for (int y = first; y < first + count; y++) {
+        if (decode_text_pattern(y) != 0) nonzero++;
+    }
+    return nonzero;
+}
+
+static void expect_row_sequence(int physical_rows, int repeat,
+                                const std::string& label) {
+    for (int y = 0; y < physical_rows; y++) {
+        const int source_row = y / repeat;
+        expect_equal(decode_text_pattern(y), static_cast<BYTE>(source_row + 1),
+                     label + " scanline " + std::to_string(y));
+    }
+}
+
+static void test_24khz_underlined_geometry() {
+    reset_renderer(6, 8);
+    set_row_coded_glyph();
+    set_cell(0, true, false);
+    width80x20_24khz();
+    expect_equal(count_nonzero_text_rows(0, 16), 16,
+                 "24kHz underline-capable Kanji rows");
+    expect_row_sequence(16, 1, "24kHz row identity");
+}
+
+static void test_24khz_doubled_geometry() {
+    reset_renderer(6, 8);
+    set_row_coded_glyph();
+    set_cell(0, true, false);
+    width80x10_24khz();
+    expect_equal(count_nonzero_text_rows(0, 32), 32,
+                 "24kHz doubled Kanji rows");
+    expect_row_sequence(32, 2, "24kHz doubled row identity");
+}
+
+static void test_unaffected_geometries() {
+    reset_renderer(8, 8);
+    set_row_coded_glyph();
+    set_cell(0, true, false);
+    width80x25_400line();
+    expect_row_sequence(16, 1, "24kHz non-underline row identity");
+
+    reset_renderer(8, 10);
+    set_row_coded_glyph();
+    set_cell(0, true, false);
+    width80x20_15khz();
+    for (int y = 0; y < 16; y++) {
+        const int source_row = (y / 2) * 2;
+        expect_equal(decode_text_pattern(y), static_cast<BYTE>(source_row + 1),
+                     "15kHz underline row identity " + std::to_string(y));
+    }
+}
+
+static std::vector<int> underline_rows(void (*draw)(), int physical_rows,
+                                       bool kanji, int font_rows = 6,
+                                       int cell_rows = 8) {
+    reset_renderer(font_rows, cell_rows);
+    set_cell(0, kanji, true);
+    draw();
+    std::vector<int> rows;
+    for (int y = 0; y < physical_rows; y++) {
+        if (has_underline_mask(y)) rows.push_back(y);
+    }
+    return rows;
+}
+
+static void expect_rows(const std::vector<int>& actual,
+                        const std::vector<int>& expected,
+                        const std::string& label) {
+    if (actual != expected) {
+        std::ostringstream out;
+        out << label << ": expected";
+        for (int row : expected) out << ' ' << row;
+        out << ", got";
+        for (int row : actual) out << ' ' << row;
+        fail(out.str());
+    }
+}
+
+static void test_underline_positions_and_merge() {
+    expect_rows(underline_rows(width80x20_24khz, 16, false), {13},
+                "24kHz ANK underline position");
+    expect_rows(underline_rows(width80x20_24khz, 16, true), {13},
+                "24kHz Kanji underline position");
+    expect_rows(underline_rows(width80x10_24khz, 32, false), {26, 27},
+                "24kHz doubled ANK underline position");
+    expect_rows(underline_rows(width80x10_24khz, 32, true), {26, 27},
+                "24kHz doubled Kanji underline position");
+
+    reset_renderer(6, 8);
+    set_row_coded_glyph();
+    set_cell(0, true, true);
+    width80x20_24khz();
+    expect_row_sequence(16, 1, "24kHz underline merge row identity");
+    if (!has_underline_mask(13)) fail("24kHz underline merge mask missing");
+    expect_rows(underline_rows(width80x20_24khz, 16, true), {13},
+                "24kHz underline merge mask");
+
+    reset_renderer(6, 8);
+    set_row_coded_glyph();
+    set_cell(0, true, true);
+    width80x10_24khz();
+    expect_row_sequence(32, 2, "24kHz doubled underline merge row identity");
+    if (!has_underline_mask(26) || !has_underline_mask(27)) {
+        fail("24kHz doubled underline merge mask missing");
+    }
+    expect_rows(underline_rows(width80x10_24khz, 32, true), {26, 27},
+                "24kHz doubled underline merge mask");
+}
+
+static void test_short_cell_bounds() {
+    reset_renderer(2, 4);
+    set_row_coded_glyph();
+    std::memset(&screenmap[8 * SCREEN_WIDTH], 0x55, SCREEN_WIDTH);
+    set_cell(0, true, true);
+    width80x20_24khz();
+    expect_row_sequence(8, 1, "short-cell row identity");
+    expect_equal(static_cast<int>(screenmap[8 * SCREEN_WIDTH]), 0x55,
+                 "short-cell following row sentinel");
+    if (!has_underline_mask(5)) fail("short-cell underline mask missing at row 5");
+
+    const int rows = SCREEN_HEIGHT / 8;
+    reset_renderer(2, 4, rows);
+    set_row_coded_glyph();
+    set_cell(rows - 1, true, false);
+    width80x20_24khz();
+    const int last_cell_top = SCREEN_HEIGHT - 8;
+    for (int y = 0; y < 8; y++) {
+        expect_equal(decode_text_pattern(last_cell_top + y),
+                     static_cast<BYTE>(y + 1),
+                     "last short cell row " + std::to_string(y));
+    }
+}
+
+int main() {
+    try {
+        test_24khz_doubled_geometry();
+        test_24khz_underlined_geometry();
+        test_unaffected_geometries();
+        test_underline_positions_and_merge();
+        test_short_cell_bounds();
+        std::cout << "draw_width Kanji tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/draw_width_kanji_test.cpp
+++ b/tests/draw_width_kanji_test.cpp
@@ -98,10 +98,51 @@ static void set_row_coded_glyph() {
     }
 }
 
+static void set_row_coded_ank() {
+    for (int row = 0; row < 16; row++) {
+        KNJ_FNT[row] = static_cast<BYTE>(row + 1);
+    }
+}
+
+static void set_row_coded_ank8() {
+    for (int row = 0; row < 8; row++) {
+        ANK_FNT[0][row] = static_cast<BYTE>(row + 1);
+    }
+}
+
+static void set_row_coded_pcg8() {
+    for (int row = 0; row < 8; row++) {
+        pcg.B[0][row] = static_cast<BYTE>(row + 1);
+    }
+}
+
+static void set_row_coded_pcg16() {
+    for (int row = 0; row < 16; row++) {
+        pcg.B[row / 8][row % 8] = static_cast<BYTE>(row + 1);
+    }
+}
+
 static void set_cell(int addr, bool kanji, bool underline) {
     TXT_RAM[TEXT_ANK + addr] = 0;
     TXT_RAM[TEXT_ATR + addr] = 7;
     TXT_RAM[TEXT_KNJ + addr] = static_cast<BYTE>((kanji ? 0x80 : 0) |
+                                                 (underline ? X1KNJ_ULINE : 0));
+    updatetmp[addr] = UPDATE_TVRAM;
+}
+
+static void set_ank_cell(int addr, bool underline, bool reverse = false) {
+    TXT_RAM[TEXT_ANK + addr] = 0;
+    TXT_RAM[TEXT_ATR + addr] = static_cast<BYTE>(7 |
+        (reverse ? X1ATR_REVERSE : 0));
+    TXT_RAM[TEXT_KNJ + addr] = underline ? X1KNJ_ULINE : 0;
+    updatetmp[addr] = UPDATE_TVRAM;
+}
+
+static void set_pcg_cell(int addr, bool pcg16, bool underline,
+                         BYTE color = 1) {
+    TXT_RAM[TEXT_ANK + addr] = 0;
+    TXT_RAM[TEXT_ATR + addr] = static_cast<BYTE>(X1ATR_PCG | color);
+    TXT_RAM[TEXT_KNJ + addr] = static_cast<BYTE>((pcg16 ? 0x10 : 0) |
                                                  (underline ? X1KNJ_ULINE : 0));
     updatetmp[addr] = UPDATE_TVRAM;
 }
@@ -115,6 +156,10 @@ static BYTE decode_text_pattern(int scanline, int x = 0) {
         }
     }
     return pattern;
+}
+
+static BYTE pixel_value(int scanline, int bit, int x = 0) {
+    return screenmap[scanline * SCREEN_WIDTH + x + bit];
 }
 
 static bool has_underline_mask(int scanline, int x = 0) {
@@ -133,12 +178,73 @@ static int count_nonzero_text_rows(int first, int count) {
     return nonzero;
 }
 
-static void expect_row_sequence(int physical_rows, int repeat,
-                                const std::string& label) {
+static void expect_row_sequence_at(int first, int physical_rows, int repeat,
+                                   const std::string& label) {
     for (int y = 0; y < physical_rows; y++) {
         const int source_row = y / repeat;
-        expect_equal(decode_text_pattern(y), static_cast<BYTE>(source_row + 1),
+        expect_equal(decode_text_pattern(first + y),
+                     static_cast<BYTE>(source_row + 1),
                      label + " scanline " + std::to_string(y));
+    }
+}
+
+static void expect_row_sequence(int physical_rows, int repeat,
+                                const std::string& label) {
+    expect_row_sequence_at(0, physical_rows, repeat, label);
+}
+
+static void test_24khz_ank_pcg_geometry() {
+    reset_renderer(6, 8);
+    set_row_coded_ank();
+    set_ank_cell(0, false);
+    width80x20_24khz();
+    const int ank_normal = count_nonzero_text_rows(0, 16);
+    expect_row_sequence(16, 1, "24kHz ANK row identity");
+
+    reset_renderer(6, 8);
+    set_row_coded_ank();
+    set_ank_cell(0, false);
+    width80x10_24khz();
+    const int ank_doubled = count_nonzero_text_rows(0, 32);
+    expect_row_sequence(32, 2, "24kHz doubled ANK row identity");
+
+    reset_renderer(6, 8);
+    set_row_coded_pcg8();
+    set_pcg_cell(0, false, false);
+    width80x20_24khz();
+    const int pcg8_normal = count_nonzero_text_rows(0, 16);
+    expect_row_sequence(16, 2, "24kHz PCG8 row identity");
+
+    reset_renderer(6, 8);
+    set_row_coded_pcg8();
+    set_pcg_cell(0, false, false);
+    width80x10_24khz();
+    const int pcg8_doubled = count_nonzero_text_rows(0, 32);
+    expect_row_sequence(32, 4, "24kHz doubled PCG8 row identity");
+
+    reset_renderer(6, 8);
+    set_row_coded_pcg16();
+    set_pcg_cell(0, true, false);
+    width80x20_24khz();
+    const int pcg16_normal = count_nonzero_text_rows(0, 16);
+    expect_row_sequence(16, 1, "24kHz PCG16 row identity");
+
+    reset_renderer(6, 8);
+    set_row_coded_pcg16();
+    set_pcg_cell(0, true, false);
+    width80x10_24khz();
+    const int pcg16_doubled = count_nonzero_text_rows(0, 32);
+    expect_row_sequence(32, 2, "24kHz doubled PCG16 row identity");
+
+    if (ank_normal != 16 || ank_doubled != 32 ||
+        pcg8_normal != 16 || pcg8_doubled != 32 ||
+        pcg16_normal != 16 || pcg16_doubled != 32) {
+        std::ostringstream out;
+        out << "24kHz baseline pixels: ANK=" << ank_normal << "/16,"
+            << ank_doubled << "/32; PCG8=" << pcg8_normal << "/16,"
+            << pcg8_doubled << "/32; PCG16=" << pcg16_normal << "/16,"
+            << pcg16_doubled << "/32";
+        fail(out.str());
     }
 }
 
@@ -177,6 +283,110 @@ static void test_unaffected_geometries() {
         const int source_row = (y / 2) * 2;
         expect_equal(decode_text_pattern(y), static_cast<BYTE>(source_row + 1),
                      "15kHz underline row identity " + std::to_string(y));
+    }
+}
+
+static void test_ank_pcg_unaffected_geometries() {
+    reset_renderer(8, 8);
+    set_row_coded_ank();
+    set_ank_cell(0, false);
+    width80x25_400line();
+    expect_row_sequence(16, 1, "24kHz non-underline ANK identity");
+
+    reset_renderer(8, 8);
+    set_row_coded_pcg8();
+    set_pcg_cell(0, false, false);
+    width80x25_400line();
+    expect_row_sequence(16, 2, "24kHz non-underline PCG8 identity");
+
+    reset_renderer(8, 8);
+    set_row_coded_pcg16();
+    set_pcg_cell(0, true, false);
+    width80x25_400line();
+    expect_row_sequence(16, 1, "24kHz non-underline PCG16 identity");
+
+    reset_renderer(8, 10);
+    fonttype = KNJ_24KHz;
+    set_row_coded_ank8();
+    set_ank_cell(0, false);
+    width80x20_15khz();
+    expect_row_sequence(16, 2, "15kHz underline ANK identity");
+
+    reset_renderer(8, 10);
+    fonttype = KNJ_24KHz;
+    set_row_coded_pcg8();
+    set_pcg_cell(0, false, false);
+    width80x20_15khz();
+    expect_row_sequence(16, 2, "15kHz underline PCG8 identity");
+
+    reset_renderer(8, 10);
+    fonttype = KNJ_24KHz;
+    set_row_coded_pcg16();
+    set_pcg_cell(0, true, false);
+    width80x20_15khz();
+    expect_row_sequence(16, 1, "15kHz underline PCG16 identity");
+}
+
+static void test_ank_pcg_underline_merge() {
+    reset_renderer(6, 8);
+    set_row_coded_ank();
+    set_ank_cell(0, true);
+    width80x20_24khz();
+    expect_row_sequence(16, 1, "24kHz underlined ANK identity");
+    if (!has_underline_mask(13)) fail("24kHz ANK underline mask missing");
+
+    reset_renderer(6, 8);
+    set_row_coded_pcg16();
+    set_pcg_cell(0, true, true);
+    width80x10_24khz();
+    expect_row_sequence(32, 2, "24kHz doubled underlined PCG16 identity");
+    if (!has_underline_mask(26) || !has_underline_mask(27)) {
+        fail("24kHz doubled PCG16 underline mask missing");
+    }
+
+    reset_renderer(6, 8);
+    pcg.B[0][6] = 0x90;
+    pcg.R[0][6] = 0x50;
+    pcg.G[0][6] = 0x30;
+    set_pcg_cell(0, false, true, 7);
+    width80x20_24khz();
+    const BYTE expected[8] = {0x09, 0x11, 0x21, 0x39,
+                              0x01, 0x01, 0x01, 0x01};
+    for (int bit = 0; bit < 8; bit++) {
+        expect_equal(static_cast<BYTE>(pixel_value(13, bit) & 0x39),
+                     expected[bit],
+                     "multicolor PCG underline pixel " + std::to_string(bit));
+    }
+
+    reset_renderer(6, 8);
+    set_ank_cell(0, true, true);
+    width80x20_24khz();
+    for (int y = 0; y < 16; y++) {
+        expect_equal(decode_text_pattern(y), static_cast<BYTE>(0xFF),
+                     "reverse ANK background row " + std::to_string(y));
+    }
+    if (!has_underline_mask(13)) {
+        fail("reverse ANK underline position changed");
+    }
+}
+
+static void test_render_row_boundaries() {
+    reset_renderer(10, 12);
+    set_row_coded_ank();
+    set_ank_cell(0, false);
+    width80x20_24khz();
+    expect_equal(count_nonzero_text_rows(0, 20), 20,
+                 "tall cell must not shrink the existing loop");
+
+    reset_renderer(2, 2);
+    std::memset(&screenmap[4 * SCREEN_WIDTH], 0x55, 4 * SCREEN_WIDTH);
+    set_ank_cell(0, false);
+    width80x20_24khz();
+    for (int y = 4; y < 8; y++) {
+        for (int bit = 0; bit < 8; bit++) {
+            expect_equal(pixel_value(y, bit), static_cast<BYTE>(0),
+                         "legacy tail clear row " + std::to_string(y));
+        }
     }
 }
 
@@ -259,16 +469,68 @@ static void test_short_cell_bounds() {
                      static_cast<BYTE>(y + 1),
                      "last short cell row " + std::to_string(y));
     }
+
+    reset_renderer(2, 4);
+    set_row_coded_ank();
+    std::memset(&screenmap[8 * SCREEN_WIDTH], 0x55, SCREEN_WIDTH);
+    set_ank_cell(0, true);
+    width80x20_24khz();
+    expect_row_sequence(8, 1, "short-cell ANK identity");
+    expect_equal(screenmap[8 * SCREEN_WIDTH], static_cast<BYTE>(0x55),
+                 "short-cell ANK following row sentinel");
+
+    reset_renderer(2, 4);
+    set_row_coded_pcg8();
+    std::memset(&screenmap[8 * SCREEN_WIDTH], 0x55, SCREEN_WIDTH);
+    set_pcg_cell(0, false, true);
+    width80x20_24khz();
+    expect_row_sequence(8, 2, "short-cell PCG8 identity");
+    expect_equal(screenmap[8 * SCREEN_WIDTH], static_cast<BYTE>(0x55),
+                 "short-cell PCG8 following row sentinel");
+
+    reset_renderer(2, 4);
+    set_row_coded_pcg16();
+    std::memset(&screenmap[8 * SCREEN_WIDTH], 0x55, SCREEN_WIDTH);
+    set_pcg_cell(0, true, true);
+    width80x20_24khz();
+    expect_row_sequence(8, 1, "short-cell PCG16 identity");
+    expect_equal(screenmap[8 * SCREEN_WIDTH], static_cast<BYTE>(0x55),
+                 "short-cell PCG16 following row sentinel");
+
+    reset_renderer(2, 4, rows);
+    set_row_coded_ank();
+    set_ank_cell(rows - 1, false);
+    width80x20_24khz();
+    expect_row_sequence_at(last_cell_top, 8, 1,
+                           "last short ANK cell identity");
+
+    reset_renderer(2, 4, rows);
+    set_row_coded_pcg8();
+    set_pcg_cell(rows - 1, false, false);
+    width80x20_24khz();
+    expect_row_sequence_at(last_cell_top, 8, 2,
+                           "last short PCG8 cell identity");
+
+    reset_renderer(2, 4, rows);
+    set_row_coded_pcg16();
+    set_pcg_cell(rows - 1, true, false);
+    width80x20_24khz();
+    expect_row_sequence_at(last_cell_top, 8, 1,
+                           "last short PCG16 cell identity");
 }
 
 int main() {
     try {
+        test_24khz_ank_pcg_geometry();
         test_24khz_doubled_geometry();
         test_24khz_underlined_geometry();
         test_unaffected_geometries();
+        test_ank_pcg_unaffected_geometries();
         test_underline_positions_and_merge();
+        test_ank_pcg_underline_merge();
+        test_render_row_boundaries();
         test_short_cell_bounds();
-        std::cout << "draw_width Kanji tests passed\n";
+        std::cout << "draw_width text glyph tests passed\n";
         return 0;
     } catch (const std::exception& error) {
         std::cerr << error.what() << '\n';

--- a/tests/draw_width_kanji_test.mjs
+++ b/tests/draw_width_kanji_test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const compilerCandidates = process.env.CXX
+  ? [process.env.CXX]
+  : ['c++', 'clang++', 'g++'];
+
+function findCompiler() {
+  for (const compiler of compilerCandidates) {
+    const probe = spawnSync(compiler, ['--version'], { encoding: 'utf8' });
+    if (!probe.error && probe.status === 0) return compiler;
+  }
+  assert.fail('C++ compiler required for test:draw (tried CXX, c++, clang++, g++)');
+}
+
+test('24kHz text Kanji renderer preserves all glyph rows', async () => {
+  const compiler = findCompiler();
+  const workDir = await mkdtemp(join(tmpdir(), 'xmil-draw-width-'));
+  const executable = join(workDir, 'draw-width-kanji-test');
+
+  try {
+    const compile = spawnSync(compiler, [
+      '-std=c++17',
+      '-O1',
+      '-g',
+      '-fsanitize=address',
+      '-fno-omit-frame-pointer',
+      '-DT_TUNE=1',
+      '-D__fastcall=',
+      '-D__cdecl=',
+      '-D__stdcall=',
+      '-D__declspec(x)=',
+      '-Iplatform/dummy_includes',
+      '-Iplatform',
+      '-Isrc',
+      '-Isrc/Z80R',
+      '-include',
+      'platform/platform_types.h',
+      'tests/draw_width_kanji_test.cpp',
+      'platform/draw_width.cpp',
+      'platform/draw_sub_data.cpp',
+      '-o',
+      executable,
+    ], { encoding: 'utf8' });
+
+    assert.equal(
+      compile.status,
+      0,
+      `native draw test compilation failed\n${compile.stdout}${compile.stderr}`,
+    );
+
+    const run = spawnSync(executable, [], {
+      encoding: 'utf8',
+      env: { ...process.env, ASAN_OPTIONS: 'detect_leaks=0' },
+    });
+    assert.equal(
+      run.status,
+      0,
+      `native draw test failed\n${run.stdout}${run.stderr}`,
+    );
+    assert.match(run.stdout, /draw_width Kanji tests passed/);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+});

--- a/tests/draw_width_kanji_test.mjs
+++ b/tests/draw_width_kanji_test.mjs
@@ -17,7 +17,7 @@ function findCompiler() {
   assert.fail('C++ compiler required for test:draw (tried CXX, c++, clang++, g++)');
 }
 
-test('24kHz text Kanji renderer preserves all glyph rows', async () => {
+test('24kHz text renderer preserves ANK, PCG, and Kanji glyph rows', async () => {
   const compiler = findCompiler();
   const workDir = await mkdtemp(join(tmpdir(), 'xmil-draw-width-'));
   const executable = join(workDir, 'draw-width-kanji-test');
@@ -62,7 +62,7 @@ test('24kHz text Kanji renderer preserves all glyph rows', async () => {
       0,
       `native draw test failed\n${run.stdout}${run.stderr}`,
     );
-    assert.match(run.stdout, /draw_width Kanji tests passed/);
+    assert.match(run.stdout, /draw_width text glyph tests passed/);
   } finally {
     await rm(workDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- preserve all ROM Kanji, ANK, 8-dot PCG, and 16-dot PCG rows in underline-capable 24kHz text modes
- merge underline pixels into the glyph instead of clearing the reserved tail
- cover exact source-row order, PCG color planes, reverse background, short/tall cells, and bounds with an ASan-backed production-renderer test

## Cause and result

With the KANJITEST CRTC setup, `fontlpcnt` is reduced from 8 to 6 for underline space while `vramylpcnt` remains 8. The old 24kHz renderers drew only 6 logical rows for every glyph class:

- ROM Kanji, ANK, and PCG16: 12/16 source rows (4 missing)
- PCG8: 6/8 source rows, rendered as 12/16 physical lines (2 source rows / 4 physical lines missing)
- doubled mode: 24/32 physical lines for all classes (8 physical lines missing)

The fix lets every text glyph use the bounded full cell while keeping the underline position unchanged and OR-composing its independent `0x01` mask:

- ROM Kanji, ANK, and PCG16: 16/16 source rows
- PCG8: 8/8 source rows
- normal/doubled output: 16/16 and 32/32 physical lines

The 24kHz non-underline and 15kHz paths are covered as unchanged. The visible ANK/PCG change is restoration of formerly cleared lower glyph/background rows, including reverse-video background where applicable.

## Verification

- `./build.sh`
- `npm test` (draw, project-disk, bridge, MCP, MCP package, extension package, automation)
- initial Kanji plan review: APPROVED in round 2
- ANK/PCG follow-up plan review: APPROVED in round 1

No version bump. Live X1Pen was not touched.
