### PR TITLE
Block Share while saved media is mounted

### DIFF
--- a/html/x1pen.js
+++ b/html/x1pen.js
@@ -1658,6 +1658,42 @@ window.__X1PEN_MODE = true;
 
     // ── Share ──
 
+    var SHARE_MEDIA_BLOCKED_STATUS = '保存済みメディアが挿入されているためShareできません。メディアを取り出してから再試行してください';
+    var SHARE_MEDIA_UNKNOWN_STATUS = 'メディア状態を確認できないためShareできません。ページを再読み込みしてください';
+    var SHARE_MEDIA_SLOTS = [
+        'drive0', 'drive1', 'hdd0', 'hdd1', 'cmt',
+        'emm0', 'emm1', 'emm2', 'emm3', 'emm4',
+        'emm5', 'emm6', 'emm7', 'emm8', 'emm9'
+    ];
+
+    function inspectShareMediaState() {
+        try {
+            if (!window.XmilCore || typeof window.XmilCore.getSlotState !== 'function') {
+                return { available: false, mountedSlots: [] };
+            }
+            var state = window.XmilCore.getSlotState();
+            if (!state || typeof state !== 'object') {
+                return { available: false, mountedSlots: [] };
+            }
+            var mountedSlots = [];
+            for (var i = 0; i < SHARE_MEDIA_SLOTS.length; i++) {
+                var slotName = SHARE_MEDIA_SLOTS[i];
+                if (!Object.prototype.hasOwnProperty.call(state, slotName)) {
+                    return { available: false, mountedSlots: [] };
+                }
+                var value = state[slotName];
+                if (value === null || value === '__x1pen_temp__') continue;
+                if (typeof value !== 'string') {
+                    return { available: false, mountedSlots: [] };
+                }
+                mountedSlots.push(slotName);
+            }
+            return { available: true, mountedSlots: mountedSlots };
+        } catch(e) {
+            return { available: false, mountedSlots: [] };
+        }
+    }
+
     var lastShareHash = null;
     var lastShareId = null;
 
@@ -2828,6 +2864,16 @@ window.__X1PEN_MODE = true;
         var asmSrc = asmEditor ? asmEditor.getValue().trim() : '';
         var slangSrc = slangEditor ? slangEditor.getValue().trim() : '';
         if (!src && !asmSrc && !slangSrc) { elStatus.textContent = 'Nothing to share'; return; }
+
+        var shareMediaState = inspectShareMediaState();
+        if (!shareMediaState.available) {
+            elStatus.textContent = SHARE_MEDIA_UNKNOWN_STATUS;
+            return;
+        }
+        if (shareMediaState.mountedSlots.length > 0) {
+            elStatus.textContent = SHARE_MEDIA_BLOCKED_STATUS;
+            return;
+        }
 
         var shareSourceMode = slangSrc ? 'slang' : (!src && asmSrc ? 'asm' : 'basic+asm');
         var shareRunMode = (shareSourceMode === 'slang' || shareSourceMode === 'asm') ? 'lsx' : detectRunMode(src, asmSrc);

--- a/tests/x1pen_automation_test.mjs
+++ b/tests/x1pen_automation_test.mjs
@@ -2269,6 +2269,112 @@ test('mounted FDD0 is forked once into a persistent project disk', { timeout: 90
   }
 });
 
+test('Share refuses persistent media without posting disk-dependent source', { timeout: 180_000 }, async () => {
+  const blockedStatus = '保存済みメディアが挿入されているためShareできません。メディアを取り出してから再試行してください';
+  const unknownStatus = 'メディア状態を確認できないためShareできません。ページを再読み込みしてください';
+
+  for (const project of [false, true]) {
+    const context = await browser.newContext();
+    const ownerPage = await context.newPage();
+    let postCount = 0;
+    try {
+      await context.route('**/api/share', (route) => {
+        postCount += 1;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: project ? 'project-blocked' : 'ordinary-blocked' }),
+        });
+      });
+      await seedX1PenPersistentDiskState(ownerPage, { project });
+
+      await ownerPage.locator('#btn-share').click();
+      await ownerPage.waitForFunction((expected) =>
+        document.getElementById('x1pen-status').textContent === expected, blockedStatus);
+      assert.equal(postCount, 0, 'persistent media must prevent Share POST');
+      assert.equal(await ownerPage.locator('#share-dialog').evaluate((element) =>
+        element.classList.contains('hidden')), true);
+      assert.equal(await ownerPage.locator('#share-dialog-url').inputValue(), '');
+    } finally {
+      await context.close();
+    }
+  }
+
+  const context = await browser.newContext();
+  const ownerPage = await context.newPage();
+  let postCount = 0;
+  try {
+    await context.route('**/api/share', (route) => {
+      postCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'allowed-share' }),
+      });
+    });
+    await ownerPage.goto(`${baseUrl}/x1pen.html`);
+    await ownerPage.evaluate(() => window.X1PenAutomation.ready());
+    await ownerPage.evaluate(async () => {
+      const api = window.X1PenAutomation;
+      const current = api.getProgram();
+      await api.setProgram({
+        sourceMode: 'basic+asm',
+        basic: '10 PRINT "SHARE GUARD"\n20 END',
+        asm: '',
+        slang: '',
+      }, current.revision, current.revisionEpoch);
+    });
+
+    await ownerPage.locator('#btn-share').click();
+    await ownerPage.waitForFunction(() =>
+      !document.getElementById('share-dialog').classList.contains('hidden'));
+    assert.equal(postCount, 1, 'empty slot state must allow Share POST');
+    await ownerPage.locator('#share-dialog-close').click();
+
+    await ownerPage.evaluate(async () => {
+      const response = await fetch('fuzzybasic_boot.v2.d88');
+      await window.XmilControls.mountTempDisk(await response.arrayBuffer(), 'drive0');
+    });
+    await ownerPage.locator('#btn-share').click();
+    await ownerPage.waitForFunction(() =>
+      !document.getElementById('share-dialog').classList.contains('hidden'));
+    assert.equal(postCount, 1, 'the internal temporary disk must allow cached Share reuse');
+    assert.equal(await ownerPage.locator('#x1pen-status').textContent(), 'Same content - URL reused');
+    await ownerPage.locator('#share-dialog-close').click();
+
+    await ownerPage.evaluate(async () => {
+      await window.XmilCore.ejectSlot('drive0');
+      const entry = await window.XmilLibrary.addToLibrary(
+        new File([new Uint8Array(256)], 'EMM0.MEM', { type: 'application/octet-stream' }),
+      );
+      await window.XmilLibrary.mountFromLibrary(entry.key, 'emm0');
+    });
+    await ownerPage.locator('#btn-share').click();
+    await ownerPage.waitForFunction((expected) =>
+      document.getElementById('x1pen-status').textContent === expected, blockedStatus);
+    assert.equal(postCount, 1, 'non-FDD persistent media must prevent Share POST');
+    assert.equal(await ownerPage.locator('#share-dialog').evaluate((element) =>
+      element.classList.contains('hidden')), true);
+
+    await ownerPage.evaluate(() => {
+      window.__savedXmilCoreForShareTest = window.XmilCore;
+      window.XmilCore = undefined;
+    });
+    await ownerPage.locator('#btn-share').click();
+    await ownerPage.waitForFunction((expected) =>
+      document.getElementById('x1pen-status').textContent === expected, unknownStatus);
+    await ownerPage.evaluate(() => {
+      window.XmilCore = window.__savedXmilCoreForShareTest;
+      delete window.__savedXmilCoreForShareTest;
+    });
+    assert.equal(postCount, 1, 'unknown media state must fail closed without Share POST');
+    assert.equal(await ownerPage.locator('#share-dialog').evaluate((element) =>
+      element.classList.contains('hidden')), true);
+  } finally {
+    await context.close();
+  }
+});
+
 test('Share runs isolate ordinary and project disks from persistent state', { timeout: 180_000 }, async () => {
   for (const project of [false, true]) {
     const context = await browser.newContext();


### PR DESCRIPTION
## Summary

- block Share generation while any saved FDD, HDD, CMT, or EMM media is mounted
- allow the internal `__x1pen_temp__` program disk so ordinary Run to Share remains available
- fail closed with an explicit status when media state cannot be inspected
- cover ordinary/project FDD, EMM, empty slots, temp disk, cached URL reuse, and unavailable media state

## Why

Share payloads contain source and runtime metadata only. They do not contain mounted disk images, so sharing disk-dependent code would create a link that cannot reproduce the sender's environment.

## Verification

- `git diff --check`
- `node --check html/x1pen.js`
- `node --check tests/x1pen_automation_test.mjs`
- `./build.sh`
- focused Share guard E2E: 1/1 pass
- `npm test`: 142/142 pass

## Manual check

1. Open X1Pen and enter any source.
2. Add and mount a saved FDD/HDD/CMT/EMM image.
3. Click Share.
4. Confirm no Share dialog opens and the status says: `保存済みメディアが挿入されているためShareできません。メディアを取り出してから再試行してください`
5. Eject all saved media and click Share again; confirm the Share dialog opens.
6. Run normally with the internal PROGRAM disk and confirm Share remains available.

No version bump. PR #111 is untouched.
