### PR TITLE
fix: isolate Share runs from persistent project disks

### DIFF
--- a/html/pre.js
+++ b/html/pre.js
@@ -526,7 +526,10 @@
     // ライブラリからスロットにマウント
     async function mountFromLibrary(key, slotName) {
         if (isEphemeralX1PenShare()) {
-            updateStatus('Share modeでは保存済みメディアをマウントできません');
+            var message = 'Share モードでは保存済みメディアをマウントできません';
+            updateStatus(message);
+            var x1penStatus = document.getElementById('x1pen-status');
+            if (x1penStatus) x1penStatus.textContent = message;
             return null;
         }
         if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');

--- a/html/pre.js
+++ b/html/pre.js
@@ -28,6 +28,10 @@
     const PAGE_SIZE = 65536;       // 64KB
     let projectDiskTransaction = null;
 
+    function isEphemeralX1PenShare() {
+        return window.__X1PEN_EPHEMERAL_SHARE === true;
+    }
+
     var emmImportSlot = -1;       // インポート対象スロット番号
     var emmImportInput = null;    // 隠し file input (init() で生成)
     var emmSlotInFlight = {};     // スロット単位の処理中ガード
@@ -39,7 +43,7 @@
     // 初期化直後から ping に応答する。キャンセル時のみ close() する。
     var _multiTabPromise = null;
     var _tabChannel = null;
-    if (typeof BroadcastChannel !== 'undefined') {
+    if (!isEphemeralX1PenShare() && typeof BroadcastChannel !== 'undefined') {
         var _channelName = window.__X1PEN_MODE ? 'x1pen_tab' : 'xmil_tab';
         _tabChannel = new BroadcastChannel(_channelName);
         var _myTabId = Math.random().toString(36).slice(2);
@@ -180,6 +184,7 @@
     }
 
     function saveMountState() {
+        if (isEphemeralX1PenShare()) return;
         try { localStorage.setItem(LS_MOUNT_STATE, JSON.stringify(slotState)); } catch(e) {
             console.warn('saveMountState failed:', e);
         }
@@ -520,6 +525,10 @@
 
     // ライブラリからスロットにマウント
     async function mountFromLibrary(key, slotName) {
+        if (isEphemeralX1PenShare()) {
+            updateStatus('Share modeでは保存済みメディアをマウントできません');
+            return null;
+        }
         if (projectDiskTransaction) throw new Error('X1Penプロジェクトディスクの更新中はメディアを変更できません');
         var entry = getLibrary().find(function(e) { return e.key === key; });
         if (!entry) { alert('ファイルが見つかりません'); return; }
@@ -720,6 +729,7 @@
     }
 
     async function inspectMountedProjectDisk() {
+        if (isEphemeralX1PenShare()) return null;
         var entry = mountedDrive0Entry();
         if (!entry || !window.XmilStorage) return null;
         var bytes = await window.XmilStorage.read(entry.key);
@@ -1013,6 +1023,7 @@
 
     // 起動時: マウント状態を復元
     async function autoRestoreMounts(excludeSlots) {
+        if (isEphemeralX1PenShare()) return;
         var state = getMountState();
         var lib = getLibrary();
         var exclude = excludeSlots || [];

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -128,6 +128,14 @@
             white-space: nowrap;
         }
 
+        #x1pen-share-mode {
+            color: #ffd28a;
+            border: 1px solid #a56b16;
+            border-radius: 3px;
+            padding: 2px 6px;
+            white-space: nowrap;
+        }
+
         #x1pen-mcp-status {
             padding: 2px 6px;
             border: 1px solid #26734d;
@@ -609,6 +617,7 @@
     <div id="x1pen-toolbar">
         <span class="brand">X1Pen</span>
         <span id="x1pen-mcp-status" class="hidden">MCP Connected</span>
+        <span id="x1pen-share-mode" class="hidden" title="Edits and persistent media are isolated in this tab">Share mode: edits are not saved; persistent disks are not mounted</span>
         <button id="btn-run" disabled title="Ctrl+Enter">&#x25B6; RUN</button>
         <button id="btn-run-recover" class="hidden" data-automation-lock-exempt="true">Reload stalled Run</button>
         <button id="btn-stop" title="Escape">&#x25A0; STOP</button>

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -617,7 +617,7 @@
     <div id="x1pen-toolbar">
         <span class="brand">X1Pen</span>
         <span id="x1pen-mcp-status" class="hidden">MCP Connected</span>
-        <span id="x1pen-share-mode" class="hidden" title="このタブでの編集内容は保存されず、保存済みディスクもマウントされません" aria-label="Share モード。このタブでの編集内容は保存されず、保存済みディスクもマウントされません">Share モード</span>
+        <span id="x1pen-share-mode" class="hidden" title="このタブでの編集内容は保存されず、保存済みディスクもマウントされません" aria-label="Share モード。このタブでの編集内容は保存されず、保存済みディスクもマウントされません">Share mode</span>
         <button id="btn-run" disabled title="Ctrl+Enter">&#x25B6; RUN</button>
         <button id="btn-run-recover" class="hidden" data-automation-lock-exempt="true">Reload stalled Run</button>
         <button id="btn-stop" title="Escape">&#x25A0; STOP</button>

--- a/html/x1pen.html
+++ b/html/x1pen.html
@@ -617,7 +617,7 @@
     <div id="x1pen-toolbar">
         <span class="brand">X1Pen</span>
         <span id="x1pen-mcp-status" class="hidden">MCP Connected</span>
-        <span id="x1pen-share-mode" class="hidden" title="Edits and persistent media are isolated in this tab">Share mode: edits are not saved; persistent disks are not mounted</span>
+        <span id="x1pen-share-mode" class="hidden" title="このタブでの編集内容は保存されず、保存済みディスクもマウントされません" aria-label="Share モード。このタブでの編集内容は保存されず、保存済みディスクもマウントされません">Share モード</span>
         <button id="btn-run" disabled title="Ctrl+Enter">&#x25B6; RUN</button>
         <button id="btn-run-recover" class="hidden" data-automation-lock-exempt="true">Reload stalled Run</button>
         <button id="btn-stop" title="Escape">&#x25A0; STOP</button>

--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -7,6 +7,16 @@ window.__X1PEN_MODE = true;
 (function() {
     'use strict';
 
+    var initialShareId = new URLSearchParams(location.search).get('id');
+    var documentRunProfile = initialShareId ? 'ephemeral-share' : 'persistent-user';
+    var isEphemeralShareSession = documentRunProfile === 'ephemeral-share';
+    Object.defineProperty(window, '__X1PEN_EPHEMERAL_SHARE', {
+        value: isEphemeralShareSession,
+        writable: false,
+        configurable: false,
+        enumerable: false
+    });
+
     var COLD_STATE_FILE = 'fuzzybasic_cold.v2.xmst';
     var BOOT_DISK_FILE  = 'fuzzybasic_boot.v2.d88';
     var LSX_COLD_STATE  = 'lsxdodgers_cold.v1.xmst';
@@ -363,6 +373,7 @@ window.__X1PEN_MODE = true;
     var LS_EDITOR_SLANG = 'x1pen_editor_slang';
 
     function persistEditorSources(basic, asm, slang) {
+        if (isEphemeralShareSession) return;
         try {
             localStorage.setItem(LS_EDITOR_BASIC, basic);
             localStorage.setItem(LS_EDITOR_ASM, asm);
@@ -372,12 +383,19 @@ window.__X1PEN_MODE = true;
         }
     }
 
+    function persistEditorSource(key, value) {
+        if (isEphemeralShareSession) return;
+        try { localStorage.setItem(key, value); } catch(e) {}
+    }
+
     var elBtnRun    = document.getElementById('btn-run');
     var elBtnRunRecover = document.getElementById('btn-run-recover');
     var elBtnStop   = document.getElementById('btn-stop');
     var elBtnDevReload = document.getElementById('btn-dev-reload');
     var elStatus    = document.getElementById('x1pen-status');
     var elLiveNotice = document.getElementById('x1pen-live-notice');
+    var elShareMode = document.getElementById('x1pen-share-mode');
+    if (elShareMode && isEphemeralShareSession) elShareMode.classList.remove('hidden');
     var activeTab   = 'basic';
 
     function isDevAssetMode() {
@@ -413,7 +431,7 @@ window.__X1PEN_MODE = true;
         { language: 'basic',
           showLineNumbers: false,
           placeholder: '10 PRINT "HELLO WORLD"\n20 GOTO 10',
-          onChange: function(text) { markProgramChanged(); try { localStorage.setItem(LS_EDITOR_BASIC, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); persistEditorSource(LS_EDITOR_BASIC, text); },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
@@ -423,7 +441,7 @@ window.__X1PEN_MODE = true;
         { language: 'asm',
           showLineNumbers: true,
           placeholder: '; Z80 Assembly\nORG 0E000h\n    LD A,042h\n    RET',
-          onChange: function(text) { markProgramChanged(); lastAsmTabOrigin = 'user'; try { localStorage.setItem(LS_EDITOR_ASM, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); lastAsmTabOrigin = 'user'; persistEditorSource(LS_EDITOR_ASM, text); },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
@@ -433,20 +451,22 @@ window.__X1PEN_MODE = true;
         { language: 'slang',
           showLineNumbers: true,
           placeholder: '// SLANG program\nVAR x = 42;\nmain() BEGIN\n  PRINT(x);\nEND;',
-          onChange: function(text) { markProgramChanged(); try { localStorage.setItem(LS_EDITOR_SLANG, text); } catch(e) {} },
+          onChange: function(text) { markProgramChanged(); persistEditorSource(LS_EDITOR_SLANG, text); },
           onFocus: pauseCallbacks.onFocus,
           onBlur:  pauseCallbacks.onBlur }
     );
 
     // localStorage から復元 (silent: onChange を発火させない)
-    try {
-        var savedBasic = localStorage.getItem(LS_EDITOR_BASIC);
-        if (savedBasic) basicEditor.setValue(savedBasic, { silent: true });
-        var savedAsm = localStorage.getItem(LS_EDITOR_ASM);
-        if (savedAsm) { asmEditor.setValue(savedAsm, { silent: true }); lastAsmTabOrigin = 'user'; }
-        var savedSlang = localStorage.getItem(LS_EDITOR_SLANG);
-        if (savedSlang) slangEditor.setValue(savedSlang, { silent: true });
-    } catch(e) {}
+    if (!isEphemeralShareSession) {
+        try {
+            var savedBasic = localStorage.getItem(LS_EDITOR_BASIC);
+            if (savedBasic) basicEditor.setValue(savedBasic, { silent: true });
+            var savedAsm = localStorage.getItem(LS_EDITOR_ASM);
+            if (savedAsm) { asmEditor.setValue(savedAsm, { silent: true }); lastAsmTabOrigin = 'user'; }
+            var savedSlang = localStorage.getItem(LS_EDITOR_SLANG);
+            if (savedSlang) slangEditor.setValue(savedSlang, { silent: true });
+        } catch(e) {}
+    }
 
 
     // ── ステート復元 (専用経路 — マウント復元なし) ──
@@ -1149,7 +1169,7 @@ window.__X1PEN_MODE = true;
             elStatus.textContent = 'SLANG compiled (' + asmSrc.split('\n').length + ' lines)';
         }
 
-        var isSharedRun = !!pendingShareRuntime;
+        var isSharedRun = isEphemeralShareSession;
         var runMode;
         if (pendingShareRuntime && pendingShareRuntime.runMode) {
             runMode = pendingShareRuntime.runMode;
@@ -1173,7 +1193,7 @@ window.__X1PEN_MODE = true;
         }
 
         var mountedProjectSelection = null;
-        if (window.XmilLibrary && window.XmilLibrary.inspectMountedProjectDisk) {
+        if (!isEphemeralShareSession && window.XmilLibrary && window.XmilLibrary.inspectMountedProjectDisk) {
             try {
                 mountedProjectSelection = await window.XmilLibrary.inspectMountedProjectDisk();
             } catch(e) {
@@ -1445,7 +1465,7 @@ window.__X1PEN_MODE = true;
         }
 
         // 8. FDD 等のマウント状態を再適用 (PROGRAM ディスク使用時は drive0 を除外)
-        if (window.XmilLibrary && window.XmilLibrary.autoRestoreMounts) {
+        if (!isEphemeralShareSession && window.XmilLibrary && window.XmilLibrary.autoRestoreMounts) {
             await window.XmilLibrary.autoRestoreMounts(hasProgramDisk ? ['drive0'] : []);
         }
 
@@ -2911,7 +2931,7 @@ window.__X1PEN_MODE = true;
         module = window.Module;
 
         // マルチタブ警告 (pre.js の _multiTabPromise を消費)
-        if (window.__multiTabPromise) {
+        if (!isEphemeralShareSession && window.__multiTabPromise) {
             var otherTabExists = await window.__multiTabPromise;
             if (otherTabExists) {
                 var ok = confirm(
@@ -2971,7 +2991,7 @@ window.__X1PEN_MODE = true;
         // 4. フォントを現セッションに反映
         if (module._js_reload_fonts) module._js_reload_fonts();
         // 5. マウント状態復元
-        if (window.XmilLibrary && window.XmilLibrary.autoRestoreMounts) {
+        if (!isEphemeralShareSession && window.XmilLibrary && window.XmilLibrary.autoRestoreMounts) {
             await window.XmilLibrary.autoRestoreMounts();
         }
         // 6. エミュレータ開始
@@ -2983,7 +3003,7 @@ window.__X1PEN_MODE = true;
         automationReadyResolve();
 
         // 共有コード読み込み (?id=xxx)
-        var urlId = new URLSearchParams(location.search).get('id');
+        var urlId = initialShareId;
 
         // Share パラメータなしの場合、保存済みコンテンツに応じてタブを自動選択
         // BASIC → SLANG → ASM の優先順で、内容のあるタブに切り替える

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -53,6 +53,109 @@ async function launchChromium() {
   }
 }
 
+async function snapshotX1PenPersistence(targetPage) {
+  return targetPage.evaluate(async () => {
+    async function hashBytes(bytes) {
+      const digest = await crypto.subtle.digest('SHA-256', bytes);
+      return Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, '0')).join('');
+    }
+
+    const entries = (await window.XmilStorage.list())
+      .map(({ key, name, size }) => ({ key, name, size }))
+      .sort((left, right) => left.key.localeCompare(right.key));
+    const stored = [];
+    for (const entry of entries) {
+      const bytes = await window.XmilStorage.read(entry.key);
+      stored.push({ key: entry.key, size: bytes.byteLength, hash: await hashBytes(bytes) });
+    }
+    const allLocalStorage = {};
+    for (let index = 0; index < localStorage.length; index++) {
+      const key = localStorage.key(index);
+      allLocalStorage[key] = localStorage.getItem(key);
+    }
+    return {
+      allLocalStorage: Object.fromEntries(Object.entries(allLocalStorage).sort(([left], [right]) =>
+        left.localeCompare(right))),
+      editor: localStorage.getItem('x1pen_editor'),
+      editorAsm: localStorage.getItem('x1pen_editor_asm'),
+      editorSlang: localStorage.getItem('x1pen_editor_slang'),
+      mountState: localStorage.getItem('x1pen_mount_state'),
+      library: localStorage.getItem('xmil_library'),
+      storageManifest: localStorage.getItem('xmil_opfs_manifest'),
+      entries,
+      stored,
+    };
+  });
+}
+
+async function seedX1PenPersistentDiskState(targetPage, { project = false } = {}) {
+  await targetPage.goto(`${baseUrl}/x1pen.html`);
+  await targetPage.evaluate(() => window.X1PenAutomation.ready());
+  return targetPage.evaluate(async ({ makeProject }) => {
+    const api = window.X1PenAutomation;
+    const current = api.getProgram();
+    await api.setProgram({
+      sourceMode: 'basic+asm',
+      basic: '10 PRINT "PERSISTENT ORIGINAL"\n20 END',
+      asm: '; PERSISTENT ASM',
+      slang: '',
+    }, current.revision, current.revisionEpoch);
+
+    const response = await fetch('fuzzybasic_boot.v2.d88');
+    const bytes = await response.arrayBuffer();
+    const owner = await window.XmilLibrary.addToLibrary(
+      new File([bytes], makeProject ? 'PROJECT.D88' : 'OWNER.D88', { type: 'application/octet-stream' }),
+    );
+    const data = await window.XmilLibrary.addToLibrary(
+      new File([bytes], 'DATA.D88', { type: 'application/octet-stream' }),
+    );
+    if (makeProject) {
+      const library = window.XmilCore.getLibrary();
+      const entry = library.find((candidate) => candidate.key === owner.key);
+      entry.x1penProject = true;
+      entry.sourceKey = 'seed-source';
+      entry.sourceHash = 'seed-hash';
+      entry.projectMode = 'fuzzybasic';
+      entry.projectUpdatedAt = '2026-08-15T00:00:00.000Z';
+      window.XmilCore.saveLibrary(library);
+    }
+    await window.XmilLibrary.mountFromLibrary(owner.key, 'drive0');
+    await window.XmilLibrary.mountFromLibrary(data.key, 'drive1');
+    return { ownerKey: owner.key, dataKey: data.key };
+  }, { makeProject: project });
+}
+
+function installShareRoute(context, id, payload, status = 200) {
+  return context.route(`**/api/share/${id}`, (route) => route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: status === 200 ? JSON.stringify(payload) : JSON.stringify({ error: 'not found' }),
+  }));
+}
+
+async function assertEphemeralShareDocument(targetPage) {
+  const state = await targetPage.evaluate(() => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, '__X1PEN_EPHEMERAL_SHARE');
+    return {
+      flag: window.__X1PEN_EPHEMERAL_SHARE,
+      writable: descriptor.writable,
+      configurable: descriptor.configurable,
+      multiTabPromise: window.__multiTabPromise,
+      tabChannel: window.__tabChannel,
+    };
+  });
+  assert.deepEqual(state, {
+    flag: true,
+    writable: false,
+    configurable: false,
+    multiTabPromise: null,
+    tabChannel: null,
+  });
+  await assert.doesNotReject(() => targetPage.locator('#x1pen-share-mode').waitFor({ state: 'visible' }));
+  assert.match(await targetPage.locator('#x1pen-share-mode').textContent(), /edits are not saved/i);
+}
+
 async function runWithRecordedKeyEvents() {
   return page.evaluate(async () => {
     const module = window.Module;
@@ -2153,6 +2256,259 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
     assert.equal(rollback.result.rollbackFailed, false);
     assert.equal(rollback.restoredHash, rollback.originalHash);
     assert.equal(rollback.drive0, rollback.projectKey);
+  } finally {
+    await context.close();
+  }
+});
+
+test('Share runs isolate ordinary and project disks from persistent state', { timeout: 180_000 }, async () => {
+  for (const project of [false, true]) {
+    const context = await browser.newContext();
+    const ownerPage = await context.newPage();
+    const shareId = project ? 'project-isolation' : 'ordinary-isolation';
+    const dialogs = [];
+    try {
+      const keys = await seedX1PenPersistentDiskState(ownerPage, { project });
+      await ownerPage.evaluate(async () => {
+        window.Module._js_xmil_stop();
+        await window.XmilCore.flushSlot('drive0');
+        await window.XmilCore.flushSlot('drive1');
+      });
+      const baseline = await snapshotX1PenPersistence(ownerPage);
+
+      await installShareRoute(context, shareId, {
+        basic: '',
+        asm: 'ORG 0100h\nRET',
+        slang: null,
+        meta: {
+          model: 1,
+          coldState: 'lsxdodgers_cold.v1.xmst',
+          bootDisk: 'lsxdodgers_boot.v1.d88',
+          runMode: 'lsx',
+          sourceMode: 'asm',
+        },
+      });
+      ownerPage.on('dialog', async (dialog) => {
+        dialogs.push(`owner: ${dialog.message()}`);
+        await dialog.dismiss();
+      });
+      const sharePage = await context.newPage();
+      sharePage.on('dialog', async (dialog) => {
+        dialogs.push(`share: ${dialog.message()}`);
+        await dialog.dismiss();
+      });
+      await sharePage.goto(`${baseUrl}/x1pen.html?id=${shareId}`);
+      await sharePage.evaluate(() => window.X1PenAutomation.ready());
+      await sharePage.waitForFunction(() =>
+        document.getElementById('x1pen-status').textContent === 'LSX-Dodgers mode' &&
+        !window.X1PenAutomation.getStatus().capabilities.debugger.runPending,
+      );
+      await assertEphemeralShareDocument(sharePage);
+
+      const shareRun = await sharePage.evaluate(() => {
+        const slots = window.XmilCore.getSlotState();
+        const vfsPath = window.XmilCore.getSlotVfsPath().drive0;
+        const bytes = window.Module.FS.readFile(vfsPath);
+        const container = window.XmilDiskContainer.openContainer(
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+          'share.d88',
+          'fdd',
+        );
+        const fs = window.XmilDiskFS.detectFilesystem(container);
+        return {
+          program: window.X1PenAutomation.getProgram(),
+          model: window.Module._js_get_rom_type(),
+          drive0: slots.drive0,
+          drive1: slots.drive1,
+          filesystem: fs && fs.fsType,
+          hasProgram: !!(fs && fs.findByName('PROG', 'COM')),
+          hasLsxLoader: !!(fs && fs.findByName('LD', 'BIN')),
+          hasFuzzyBasic: !!(fs && fs.findByName('FZBASIC', 'COM')),
+        };
+      });
+      assert.equal(shareRun.program.sourceMode, 'asm');
+      assert.equal(shareRun.program.asm, 'ORG 0100h\nRET');
+      assert.equal(shareRun.model, 1);
+      assert.equal(shareRun.drive0, '__x1pen_temp__');
+      assert.equal(shareRun.drive1, null);
+      assert.equal(shareRun.filesystem, 'LSX-Dodgers');
+      assert.equal(shareRun.hasProgram, true);
+      assert.equal(shareRun.hasLsxLoader, true);
+      assert.equal(shareRun.hasFuzzyBasic, false);
+      assert.deepEqual(await snapshotX1PenPersistence(sharePage), baseline);
+
+      const refusedMount = await sharePage.evaluate(async ({ ownerKey }) => {
+        const api = window.X1PenAutomation;
+        const current = api.getProgram();
+        await api.setProgram({ sourceMode: 'asm', asm: 'ORG 0100h\nNOP\nRET' },
+          current.revision, current.revisionEpoch);
+        return window.XmilLibrary.mountFromLibrary(ownerKey, 'drive1');
+      }, { ownerKey: keys.ownerKey });
+      assert.equal(refusedMount, null);
+      await sharePage.locator('.editor-tab[data-tab="asm"]').click();
+      await sharePage.locator('#asm-editor-container .cm-content').click();
+      await sharePage.keyboard.press('End');
+      await sharePage.keyboard.type('\n; TRANSIENT TYPING');
+      const repeatedRun = await sharePage.evaluate(() => window.X1PenAutomation.run());
+      assert.equal(repeatedRun.ok, true);
+      assert.equal(await sharePage.evaluate(() => window.XmilCore.getSlotState().drive0), '__x1pen_temp__');
+      await sharePage.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pagehide')));
+
+      assert.deepEqual(await snapshotX1PenPersistence(sharePage), baseline);
+      const isolatedSlots = await sharePage.evaluate(() => window.XmilCore.getSlotState());
+      assert.deepEqual(isolatedSlots, {
+        drive0: '__x1pen_temp__', drive1: null, hdd0: null, hdd1: null, cmt: null,
+        emm0: null, emm1: null, emm2: null, emm3: null, emm4: null,
+        emm5: null, emm6: null, emm7: null, emm8: null, emm9: null,
+      });
+      assert.deepEqual(await ownerPage.evaluate(() => window.XmilCore.getSlotState()), {
+        drive0: keys.ownerKey,
+        drive1: keys.dataKey,
+        hdd0: null, hdd1: null, cmt: null,
+        emm0: null, emm1: null, emm2: null, emm3: null, emm4: null,
+        emm5: null, emm6: null, emm7: null, emm8: null, emm9: null,
+      });
+      assert.deepEqual(await snapshotX1PenPersistence(ownerPage), baseline);
+      assert.deepEqual(dialogs, [], 'Share must not trigger multi-tab or project-disk dialogs');
+      await sharePage.close();
+
+      await ownerPage.reload();
+      await ownerPage.evaluate(() => window.X1PenAutomation.ready());
+      const restored = await ownerPage.evaluate(() => ({
+        program: window.X1PenAutomation.getProgram(),
+        slots: window.XmilCore.getSlotState(),
+      }));
+      assert.equal(restored.program.basic, '10 PRINT "PERSISTENT ORIGINAL"\n20 END');
+      assert.equal(restored.program.asm, '; PERSISTENT ASM');
+      assert.equal(restored.slots.drive0, keys.ownerKey);
+      assert.equal(restored.slots.drive1, keys.dataKey);
+      assert.deepEqual(await snapshotX1PenPersistence(ownerPage), baseline);
+    } finally {
+      await context.close();
+    }
+  }
+});
+
+test('legacy Share payloads use an ephemeral FuzzyBASIC runtime', { timeout: 90_000 }, async () => {
+  const context = await browser.newContext();
+  const ownerPage = await context.newPage();
+  try {
+    await ownerPage.goto(`${baseUrl}/x1pen.html`);
+    await ownerPage.evaluate(() => window.X1PenAutomation.ready());
+    await ownerPage.evaluate(async () => {
+      const api = window.X1PenAutomation;
+      const current = api.getProgram();
+      await api.setProgram({
+        sourceMode: 'basic+asm',
+        basic: '10 PRINT "NO MOUNT ORIGINAL"\n20 END',
+        asm: '',
+        slang: '',
+      }, current.revision, current.revisionEpoch);
+      window.Module._js_xmil_stop();
+    });
+    const baseline = await snapshotX1PenPersistence(ownerPage);
+    await installShareRoute(context, 'legacy-isolation', {
+      basic: '10 PRINT "LEGACY SHARE"\n20 END',
+      asm: null,
+      slang: null,
+    });
+    const sharePage = await context.newPage();
+    await sharePage.goto(`${baseUrl}/x1pen.html?id=legacy-isolation`);
+    await sharePage.evaluate(() => window.X1PenAutomation.ready());
+    await sharePage.waitForFunction(() =>
+      window.X1PenAutomation.getProgram().basic.includes('LEGACY SHARE') &&
+      window.XmilCore.getSlotState().drive0 === '__x1pen_temp__' &&
+      !window.X1PenAutomation.getStatus().capabilities.debugger.runPending,
+    );
+    await assertEphemeralShareDocument(sharePage);
+    const result = await sharePage.evaluate(() => {
+      const vfsPath = window.XmilCore.getSlotVfsPath().drive0;
+      const bytes = window.Module.FS.readFile(vfsPath);
+      const container = window.XmilDiskContainer.openContainer(
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+        'legacy-share.d88',
+        'fdd',
+      );
+      const fs = window.XmilDiskFS.detectFilesystem(container);
+      return {
+        program: window.X1PenAutomation.getProgram(),
+        slots: window.XmilCore.getSlotState(),
+        model: window.Module._js_get_rom_type(),
+        filesystem: fs && fs.fsType,
+        hasAutorun: !!(fs && fs.findByName('AUTORUN', 'BAS')),
+        hasFuzzyBasic: !!(fs && fs.findByName('FZBASIC', 'COM')),
+      };
+    });
+    assert.equal(result.program.basic, '10 PRINT "LEGACY SHARE"\n20 END');
+    assert.equal(result.slots.drive0, '__x1pen_temp__');
+    assert.equal(result.slots.drive1, null);
+    assert.equal(result.model, 1);
+    assert.equal(result.filesystem, 'LSX-Dodgers');
+    assert.equal(result.hasAutorun, true);
+    assert.equal(result.hasFuzzyBasic, true);
+    assert.deepEqual(await snapshotX1PenPersistence(sharePage), baseline);
+  } finally {
+    await context.close();
+  }
+});
+
+test('failed Share links remain visibly ephemeral and cannot overwrite saved source', { timeout: 90_000 }, async () => {
+  const context = await browser.newContext();
+  const ownerPage = await context.newPage();
+  try {
+    const keys = await seedX1PenPersistentDiskState(ownerPage);
+    await ownerPage.evaluate(() => window.Module._js_xmil_stop());
+    const baseline = await snapshotX1PenPersistence(ownerPage);
+    await installShareRoute(context, 'missing-share', null, 404);
+    const sharePage = await context.newPage();
+    await sharePage.goto(`${baseUrl}/x1pen.html?id=missing-share`);
+    await sharePage.evaluate(() => window.X1PenAutomation.ready());
+    await sharePage.waitForFunction(() =>
+      document.getElementById('x1pen-status').textContent === 'Shared code not found',
+    );
+    await assertEphemeralShareDocument(sharePage);
+    const initial = await sharePage.evaluate(() => ({
+      program: window.X1PenAutomation.getProgram(),
+      slots: window.XmilCore.getSlotState(),
+    }));
+    assert.equal(initial.program.basic, '');
+    assert.equal(initial.program.asm, '');
+    assert.equal(initial.program.slang, '');
+    assert.equal(initial.slots.drive0, null);
+    assert.equal(initial.slots.drive1, null);
+
+    await sharePage.evaluate(async ({ ownerKey }) => {
+      const api = window.X1PenAutomation;
+      const current = api.getProgram();
+      await api.setProgram({ sourceMode: 'basic+asm', basic: '10 PRINT "TRANSIENT"', asm: '', slang: '' },
+        current.revision, current.revisionEpoch);
+      await window.XmilLibrary.mountFromLibrary(ownerKey, 'drive0');
+      window.dispatchEvent(new PageTransitionEvent('pagehide'));
+    }, { ownerKey: keys.ownerKey });
+    assert.deepEqual(await snapshotX1PenPersistence(sharePage), baseline);
+    assert.deepEqual(await snapshotX1PenPersistence(ownerPage), baseline);
+
+    await installShareRoute(context, 'compile-failure', {
+      basic: '',
+      asm: 'THIS IS NOT VALID ASSEMBLY',
+      slang: null,
+      meta: {
+        model: 1,
+        coldState: 'lsxdodgers_cold.v1.xmst',
+        bootDisk: 'lsxdodgers_boot.v1.d88',
+        runMode: 'lsx',
+        sourceMode: 'asm',
+      },
+    });
+    const compileFailurePage = await context.newPage();
+    await compileFailurePage.goto(`${baseUrl}/x1pen.html?id=compile-failure`);
+    await compileFailurePage.evaluate(() => window.X1PenAutomation.ready());
+    await compileFailurePage.waitForFunction(() =>
+      document.getElementById('x1pen-status').textContent.startsWith('ASM error'),
+    );
+    await assertEphemeralShareDocument(compileFailurePage);
+    assert.equal(await compileFailurePage.evaluate(() => window.XmilCore.getSlotState().drive0), null);
+    assert.deepEqual(await snapshotX1PenPersistence(compileFailurePage), baseline);
   } finally {
     await context.close();
   }

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -153,7 +153,15 @@ async function assertEphemeralShareDocument(targetPage) {
     tabChannel: null,
   });
   await assert.doesNotReject(() => targetPage.locator('#x1pen-share-mode').waitFor({ state: 'visible' }));
-  assert.match(await targetPage.locator('#x1pen-share-mode').textContent(), /edits are not saved/i);
+  assert.equal(await targetPage.locator('#x1pen-share-mode').textContent(), 'Share モード');
+  assert.equal(
+    await targetPage.locator('#x1pen-share-mode').getAttribute('title'),
+    'このタブでの編集内容は保存されず、保存済みディスクもマウントされません',
+  );
+  assert.equal(
+    await targetPage.locator('#x1pen-share-mode').getAttribute('aria-label'),
+    'Share モード。このタブでの編集内容は保存されず、保存済みディスクもマウントされません',
+  );
 }
 
 async function runWithRecordedKeyEvents() {
@@ -2345,6 +2353,10 @@ test('Share runs isolate ordinary and project disks from persistent state', { ti
         return window.XmilLibrary.mountFromLibrary(ownerKey, 'drive1');
       }, { ownerKey: keys.ownerKey });
       assert.equal(refusedMount, null);
+      assert.equal(
+        await sharePage.locator('#x1pen-status').textContent(),
+        'Share モードでは保存済みメディアをマウントできません',
+      );
       await sharePage.locator('.editor-tab[data-tab="asm"]').click();
       await sharePage.locator('#asm-editor-container .cm-content').click();
       await sharePage.keyboard.press('End');

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -153,7 +153,7 @@ async function assertEphemeralShareDocument(targetPage) {
     tabChannel: null,
   });
   await assert.doesNotReject(() => targetPage.locator('#x1pen-share-mode').waitFor({ state: 'visible' }));
-  assert.equal(await targetPage.locator('#x1pen-share-mode').textContent(), 'Share モード');
+  assert.equal(await targetPage.locator('#x1pen-share-mode').textContent(), 'Share mode');
   assert.equal(
     await targetPage.locator('#x1pen-share-mode').getAttribute('title'),
     'このタブでの編集内容は保存されず、保存済みディスクもマウントされません',


### PR DESCRIPTION
## Summary
- classify every non-empty Share URL as an immutable ephemeral document before emulator initialization
- prevent Share documents from restoring or attaching persistent media, entering project-disk transactions, or persisting editor changes
- show a persistent Share isolation badge and exempt Share tabs from persistent-state multi-tab ownership
- add browser regressions for ordinary/project disks, legacy payloads, invalid/compile-failing links, repeated Runs, pagehide, and byte-for-byte storage preservation

## Cross-review
- design: APPROVED in round 3 by Claude Opus 5
- implementation: APPROVED in round 4 by Claude Opus 5, blocking findings 0
- adopted the non-blocking persistence finding by comparing every localStorage key/value; focused Share tests remained 3/3 PASS

## Verification
- ./build.sh
- npm test (141/141)
- git diff --check

No product or package version was changed. PR #111 was not touched.

Closes #125